### PR TITLE
Security: add sgt-authorized label gate

### DIFF
--- a/sgt
+++ b/sgt
@@ -62,6 +62,15 @@ ensure_rig() {
   [[ -f "$SGT_RIGS/$name" ]] || die "rig '$name' not found — run: sgt rig list"
 }
 
+# Check if a GitHub issue has the sgt-authorized label
+_has_sgt_authorized() {
+  local repo="$1" issue="$2"
+  [[ -n "$issue" && "$issue" != "0" ]] || return 1
+  local labels
+  labels=$(gh issue view "$issue" --repo "$repo" --json labels --jq '.labels[].name' 2>/dev/null || true)
+  echo "$labels" | grep -qx "sgt-authorized"
+}
+
 rig_repo() {
   local name="$1"
   cat "$SGT_RIGS/$name"
@@ -201,6 +210,9 @@ cmd_sling() {
 
   # ── 1. Create GitHub Issue ──
   info "creating issue on $(basename "$repo")..."
+  # Ensure sgt-authorized label exists on the repo
+  gh label create "sgt-authorized" --repo "$repo" --description "Authorized for sgt processing" --color "0E8A16" --force 2>/dev/null || true
+  labels+=("sgt-authorized")
   local label_args=""
   for l in "${labels[@]+"${labels[@]}"}"; do
     label_args="$label_args --label $l"
@@ -873,12 +885,24 @@ MQSTATE
         fi
 
         if [[ "$tracked" == "false" ]]; then
-          echo "[witness/$rig] orphaned PR #$pr_num on branch $pr_branch — queuing for refinery"
-          log_event "WITNESS_ORPHAN_PR pr=#$pr_num branch=$pr_branch"
-
           local orphan_pname="${pr_branch#sgt/}"
           local orphan_issue
           orphan_issue=$(gh pr view "$pr_num" --repo "$repo" --json body --jq '.body' 2>/dev/null | grep -oP 'Closes #\K[0-9]+' || true)
+
+          # Security gate: only process PRs linked to sgt-authorized issues
+          if [[ -n "$orphan_issue" ]] && ! _has_sgt_authorized "$repo" "$orphan_issue"; then
+            echo "[witness/$rig] BLOCKED orphan PR #$pr_num — issue #$orphan_issue missing sgt-authorized label"
+            log_event "WITNESS_ORPHAN_BLOCKED pr=#$pr_num issue=#$orphan_issue (missing sgt-authorized)"
+            continue
+          fi
+          if [[ -z "$orphan_issue" ]]; then
+            echo "[witness/$rig] BLOCKED orphan PR #$pr_num — no linked issue, cannot verify authorization"
+            log_event "WITNESS_ORPHAN_BLOCKED pr=#$pr_num (no linked issue)"
+            continue
+          fi
+
+          echo "[witness/$rig] orphaned PR #$pr_num on branch $pr_branch — queuing for refinery"
+          log_event "WITNESS_ORPHAN_PR pr=#$pr_num branch=$pr_branch"
 
           mkdir -p "$SGT_CONFIG/merge-queue"
           cat > "$SGT_CONFIG/merge-queue/$orphan_pname" <<MQSTATE
@@ -905,6 +929,13 @@ MQSTATE
 # Re-sling an existing issue (don't create a new one)
 _resling_existing_issue() {
   local rig="$1" issue_number="$2" task="$3" repo="$4"
+
+  # Security gate: only process issues with sgt-authorized label
+  if ! _has_sgt_authorized "$repo" "$issue_number"; then
+    echo "[resling] BLOCKED — issue #$issue_number missing sgt-authorized label"
+    log_event "RESLING_BLOCKED issue=#$issue_number (missing sgt-authorized label)"
+    return 1
+  fi
 
   local rpath pname branch session_name
   rpath="$(rig_path "$rig")"
@@ -1213,6 +1244,21 @@ _refinery_loop() {
 
       echo "[refinery/$rig] processing $mq_type: PR #$mq_pr ($mq_branch)"
 
+      # Security gate: verify issue has sgt-authorized label
+      if [[ "$mq_issue" != "0" && -n "$mq_issue" ]]; then
+        if ! _has_sgt_authorized "$mq_repo" "$mq_issue"; then
+          echo "[refinery/$rig] BLOCKED PR #$mq_pr — issue #$mq_issue missing sgt-authorized label"
+          log_event "REFINERY_BLOCKED pr=#$mq_pr issue=#$mq_issue (missing sgt-authorized)"
+          rm -f "$f"
+          continue
+        fi
+      else
+        echo "[refinery/$rig] BLOCKED PR #$mq_pr — no linked issue, cannot verify authorization"
+        log_event "REFINERY_BLOCKED pr=#$mq_pr (no linked issue)"
+        rm -f "$f"
+        continue
+      fi
+
       # Check PR state
       local pr_state
       pr_state=$(gh pr view "$mq_pr" --repo "$mq_repo" --json state --jq '.state' 2>/dev/null || true)
@@ -1331,6 +1377,16 @@ Please address the feedback in the next iteration." 2>/dev/null || true
         fi
 
         echo "[refinery/$rig] dog $dname finished — reviewing output"
+
+        # Security gate: verify issue has sgt-authorized label
+        if [[ "$d_issue" != "0" && -n "$d_issue" ]]; then
+          if ! _has_sgt_authorized "$d_repo" "$d_issue"; then
+            echo "[refinery/$rig] BLOCKED dog $dname — issue #$d_issue missing sgt-authorized label"
+            log_event "REFINERY_DOG_BLOCKED dog=$dname issue=#$d_issue (missing sgt-authorized)"
+            rm -f "$df"
+            continue
+          fi
+        fi
 
         REFINERY_REJECT_REASON=""
         if _refinery_review_dog "$d_repo" "$d_issue" "$rig" "$dname"; then
@@ -1735,15 +1791,15 @@ HEADER
   [[ "$mq_count" -eq 0 ]] && echo "Empty" >> "$briefing"
   echo "" >> "$briefing"
 
-  # Open issues across all rigs
-  echo "## Open Issues (all rigs)" >> "$briefing"
+  # Open issues across all rigs (sgt-authorized only)
+  echo "## Open Issues (all rigs, sgt-authorized only)" >> "$briefing"
   for rig_file in "$SGT_RIGS"/*; do
     [[ -f "$rig_file" ]] || continue
     local rname repo
     rname="$(basename "$rig_file")"
     repo="$(cat "$rig_file")"
     echo "### $rname ($repo)" >> "$briefing"
-    gh issue list --repo "$repo" --state open --json number,title,labels,milestone \
+    gh issue list --repo "$repo" --state open --label sgt-authorized --json number,title,labels,milestone \
       --jq '.[] | "- #\(.number): \(.title) [\(.labels | map(.name) | join(","))] \(if .milestone then "(" + .milestone.title + ")" else "" end)"' \
       2>/dev/null >> "$briefing" || echo "  (couldn't fetch)" >> "$briefing"
     echo "" >> "$briefing"
@@ -1875,13 +1931,14 @@ _mayor_loop() {
       fi
     done
 
-    # === 4. Check for open issues with critical/high labels ===
+    # === 4. Check for open issues with critical/high labels (sgt-authorized only) ===
     for rig_file in "$SGT_RIGS"/*; do
       [[ -f "$rig_file" ]] || continue
       local rname repo critical_issues
       rname="$(basename "$rig_file")"
       repo="$(cat "$rig_file")"
-      critical_issues=$(gh issue list --repo "$repo" --state open --label critical,high \
+      # Only consider issues that have the sgt-authorized label
+      critical_issues=$(gh issue list --repo "$repo" --state open --label critical,high,sgt-authorized \
         --json number,title --jq '.[].title' 2>/dev/null | head -5)
       if [[ -n "$critical_issues" ]]; then
         issues_found+="  - critical/high issues on $rname:\n"
@@ -1916,6 +1973,14 @@ _mayor_loop() {
           if [[ "$has_polecat" == "false" ]]; then
             local pr_num
             pr_num=$(echo "$pr_info" | grep -oP '#\d+' | tr -d '#')
+
+            # Security gate: verify linked issue has sgt-authorized label
+            local mayor_orphan_issue
+            mayor_orphan_issue=$(gh pr view "$pr_num" --repo "$repo" --json body --jq '.body' 2>/dev/null | grep -oP 'Closes #\K[0-9]+' || true)
+            if [[ -z "$mayor_orphan_issue" ]] || ! _has_sgt_authorized "$repo" "$mayor_orphan_issue"; then
+              continue
+            fi
+
             local mergeable
             mergeable=$(gh pr view "$pr_num" --repo "$repo" --json mergeable --jq '.mergeable' 2>/dev/null)
             if [[ "$mergeable" == "MERGEABLE" ]]; then
@@ -1927,7 +1992,7 @@ RIG=$rname
 REPO=$repo
 PR=$pr_num
 BRANCH=$pr_branch
-ISSUE=0
+ISSUE=${mayor_orphan_issue:-0}
 TYPE=polecat
 AUTO_MERGE=true
 QUEUED=$(date -Iseconds)
@@ -2106,6 +2171,8 @@ cmd_dog() {
 
   # Create issue for tracking
   info "creating issue for dog task..."
+  # Ensure sgt-authorized label exists on the repo
+  gh label create "sgt-authorized" --repo "$repo" --description "Authorized for sgt processing" --color "0E8A16" --force 2>/dev/null || true
   local issue_url issue_number
   issue_url=$(gh issue create \
     --repo "$repo" \
@@ -2121,8 +2188,8 @@ $task
 *Type: non-coding (results posted as comments)*
 EOF
 )" \
-    --label "dog" 2>&1) || {
-    # Label might not exist, try without
+    --label "dog" --label "sgt-authorized" 2>&1) || {
+    # Label might not exist, try without dog label
     issue_url=$(gh issue create \
       --repo "$repo" \
       --title "[Dog] $task" \
@@ -2136,7 +2203,8 @@ $task
 *Created by sgt — dog: \`$dname\`*
 *Type: non-coding (results posted as comments)*
 EOF
-)" 2>&1) || die "failed to create issue: $issue_url"
+)" \
+      --label "sgt-authorized" 2>&1) || die "failed to create issue: $issue_url"
   }
 
   issue_number=$(echo "$issue_url" | grep -oP '/issues/\K[0-9]+')
@@ -2558,6 +2626,9 @@ cmd_molecule_run() {
   local repo
   repo="$(rig_repo "$rig")"
 
+  # Ensure sgt-authorized label exists on the repo
+  gh label create "sgt-authorized" --repo "$repo" --description "Authorized for sgt processing" --color "0E8A16" --force 2>/dev/null || true
+
   # Create a convoy (milestone) for this molecule run
   local convoy_name="mol-${molecule}-$(date +%s)"
   info "creating convoy for molecule run: $convoy_name"
@@ -2603,7 +2674,8 @@ $task
 ---
 *Part of molecule run. Dispatched by sgt.*
 EOF
-)" 2>&1) || warn "failed to create issue for step $step_idx"
+)" \
+        --label "sgt-authorized" 2>&1) || warn "failed to create issue for step $step_idx"
 
       if [[ -n "$issue_url" ]]; then
         issue_number=$(echo "$issue_url" | grep -oP '/issues/\K[0-9]+')
@@ -2678,6 +2750,7 @@ ESCJSON
     for level in critical high normal low dog; do
       gh label create "$level" --repo "$repo" --force 2>/dev/null || true
     done
+    gh label create "sgt-authorized" --repo "$repo" --description "Authorized for sgt processing" --color "0E8A16" --force 2>/dev/null || true
     info "created escalation labels on $(basename "$rig_file")"
   done
 

--- a/test_sgt_authorized.sh
+++ b/test_sgt_authorized.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# Tests for the sgt-authorized label gate feature
+#
+# These tests validate that the _has_sgt_authorized helper function
+# and the label gate checks work correctly by mocking the gh CLI.
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TESTS=0
+
+pass() { PASS=$((PASS + 1)); TESTS=$((TESTS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); TESTS=$((TESTS + 1)); echo "  FAIL: $1"; }
+
+# ─── Setup ────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$SCRIPT_DIR/sgt"
+
+# Create a temp directory for mock gh
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+MOCK_GH="$TMPDIR/gh"
+
+# ─── Test 1: _has_sgt_authorized returns true when label is present ──
+
+echo "Test 1: _has_sgt_authorized with sgt-authorized label present"
+cat > "$MOCK_GH" <<'EOF'
+#!/bin/bash
+# Mock gh: returns sgt-authorized label
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+  echo "sgt-authorized"
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$MOCK_GH"
+
+# Source only the helper function and run it
+result=$(PATH="$TMPDIR:$PATH" bash -c '
+  _has_sgt_authorized() {
+    local repo="$1" issue="$2"
+    [[ -n "$issue" && "$issue" != "0" ]] || return 1
+    local labels
+    labels=$(gh issue view "$issue" --repo "$repo" --json labels --jq ".labels[].name" 2>/dev/null || true)
+    echo "$labels" | grep -qx "sgt-authorized"
+  }
+  _has_sgt_authorized "owner/repo" "42" && echo "AUTHORIZED" || echo "NOT_AUTHORIZED"
+')
+if [[ "$result" == "AUTHORIZED" ]]; then
+  pass "_has_sgt_authorized returns true when label present"
+else
+  fail "_has_sgt_authorized should return true when label present (got: $result)"
+fi
+
+# ─── Test 2: _has_sgt_authorized returns false when label is absent ──
+
+echo "Test 2: _has_sgt_authorized without sgt-authorized label"
+cat > "$MOCK_GH" <<'EOF'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+  echo "bug"
+  echo "enhancement"
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$MOCK_GH"
+
+result=$(PATH="$TMPDIR:$PATH" bash -c '
+  _has_sgt_authorized() {
+    local repo="$1" issue="$2"
+    [[ -n "$issue" && "$issue" != "0" ]] || return 1
+    local labels
+    labels=$(gh issue view "$issue" --repo "$repo" --json labels --jq ".labels[].name" 2>/dev/null || true)
+    echo "$labels" | grep -qx "sgt-authorized"
+  }
+  _has_sgt_authorized "owner/repo" "42" && echo "AUTHORIZED" || echo "NOT_AUTHORIZED"
+')
+if [[ "$result" == "NOT_AUTHORIZED" ]]; then
+  pass "_has_sgt_authorized returns false when label absent"
+else
+  fail "_has_sgt_authorized should return false when label absent (got: $result)"
+fi
+
+# ─── Test 3: _has_sgt_authorized returns false for issue 0 ───────────
+
+echo "Test 3: _has_sgt_authorized rejects issue number 0"
+result=$(PATH="$TMPDIR:$PATH" bash -c '
+  _has_sgt_authorized() {
+    local repo="$1" issue="$2"
+    [[ -n "$issue" && "$issue" != "0" ]] || return 1
+    local labels
+    labels=$(gh issue view "$issue" --repo "$repo" --json labels --jq ".labels[].name" 2>/dev/null || true)
+    echo "$labels" | grep -qx "sgt-authorized"
+  }
+  _has_sgt_authorized "owner/repo" "0" && echo "AUTHORIZED" || echo "NOT_AUTHORIZED"
+')
+if [[ "$result" == "NOT_AUTHORIZED" ]]; then
+  pass "_has_sgt_authorized rejects issue 0"
+else
+  fail "_has_sgt_authorized should reject issue 0 (got: $result)"
+fi
+
+# ─── Test 4: _has_sgt_authorized returns false for empty issue ───────
+
+echo "Test 4: _has_sgt_authorized rejects empty issue"
+result=$(PATH="$TMPDIR:$PATH" bash -c '
+  _has_sgt_authorized() {
+    local repo="$1" issue="$2"
+    [[ -n "$issue" && "$issue" != "0" ]] || return 1
+    local labels
+    labels=$(gh issue view "$issue" --repo "$repo" --json labels --jq ".labels[].name" 2>/dev/null || true)
+    echo "$labels" | grep -qx "sgt-authorized"
+  }
+  _has_sgt_authorized "owner/repo" "" && echo "AUTHORIZED" || echo "NOT_AUTHORIZED"
+')
+if [[ "$result" == "NOT_AUTHORIZED" ]]; then
+  pass "_has_sgt_authorized rejects empty issue"
+else
+  fail "_has_sgt_authorized should reject empty issue (got: $result)"
+fi
+
+# ─── Test 5: _has_sgt_authorized doesn't match partial label names ───
+
+echo "Test 5: _has_sgt_authorized rejects partial matches"
+cat > "$MOCK_GH" <<'EOF'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+  echo "not-sgt-authorized"
+  echo "sgt-authorized-extra"
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$MOCK_GH"
+
+result=$(PATH="$TMPDIR:$PATH" bash -c '
+  _has_sgt_authorized() {
+    local repo="$1" issue="$2"
+    [[ -n "$issue" && "$issue" != "0" ]] || return 1
+    local labels
+    labels=$(gh issue view "$issue" --repo "$repo" --json labels --jq ".labels[].name" 2>/dev/null || true)
+    echo "$labels" | grep -qx "sgt-authorized"
+  }
+  _has_sgt_authorized "owner/repo" "42" && echo "AUTHORIZED" || echo "NOT_AUTHORIZED"
+')
+if [[ "$result" == "NOT_AUTHORIZED" ]]; then
+  pass "_has_sgt_authorized rejects partial label matches"
+else
+  fail "_has_sgt_authorized should reject partial matches (got: $result)"
+fi
+
+# ─── Test 6: _has_sgt_authorized works with multiple labels ──────────
+
+echo "Test 6: _has_sgt_authorized finds label among multiple"
+cat > "$MOCK_GH" <<'EOF'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+  echo "bug"
+  echo "sgt-authorized"
+  echo "critical"
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$MOCK_GH"
+
+result=$(PATH="$TMPDIR:$PATH" bash -c '
+  _has_sgt_authorized() {
+    local repo="$1" issue="$2"
+    [[ -n "$issue" && "$issue" != "0" ]] || return 1
+    local labels
+    labels=$(gh issue view "$issue" --repo "$repo" --json labels --jq ".labels[].name" 2>/dev/null || true)
+    echo "$labels" | grep -qx "sgt-authorized"
+  }
+  _has_sgt_authorized "owner/repo" "42" && echo "AUTHORIZED" || echo "NOT_AUTHORIZED"
+')
+if [[ "$result" == "AUTHORIZED" ]]; then
+  pass "_has_sgt_authorized finds label among multiple labels"
+else
+  fail "_has_sgt_authorized should find label among multiple (got: $result)"
+fi
+
+# ─── Test 7: Verify sgt-authorized label in cmd_sling issue creation ─
+
+echo "Test 7: cmd_sling includes sgt-authorized label in issue creation"
+if grep -q 'labels+=("sgt-authorized")' "$SGT_SCRIPT"; then
+  pass "cmd_sling adds sgt-authorized to labels array"
+else
+  fail "cmd_sling should add sgt-authorized to labels array"
+fi
+
+# ─── Test 8: Verify _resling_existing_issue has label gate ───────────
+
+echo "Test 8: _resling_existing_issue checks for sgt-authorized"
+if grep -A5 '_resling_existing_issue()' "$SGT_SCRIPT" | grep -q '_has_sgt_authorized'; then
+  pass "_resling_existing_issue has sgt-authorized gate"
+else
+  fail "_resling_existing_issue should check sgt-authorized label"
+fi
+
+# ─── Test 9: Verify refinery has label gate ──────────────────────────
+
+echo "Test 9: Refinery PR processing checks for sgt-authorized"
+if grep -B2 -A5 'Security gate: verify issue has sgt-authorized label' "$SGT_SCRIPT" | grep -q '_has_sgt_authorized'; then
+  pass "Refinery has sgt-authorized gate for PR processing"
+else
+  fail "Refinery should check sgt-authorized for PR processing"
+fi
+
+# ─── Test 10: Verify witness orphan PR scanner has label gate ────────
+
+echo "Test 10: Witness orphan PR scanner checks for sgt-authorized"
+if grep -A10 'BLOCKED orphan PR' "$SGT_SCRIPT" | grep -q 'sgt-authorized'; then
+  pass "Witness orphan PR scanner has sgt-authorized gate"
+else
+  fail "Witness orphan PR scanner should check sgt-authorized"
+fi
+
+# ─── Test 11: Mayor critical issue scan uses sgt-authorized filter ───
+
+echo "Test 11: Mayor critical issue scan filters by sgt-authorized"
+if grep 'critical,high,sgt-authorized' "$SGT_SCRIPT" | grep -q 'gh issue list'; then
+  pass "Mayor critical issue scan filters by sgt-authorized label"
+else
+  fail "Mayor critical issue scan should filter by sgt-authorized"
+fi
+
+# ─── Test 12: Dog dispatch includes sgt-authorized label ─────────────
+
+echo "Test 12: Dog dispatch adds sgt-authorized label"
+if grep -A3 'label "dog" --label "sgt-authorized"' "$SGT_SCRIPT" >/dev/null 2>&1; then
+  pass "Dog dispatch includes sgt-authorized label"
+else
+  fail "Dog dispatch should include sgt-authorized label"
+fi
+
+# ─── Test 13: Molecule dispatch includes sgt-authorized label ────────
+
+echo "Test 13: Molecule dispatch adds sgt-authorized label"
+if grep -B5 'label "sgt-authorized"' "$SGT_SCRIPT" | grep -q 'molecule'; then
+  pass "Molecule dispatch includes sgt-authorized label"
+else
+  fail "Molecule dispatch should include sgt-authorized label"
+fi
+
+# ─── Test 14: Mayor briefing only shows sgt-authorized issues ────────
+
+echo "Test 14: Mayor briefing filters issues by sgt-authorized"
+if sed -n '/_mayor_build_briefing/,/^}/p' "$SGT_SCRIPT" | grep -q 'issue list.*--label sgt-authorized'; then
+  pass "Mayor briefing filters by sgt-authorized"
+else
+  fail "Mayor briefing should filter issues by sgt-authorized"
+fi
+
+# ─── Test 15: Refinery dog review has label gate ─────────────────────
+
+echo "Test 15: Refinery dog review checks sgt-authorized"
+if grep -B2 -A5 'BLOCKED dog.*missing sgt-authorized' "$SGT_SCRIPT" >/dev/null 2>&1; then
+  pass "Refinery dog review has sgt-authorized gate"
+else
+  fail "Refinery dog review should check sgt-authorized"
+fi
+
+# ─── Test 16: Escalation init creates sgt-authorized label ───────────
+
+echo "Test 16: Escalation init creates sgt-authorized label"
+if sed -n '/^cmd_escalation_init/,/^cmd_escalation_show/p' "$SGT_SCRIPT" | grep -q 'sgt-authorized'; then
+  pass "Escalation init creates sgt-authorized label"
+else
+  fail "Escalation init should create sgt-authorized label"
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────
+
+echo ""
+echo "════════════════════════════════"
+echo "Results: $PASS passed, $FAIL failed ($TESTS total)"
+echo "════════════════════════════════"
+
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- Adds a `sgt-authorized` label gate to prevent unauthorized issue/PR injection into the sgt pipeline
- All issue-creating commands (`sling`, `dog`, `molecule run`) now auto-apply the `sgt-authorized` label
- All processing pipelines (witness, refinery, mayor) now verify the label before acting on issues or PRs
- Issues/PRs without the `sgt-authorized` label are blocked and logged

## Security model

**Before:** Any GitHub issue or PR on a monitored repo could be picked up and processed by sgt's automation (witness, refinery, mayor). An attacker could create a malicious issue or PR that sgt would automatically act on.

**After:** Only issues with the `sgt-authorized` label are processed. Since only sgt's own dispatch commands (`sling`, `dog`, `molecule run`) apply this label, externally-created issues are ignored by default.

### Protected surfaces
- `_resling_existing_issue` — blocks re-slinging unauthorized issues
- Witness orphan PR scanner — blocks PRs without authorized linked issues
- Refinery PR processing — blocks PRs whose issues lack the label
- Refinery dog review — blocks dogs whose issues lack the label
- Mayor critical issue scan — filters to only authorized issues
- Mayor orphan PR scanner — verifies linked issue authorization
- Mayor briefing — shows only authorized issues

## Test plan

- [x] 16 automated tests pass (`bash test_sgt_authorized.sh`)
- [x] Script passes `bash -n` syntax check
- [x] Helper function correctly handles: label present, label absent, issue 0, empty issue, partial matches, multiple labels

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)