### PR TITLE
Add SGT web UI control panel

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,54 @@
+# SGT Web UI Control Panel
+
+Real-time dashboard for monitoring and managing SGT agents, workers, rigs, logs, and dispatching tasks.
+
+## Setup
+
+```bash
+cd web
+npm install
+npm start
+```
+
+The UI will be available at `http://localhost:4747`.
+
+## Configuration
+
+Environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SGT_WEB_PORT` | `4747` | Server port |
+| `SGT_ROOT` | `~/sgt` | SGT workspace root |
+| `SGT_BIN` | `$SGT_ROOT/sgt` | Path to sgt binary |
+
+## Features
+
+- **Dashboard** — Live agent status, polecat overview, merge queue summary
+- **Polecats panel** — All active polecats with status, rig, issue, branch, PR info. Click to peek at tmux output
+- **Dogs panel** — Active dogs with status
+- **Rigs** — Registered rigs with repo links, witness/refinery status, polecat counts
+- **Sling** — Dispatch new polecats (pick rig, enter task, optional labels/convoy) or dogs
+- **Log viewer** — Real-time tailing of sgt.log with auto-scroll
+- **Merge Queue** — Pending PRs in refinery queue
+
+## Architecture
+
+- **Backend**: Node.js + Express. Reads SGT state from `~/.sgt/` directory and shells out to `sgt` CLI for actions.
+- **Frontend**: Single HTML page with vanilla JS. Dark theme, monospace design.
+- **Real-time**: WebSocket connection pushes status updates (polled every 3s) and new log lines (file watcher).
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/status` | Full parsed SGT status |
+| GET | `/api/rigs` | List registered rigs |
+| GET | `/api/polecats` | Polecat state files |
+| GET | `/api/dogs` | Dog state files |
+| GET | `/api/merge-queue` | Merge queue items |
+| GET | `/api/peek/:target` | Peek at tmux pane output |
+| GET | `/api/logs?lines=N` | Tail sgt.log |
+| POST | `/api/sling` | Dispatch a polecat `{rig, task, labels?, convoy?}` |
+| POST | `/api/sling-dog` | Dispatch a dog `{rig, issue}` |
+| WS | `/` | Real-time status + log stream |

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sgt-web",
+  "version": "1.0.0",
+  "description": "SGT Web UI Control Panel — real-time dashboard for monitoring agents, workers, rigs, logs, and dispatching tasks",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.21.0",
+    "ws": "^8.18.0"
+  }
+}

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,0 +1,860 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SGT Control Panel</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --bg2: #161b22;
+    --bg3: #21262d;
+    --border: #30363d;
+    --text: #c9d1d9;
+    --text-dim: #8b949e;
+    --accent: #58a6ff;
+    --green: #3fb950;
+    --red: #f85149;
+    --orange: #d29922;
+    --purple: #bc8cff;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+    background: var(--bg);
+    color: var(--text);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  /* Layout */
+  .header {
+    background: var(--bg2);
+    border-bottom: 1px solid var(--border);
+    padding: 12px 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .header h1 {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text);
+  }
+  .header h1 span { color: var(--accent); }
+  .header .conn-status {
+    font-size: 11px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .header .conn-dot {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    background: var(--red);
+  }
+  .header .conn-dot.connected { background: var(--green); }
+
+  .nav {
+    background: var(--bg2);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    gap: 0;
+    overflow-x: auto;
+  }
+  .nav button {
+    background: none;
+    border: none;
+    color: var(--text-dim);
+    padding: 10px 18px;
+    font-family: inherit;
+    font-size: 12px;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    white-space: nowrap;
+  }
+  .nav button:hover { color: var(--text); }
+  .nav button.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+  }
+
+  .main { padding: 16px 20px; max-width: 1200px; margin: 0 auto; }
+
+  .panel { display: none; }
+  .panel.active { display: block; }
+
+  /* Cards */
+  .card {
+    background: var(--bg2);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    margin-bottom: 12px;
+    overflow: hidden;
+  }
+  .card-header {
+    padding: 10px 14px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .card-body { padding: 12px 14px; }
+
+  /* Status indicators */
+  .status-dot {
+    display: inline-block;
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    margin-right: 6px;
+  }
+  .status-on { background: var(--green); }
+  .status-off { background: var(--red); }
+  .status-alive { background: var(--green); }
+  .status-dead { background: var(--red); }
+
+  /* Agent grid */
+  .agent-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 10px;
+  }
+  .agent-item {
+    background: var(--bg3);
+    border-radius: 4px;
+    padding: 10px 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .agent-item .name { font-weight: 600; flex: 1; }
+  .agent-item .meta { color: var(--text-dim); font-size: 11px; }
+
+  /* Polecat/Dog list */
+  .worker-list { display: flex; flex-direction: column; gap: 8px; }
+  .worker-item {
+    background: var(--bg3);
+    border-radius: 4px;
+    padding: 12px 14px;
+    cursor: pointer;
+  }
+  .worker-item:hover { border-left: 3px solid var(--accent); padding-left: 11px; }
+  .worker-item .worker-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+  }
+  .worker-item .worker-name { font-weight: 600; }
+  .worker-item .worker-meta {
+    color: var(--text-dim);
+    font-size: 11px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .worker-item .worker-meta span { display: block; }
+  .badge {
+    font-size: 10px;
+    padding: 2px 6px;
+    border-radius: 10px;
+    font-weight: 600;
+  }
+  .badge-alive { background: rgba(63, 185, 80, 0.15); color: var(--green); }
+  .badge-dead { background: rgba(248, 81, 73, 0.15); color: var(--red); }
+  .badge-running { background: rgba(88, 166, 255, 0.15); color: var(--accent); }
+
+  /* Rig cards */
+  .rig-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 10px;
+  }
+  .rig-card {
+    background: var(--bg3);
+    border-radius: 4px;
+    padding: 12px 14px;
+  }
+  .rig-card .rig-name {
+    font-weight: 600;
+    font-size: 14px;
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .rig-card .rig-repo { color: var(--text-dim); font-size: 11px; margin-bottom: 8px; word-break: break-all; }
+  .rig-card .rig-stats {
+    display: flex;
+    gap: 12px;
+    font-size: 11px;
+  }
+  .rig-card .rig-stats span { color: var(--text-dim); }
+  .rig-card .rig-stats .val { color: var(--text); font-weight: 600; }
+
+  /* Sling form */
+  .sling-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-width: 600px;
+  }
+  .form-group { display: flex; flex-direction: column; gap: 4px; }
+  .form-group label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    letter-spacing: 0.5px;
+  }
+  .form-group select,
+  .form-group input,
+  .form-group textarea {
+    background: var(--bg3);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 8px 10px;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 13px;
+  }
+  .form-group textarea { min-height: 80px; resize: vertical; }
+  .form-group select:focus,
+  .form-group input:focus,
+  .form-group textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .form-row { display: flex; gap: 12px; }
+  .form-row .form-group { flex: 1; }
+  .btn {
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    align-self: flex-start;
+  }
+  .btn:hover { opacity: 0.9; }
+  .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .btn-secondary {
+    background: var(--bg3);
+    border: 1px solid var(--border);
+    color: var(--text);
+  }
+
+  /* Log viewer */
+  .log-viewer {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    height: 500px;
+    overflow-y: auto;
+    padding: 10px;
+    font-size: 11px;
+    line-height: 1.6;
+  }
+  .log-line { white-space: pre-wrap; word-break: break-all; }
+  .log-line .timestamp { color: var(--text-dim); }
+  .log-line .event { color: var(--orange); font-weight: 600; }
+
+  /* Merge queue */
+  .mq-list { display: flex; flex-direction: column; gap: 8px; }
+  .mq-item {
+    background: var(--bg3);
+    border-radius: 4px;
+    padding: 12px 14px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .mq-item .mq-pr { font-weight: 600; color: var(--accent); }
+  .mq-item .mq-meta { color: var(--text-dim); font-size: 11px; flex: 1; }
+
+  /* Peek modal */
+  .modal-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.6);
+    z-index: 100;
+    align-items: center;
+    justify-content: center;
+  }
+  .modal-overlay.active { display: flex; }
+  .modal {
+    background: var(--bg2);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    width: 90%;
+    max-width: 800px;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+  }
+  .modal-header {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-weight: 600;
+  }
+  .modal-header button {
+    background: none;
+    border: none;
+    color: var(--text-dim);
+    font-size: 18px;
+    cursor: pointer;
+  }
+  .modal-body {
+    padding: 16px;
+    overflow-y: auto;
+    flex: 1;
+  }
+  .modal-body pre {
+    white-space: pre-wrap;
+    word-break: break-all;
+    font-size: 11px;
+    line-height: 1.5;
+  }
+
+  /* Empty state */
+  .empty {
+    color: var(--text-dim);
+    text-align: center;
+    padding: 24px;
+    font-style: italic;
+  }
+
+  /* Toast notifications */
+  .toast-container {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    z-index: 200;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .toast {
+    background: var(--bg3);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 10px 14px;
+    font-size: 12px;
+    max-width: 350px;
+    animation: fadeIn 0.2s ease-out;
+  }
+  .toast.error { border-color: var(--red); }
+  .toast.success { border-color: var(--green); }
+  @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+
+  /* Section titles */
+  .section-title {
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .section-title .count {
+    background: var(--bg3);
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 11px;
+    color: var(--text-dim);
+  }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1><span>SGT</span> Control Panel</h1>
+  <div class="conn-status">
+    <div class="conn-dot" id="connDot"></div>
+    <span id="connLabel">Disconnected</span>
+  </div>
+</div>
+
+<nav class="nav" id="nav">
+  <button class="active" data-panel="dashboard">Dashboard</button>
+  <button data-panel="polecats">Polecats</button>
+  <button data-panel="dogs">Dogs</button>
+  <button data-panel="rigs">Rigs</button>
+  <button data-panel="sling">Sling</button>
+  <button data-panel="logs">Logs</button>
+  <button data-panel="merge-queue">Merge Queue</button>
+</nav>
+
+<div class="main">
+  <!-- Dashboard -->
+  <div class="panel active" id="panel-dashboard">
+    <div class="card">
+      <div class="card-header">Agents</div>
+      <div class="card-body">
+        <div class="agent-grid" id="agentGrid"></div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-header">
+        <span>Polecats</span>
+        <span class="count" id="polecatCount">0</span>
+      </div>
+      <div class="card-body">
+        <div class="worker-list" id="dashPolecats"></div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-header">
+        <span>Merge Queue</span>
+        <span class="count" id="mqCount">0</span>
+      </div>
+      <div class="card-body">
+        <div class="mq-list" id="dashMergeQueue"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Polecats -->
+  <div class="panel" id="panel-polecats">
+    <div class="section-title">Active Polecats <span class="count" id="polecatCount2">0</span></div>
+    <div class="worker-list" id="polecatList"></div>
+  </div>
+
+  <!-- Dogs -->
+  <div class="panel" id="panel-dogs">
+    <div class="section-title">Active Dogs <span class="count" id="dogCount">0</span></div>
+    <div class="worker-list" id="dogList"></div>
+  </div>
+
+  <!-- Rigs -->
+  <div class="panel" id="panel-rigs">
+    <div class="section-title">Registered Rigs <span class="count" id="rigCount">0</span></div>
+    <div class="rig-grid" id="rigGrid"></div>
+  </div>
+
+  <!-- Sling -->
+  <div class="panel" id="panel-sling">
+    <div class="card">
+      <div class="card-header">Dispatch Polecat</div>
+      <div class="card-body">
+        <form class="sling-form" id="slingForm">
+          <div class="form-group">
+            <label>Rig</label>
+            <select id="slingRig" required></select>
+          </div>
+          <div class="form-group">
+            <label>Task Description</label>
+            <textarea id="slingTask" placeholder="Describe the task..." required></textarea>
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <label>Labels (comma-separated)</label>
+              <input type="text" id="slingLabels" placeholder="enhancement, bug...">
+            </div>
+            <div class="form-group">
+              <label>Convoy (Milestone)</label>
+              <input type="text" id="slingConvoy" placeholder="Optional milestone name">
+            </div>
+          </div>
+          <button type="submit" class="btn" id="slingBtn">Sling Polecat</button>
+        </form>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-header">Dispatch Dog</div>
+      <div class="card-body">
+        <form class="sling-form" id="dogForm">
+          <div class="form-group">
+            <label>Rig</label>
+            <select id="dogRig" required></select>
+          </div>
+          <div class="form-group">
+            <label>Issue Number</label>
+            <input type="text" id="dogIssue" placeholder="#7 or 7" required>
+          </div>
+          <button type="submit" class="btn" id="dogBtn">Sling Dog</button>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- Logs -->
+  <div class="panel" id="panel-logs">
+    <div class="card">
+      <div class="card-header">
+        <span>sgt.log</span>
+        <button class="btn btn-secondary" onclick="loadLogs()" style="padding:4px 10px;font-size:11px;">Refresh</button>
+      </div>
+      <div class="card-body" style="padding:0;">
+        <div class="log-viewer" id="logViewer"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Merge Queue -->
+  <div class="panel" id="panel-merge-queue">
+    <div class="section-title">Refinery Merge Queue <span class="count" id="mqCount2">0</span></div>
+    <div class="mq-list" id="mergeQueueList"></div>
+  </div>
+</div>
+
+<!-- Peek Modal -->
+<div class="modal-overlay" id="peekModal">
+  <div class="modal">
+    <div class="modal-header">
+      <span id="peekTitle">Peek</span>
+      <button onclick="closePeek()">&times;</button>
+    </div>
+    <div class="modal-body">
+      <pre id="peekOutput">Loading...</pre>
+    </div>
+  </div>
+</div>
+
+<!-- Toast Container -->
+<div class="toast-container" id="toasts"></div>
+
+<script>
+// --- State ---
+let ws = null;
+let state = { agents: [], polecats: [], dogs: [], crew: [], mergeQueue: [] };
+let rigs = [];
+
+// --- Nav ---
+document.getElementById('nav').addEventListener('click', (e) => {
+  if (e.target.tagName !== 'BUTTON') return;
+  document.querySelectorAll('.nav button').forEach(b => b.classList.remove('active'));
+  document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+  e.target.classList.add('active');
+  document.getElementById('panel-' + e.target.dataset.panel).classList.add('active');
+
+  if (e.target.dataset.panel === 'logs') loadLogs();
+  if (e.target.dataset.panel === 'rigs') loadRigs();
+});
+
+// --- WebSocket ---
+function connectWs() {
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  ws = new WebSocket(proto + '//' + location.host);
+
+  ws.onopen = () => {
+    document.getElementById('connDot').classList.add('connected');
+    document.getElementById('connLabel').textContent = 'Connected';
+  };
+
+  ws.onclose = () => {
+    document.getElementById('connDot').classList.remove('connected');
+    document.getElementById('connLabel').textContent = 'Disconnected';
+    setTimeout(connectWs, 3000);
+  };
+
+  ws.onerror = () => ws.close();
+
+  ws.onmessage = (e) => {
+    const msg = JSON.parse(e.data);
+    if (msg.type === 'status') {
+      state = msg.parsed;
+      renderDashboard();
+      renderPolecats();
+      renderDogs();
+      renderMergeQueue();
+    } else if (msg.type === 'log') {
+      appendLogLines(msg.lines);
+    }
+  };
+}
+connectWs();
+
+// --- Render: Dashboard ---
+function renderDashboard() {
+  // Agents
+  const grid = document.getElementById('agentGrid');
+  grid.innerHTML = state.agents.map(a => {
+    const isOn = a.status.startsWith('on');
+    return `<div class="agent-item">
+      <span class="status-dot ${isOn ? 'status-on' : 'status-off'}"></span>
+      <span class="name">${esc(a.name)}</span>
+      <span class="meta">${esc(a.status)}${a.heartbeat ? '<br>' + esc(a.heartbeat) : ''}</span>
+    </div>`;
+  }).join('');
+
+  // Polecats summary
+  document.getElementById('polecatCount').textContent = state.polecats.length;
+  const dashP = document.getElementById('dashPolecats');
+  if (state.polecats.length === 0) {
+    dashP.innerHTML = '<div class="empty">No active polecats</div>';
+  } else {
+    dashP.innerHTML = state.polecats.map(p => workerHtml(p)).join('');
+  }
+
+  // Merge queue summary
+  document.getElementById('mqCount').textContent = state.mergeQueue.length;
+  const dashMq = document.getElementById('dashMergeQueue');
+  if (state.mergeQueue.length === 0) {
+    dashMq.innerHTML = '<div class="empty">Merge queue empty</div>';
+  } else {
+    dashMq.innerHTML = state.mergeQueue.map(m =>
+      `<div class="mq-item">
+        <span class="mq-pr">${esc(m.name)}</span>
+        <span class="mq-meta">${esc(m.detail)}</span>
+      </div>`
+    ).join('');
+  }
+}
+
+function workerHtml(p) {
+  const isAlive = p.alive === 'alive';
+  return `<div class="worker-item" onclick="peek('${esc(p.name)}')">
+    <div class="worker-header">
+      <span class="status-dot ${isAlive ? 'status-alive' : 'status-dead'}"></span>
+      <span class="worker-name">${esc(p.name)}</span>
+      <span class="badge ${isAlive ? 'badge-alive' : 'badge-dead'}">${isAlive ? 'alive' : 'dead'}</span>
+    </div>
+    <div class="worker-meta">
+      ${p.rig ? '<span>rig: ' + esc(p.rig) + '</span>' : ''}
+      ${p.issue ? '<span>issue: ' + esc(p.issue) + '</span>' : ''}
+      ${p.branch ? '<span>branch: ' + esc(p.branch) + '</span>' : ''}
+      ${p.pr ? '<span>pr: ' + esc(p.pr) + '</span>' : ''}
+    </div>
+  </div>`;
+}
+
+// --- Render: Polecats ---
+function renderPolecats() {
+  document.getElementById('polecatCount2').textContent = state.polecats.length;
+  const list = document.getElementById('polecatList');
+  if (state.polecats.length === 0) {
+    list.innerHTML = '<div class="empty">No active polecats</div>';
+  } else {
+    list.innerHTML = state.polecats.map(p => workerHtml(p)).join('');
+  }
+}
+
+// --- Render: Dogs ---
+function renderDogs() {
+  document.getElementById('dogCount').textContent = state.dogs.length;
+  const list = document.getElementById('dogList');
+  if (state.dogs.length === 0) {
+    list.innerHTML = '<div class="empty">No active dogs</div>';
+  } else {
+    list.innerHTML = state.dogs.map(d =>
+      `<div class="worker-item">
+        <div class="worker-header">
+          <span class="status-dot ${d.alive === 'alive' ? 'status-alive' : 'status-dead'}"></span>
+          <span class="worker-name">${esc(d.name)}</span>
+          <span class="badge ${d.alive === 'alive' ? 'badge-alive' : 'badge-dead'}">${d.alive}</span>
+        </div>
+        <div class="worker-meta"><span>${esc(d.issue)}</span></div>
+      </div>`
+    ).join('');
+  }
+}
+
+// --- Render: Merge Queue ---
+function renderMergeQueue() {
+  document.getElementById('mqCount2').textContent = state.mergeQueue.length;
+  const list = document.getElementById('mergeQueueList');
+  if (state.mergeQueue.length === 0) {
+    list.innerHTML = '<div class="empty">Merge queue empty</div>';
+  } else {
+    list.innerHTML = state.mergeQueue.map(m =>
+      `<div class="mq-item">
+        <span class="mq-pr">${esc(m.name)}</span>
+        <span class="mq-meta">${esc(m.detail)}</span>
+      </div>`
+    ).join('');
+  }
+}
+
+// --- Rigs ---
+async function loadRigs() {
+  try {
+    const res = await fetch('/api/rigs');
+    rigs = await res.json();
+    renderRigs();
+    populateRigSelects();
+  } catch {}
+}
+
+function renderRigs() {
+  document.getElementById('rigCount').textContent = rigs.length;
+  const grid = document.getElementById('rigGrid');
+  if (rigs.length === 0) {
+    grid.innerHTML = '<div class="empty">No rigs registered</div>';
+    return;
+  }
+  grid.innerHTML = rigs.map(r =>
+    `<div class="rig-card">
+      <div class="rig-name">${esc(r.name)}</div>
+      <div class="rig-repo"><a href="${esc(r.repo)}" target="_blank">${esc(r.repo)}</a></div>
+      <div class="rig-stats">
+        <span>polecats: <span class="val">${r.polecats ?? '?'}</span></span>
+        <span>witness: <span class="val">${esc(r.witness ?? '?')}</span></span>
+        <span>refinery: <span class="val">${esc(r.refinery ?? '?')}</span></span>
+      </div>
+    </div>`
+  ).join('');
+}
+
+function populateRigSelects() {
+  const opts = rigs.map(r => `<option value="${esc(r.name)}">${esc(r.name)}</option>`).join('');
+  const placeholder = '<option value="">Select a rig...</option>';
+  document.getElementById('slingRig').innerHTML = placeholder + opts;
+  document.getElementById('dogRig').innerHTML = placeholder + opts;
+}
+
+// Load rigs on start
+loadRigs();
+
+// --- Sling Form ---
+document.getElementById('slingForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const btn = document.getElementById('slingBtn');
+  btn.disabled = true;
+  btn.textContent = 'Dispatching...';
+  try {
+    const labels = document.getElementById('slingLabels').value
+      .split(',').map(l => l.trim()).filter(Boolean);
+    const res = await fetch('/api/sling', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        rig: document.getElementById('slingRig').value,
+        task: document.getElementById('slingTask').value,
+        labels,
+        convoy: document.getElementById('slingConvoy').value || undefined,
+      }),
+    });
+    const data = await res.json();
+    if (res.ok) {
+      toast('Polecat dispatched!', 'success');
+      document.getElementById('slingTask').value = '';
+      document.getElementById('slingLabels').value = '';
+      document.getElementById('slingConvoy').value = '';
+    } else {
+      toast('Error: ' + data.error, 'error');
+    }
+  } catch (err) {
+    toast('Error: ' + err.message, 'error');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Sling Polecat';
+  }
+});
+
+document.getElementById('dogForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const btn = document.getElementById('dogBtn');
+  btn.disabled = true;
+  btn.textContent = 'Dispatching...';
+  try {
+    const issue = document.getElementById('dogIssue').value.replace('#', '');
+    const res = await fetch('/api/sling-dog', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        rig: document.getElementById('dogRig').value,
+        issue,
+      }),
+    });
+    const data = await res.json();
+    if (res.ok) {
+      toast('Dog dispatched!', 'success');
+      document.getElementById('dogIssue').value = '';
+    } else {
+      toast('Error: ' + data.error, 'error');
+    }
+  } catch (err) {
+    toast('Error: ' + err.message, 'error');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Sling Dog';
+  }
+});
+
+// --- Logs ---
+async function loadLogs() {
+  try {
+    const res = await fetch('/api/logs?lines=200');
+    const data = await res.json();
+    const viewer = document.getElementById('logViewer');
+    viewer.innerHTML = data.lines.map(formatLogLine).join('');
+    viewer.scrollTop = viewer.scrollHeight;
+  } catch {}
+}
+
+function appendLogLines(lines) {
+  const viewer = document.getElementById('logViewer');
+  const wasAtBottom = viewer.scrollHeight - viewer.scrollTop - viewer.clientHeight < 50;
+  viewer.innerHTML += lines.map(formatLogLine).join('');
+  if (wasAtBottom) viewer.scrollTop = viewer.scrollHeight;
+}
+
+function formatLogLine(line) {
+  const m = line.match(/^\[([^\]]+)\]\s+(\S+)\s*(.*)/);
+  if (m) {
+    return `<div class="log-line"><span class="timestamp">[${esc(m[1])}]</span> <span class="event">${esc(m[2])}</span> ${esc(m[3])}</div>`;
+  }
+  return `<div class="log-line">${esc(line)}</div>`;
+}
+
+// --- Peek ---
+async function peek(target) {
+  document.getElementById('peekModal').classList.add('active');
+  document.getElementById('peekTitle').textContent = 'Peek: ' + target;
+  document.getElementById('peekOutput').textContent = 'Loading...';
+  try {
+    const res = await fetch('/api/peek/' + encodeURIComponent(target));
+    const data = await res.json();
+    document.getElementById('peekOutput').textContent = data.output || data.error || 'No output';
+  } catch (err) {
+    document.getElementById('peekOutput').textContent = 'Error: ' + err.message;
+  }
+}
+
+function closePeek() {
+  document.getElementById('peekModal').classList.remove('active');
+}
+
+document.getElementById('peekModal').addEventListener('click', (e) => {
+  if (e.target === e.currentTarget) closePeek();
+});
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') closePeek();
+});
+
+// --- Toast ---
+function toast(msg, type) {
+  const container = document.getElementById('toasts');
+  const el = document.createElement('div');
+  el.className = 'toast ' + (type || '');
+  el.textContent = msg;
+  container.appendChild(el);
+  setTimeout(() => el.remove(), 4000);
+}
+
+// --- Util ---
+function esc(s) {
+  if (s == null) return '';
+  const d = document.createElement('div');
+  d.textContent = String(s);
+  return d.innerHTML;
+}
+</script>
+</body>
+</html>

--- a/web/server.js
+++ b/web/server.js
@@ -1,0 +1,310 @@
+const express = require('express');
+const { WebSocketServer } = require('ws');
+const http = require('http');
+const path = require('path');
+const { execFile, spawn } = require('child_process');
+const fs = require('fs');
+
+const app = express();
+const server = http.createServer(app);
+const wss = new WebSocketServer({ server });
+
+const PORT = process.env.SGT_WEB_PORT || 4747;
+const SGT_ROOT = process.env.SGT_ROOT || path.join(process.env.HOME, 'sgt');
+const SGT_BIN = process.env.SGT_BIN || path.join(SGT_ROOT, 'sgt');
+const SGT_CONFIG = path.join(SGT_ROOT, '.sgt');
+const SGT_LOG = path.join(SGT_ROOT, 'sgt.log');
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+// --- Helpers ---
+
+function runSgt(args) {
+  return new Promise((resolve, reject) => {
+    execFile(SGT_BIN, args, { timeout: 15000, env: { ...process.env, SGT_ROOT } }, (err, stdout, stderr) => {
+      if (err) {
+        reject(new Error(stderr || err.message));
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+}
+
+function readStateFile(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const state = {};
+    for (const line of content.split('\n')) {
+      const eq = line.indexOf('=');
+      if (eq > 0) {
+        state[line.slice(0, eq)] = line.slice(eq + 1);
+      }
+    }
+    return state;
+  } catch {
+    return null;
+  }
+}
+
+function readDir(dir) {
+  try {
+    return fs.readdirSync(dir).filter(f => !f.startsWith('.'));
+  } catch {
+    return [];
+  }
+}
+
+// --- API: Status (parsed from sgt status output) ---
+
+app.get('/api/status', async (req, res) => {
+  try {
+    const output = await runSgt(['status']);
+    res.json({ raw: output, parsed: parseStatus(output) });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+function parseStatus(raw) {
+  const result = { agents: [], polecats: [], dogs: [], crew: [], mergeQueue: [] };
+  let section = null;
+
+  for (const line of raw.split('\n')) {
+    if (line.startsWith('=== Agents ===')) { section = 'agents'; continue; }
+    if (line.startsWith('=== Dogs ===')) { section = 'dogs'; continue; }
+    if (line.startsWith('=== Crew ===')) { section = 'crew'; continue; }
+    if (line.startsWith('=== Merge Queue')) { section = 'mergeQueue'; continue; }
+    if (line.startsWith('=== Polecats ===')) { section = 'polecats'; continue; }
+    if (line.startsWith('»') || line.trim() === '') continue;
+
+    if (section === 'agents') {
+      const m = line.match(/^\s+(\S+):\s+(.+)$/);
+      if (m) {
+        result.agents.push({ name: m[1], status: m[2].trim() });
+      } else if (line.includes('last heartbeat:')) {
+        const hb = line.match(/last heartbeat:\s+(.+)/);
+        if (hb && result.agents.length > 0) {
+          result.agents[result.agents.length - 1].heartbeat = hb[1].trim();
+        }
+      }
+    } else if (section === 'polecats') {
+      const pm = line.match(/^\s+(\S+)\s+\[(\w+)\]/);
+      if (pm) {
+        result.polecats.push({ name: pm[1], alive: pm[2] });
+      } else if (result.polecats.length > 0) {
+        const last = result.polecats[result.polecats.length - 1];
+        const kv = line.match(/^\s+(\w+):\s+(.+)/);
+        if (kv) last[kv[1]] = kv[2].trim();
+      }
+    } else if (section === 'dogs') {
+      const dm = line.match(/^\s+(\S+)\s+\[(\w+)\]\s+—\s+(.+)/);
+      if (dm) {
+        result.dogs.push({ name: dm[1], alive: dm[2], issue: dm[3] });
+      }
+    } else if (section === 'crew') {
+      const cm = line.match(/^\s+(\S+)\s+\[(\w+)\]\s+—\s+(.+)/);
+      if (cm) {
+        result.crew.push({ name: cm[1], status: cm[2], detail: cm[3] });
+      }
+    } else if (section === 'mergeQueue') {
+      const mm = line.match(/^\s+(\S+)\s+—\s+(.+)/);
+      if (mm) {
+        result.mergeQueue.push({ name: mm[1], detail: mm[2] });
+      }
+    }
+  }
+  return result;
+}
+
+// --- API: Rigs ---
+
+app.get('/api/rigs', async (req, res) => {
+  try {
+    const output = await runSgt(['rig', 'list']);
+    const rigs = [];
+    const lines = output.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const m = lines[i].match(/^\s+(\S+)\s+(https?:\/\/.+)$/);
+      if (m) {
+        const info = { name: m[1], repo: m[2] };
+        if (i + 1 < lines.length) {
+          const detail = lines[i + 1].match(/polecats:\s*(\d+)\s+witness:\s*(\w+)\s+refinery:\s*(\w+)/);
+          if (detail) {
+            info.polecats = parseInt(detail[1]);
+            info.witness = detail[2];
+            info.refinery = detail[3];
+          }
+        }
+        rigs.push(info);
+      }
+    }
+    res.json(rigs);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// --- API: Polecats (from state files for richer data) ---
+
+app.get('/api/polecats', (req, res) => {
+  const dir = path.join(SGT_CONFIG, 'polecats');
+  const polecats = readDir(dir).map(name => {
+    const state = readStateFile(path.join(dir, name));
+    if (!state) return null;
+    return { name, ...state };
+  }).filter(Boolean);
+  res.json(polecats);
+});
+
+// --- API: Dogs ---
+
+app.get('/api/dogs', (req, res) => {
+  const dir = path.join(SGT_CONFIG, 'dogs');
+  const dogs = readDir(dir).map(name => {
+    const state = readStateFile(path.join(dir, name));
+    if (!state) return null;
+    return { name, ...state };
+  }).filter(Boolean);
+  res.json(dogs);
+});
+
+// --- API: Merge Queue ---
+
+app.get('/api/merge-queue', (req, res) => {
+  const dir = path.join(SGT_CONFIG, 'merge-queue');
+  const items = readDir(dir).map(name => {
+    const state = readStateFile(path.join(dir, name));
+    if (!state) return null;
+    return { name, ...state };
+  }).filter(Boolean);
+  res.json(items);
+});
+
+// --- API: Peek ---
+
+app.get('/api/peek/:target', async (req, res) => {
+  try {
+    const output = await runSgt(['peek', req.params.target]);
+    res.json({ output });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// --- API: Sling (dispatch polecat) ---
+
+app.post('/api/sling', async (req, res) => {
+  const { rig, task, labels, convoy } = req.body;
+  if (!rig || !task) {
+    return res.status(400).json({ error: 'rig and task are required' });
+  }
+  const args = ['sling', rig, task];
+  if (convoy) { args.push('--convoy', convoy); }
+  if (labels && labels.length) {
+    for (const l of labels) { args.push('--label', l); }
+  }
+  try {
+    const output = await runSgt(args);
+    res.json({ output });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// --- API: Sling dog ---
+
+app.post('/api/sling-dog', async (req, res) => {
+  const { rig, issue } = req.body;
+  if (!rig || !issue) {
+    return res.status(400).json({ error: 'rig and issue are required' });
+  }
+  try {
+    const output = await runSgt(['dog', rig, issue]);
+    res.json({ output });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// --- API: Log tail (last N lines) ---
+
+app.get('/api/logs', (req, res) => {
+  const lines = parseInt(req.query.lines) || 100;
+  try {
+    const content = fs.readFileSync(SGT_LOG, 'utf8');
+    const allLines = content.split('\n');
+    const tail = allLines.slice(Math.max(0, allLines.length - lines));
+    res.json({ lines: tail });
+  } catch {
+    res.json({ lines: [] });
+  }
+});
+
+// --- WebSocket: Real-time updates ---
+
+const WS_INTERVAL = 3000; // poll every 3 seconds
+
+wss.on('connection', (ws) => {
+  let alive = true;
+  let logWatcher = null;
+  let statusInterval = null;
+
+  // Send initial status
+  sendStatus(ws);
+
+  // Poll status on interval
+  statusInterval = setInterval(() => {
+    if (alive) sendStatus(ws);
+  }, WS_INTERVAL);
+
+  // Watch log file for changes
+  try {
+    let lastSize = 0;
+    try { lastSize = fs.statSync(SGT_LOG).size; } catch {}
+
+    logWatcher = fs.watchFile(SGT_LOG, { interval: 1000 }, () => {
+      try {
+        const stat = fs.statSync(SGT_LOG);
+        if (stat.size > lastSize) {
+          const fd = fs.openSync(SGT_LOG, 'r');
+          const buf = Buffer.alloc(stat.size - lastSize);
+          fs.readSync(fd, buf, 0, buf.length, lastSize);
+          fs.closeSync(fd);
+          const newLines = buf.toString('utf8').split('\n').filter(l => l.trim());
+          if (newLines.length > 0 && ws.readyState === 1) {
+            ws.send(JSON.stringify({ type: 'log', lines: newLines }));
+          }
+          lastSize = stat.size;
+        }
+      } catch {}
+    });
+  } catch {}
+
+  ws.on('close', () => {
+    alive = false;
+    if (statusInterval) clearInterval(statusInterval);
+    if (logWatcher) fs.unwatchFile(SGT_LOG);
+  });
+
+  ws.on('error', () => {
+    alive = false;
+  });
+});
+
+async function sendStatus(ws) {
+  if (ws.readyState !== 1) return;
+  try {
+    const output = await runSgt(['status']);
+    ws.send(JSON.stringify({ type: 'status', raw: output, parsed: parseStatus(output) }));
+  } catch {}
+}
+
+// --- Start ---
+
+server.listen(PORT, () => {
+  console.log(`SGT Web UI running at http://localhost:${PORT}`);
+  console.log(`SGT_ROOT: ${SGT_ROOT}`);
+  console.log(`SGT_BIN:  ${SGT_BIN}`);
+});


### PR DESCRIPTION
## Summary

- Real-time web dashboard for monitoring SGT agents, polecats, dogs, rigs, logs, and merge queue
- Node.js + Express backend that reads SGT state from `.sgt/` directory and shells out to `sgt` CLI
- WebSocket for live status updates (3s polling) and log file streaming
- Single-page frontend: dark theme, monospace design, all panels (dashboard, polecats, dogs, rigs, sling, logs, merge queue)
- Sling interface to dispatch new polecats and dogs directly from the UI
- Peek modal to view tmux pane output for any worker

## Test plan

- [ ] Run `cd web && npm install && npm start`
- [ ] Open `http://localhost:4747` and verify dashboard shows live agent status
- [ ] Click through all tabs: Polecats, Dogs, Rigs, Sling, Logs, Merge Queue
- [ ] Click a polecat to peek at its tmux output
- [ ] Verify log viewer shows sgt.log entries and updates in real-time
- [ ] Test sling form dispatches a polecat successfully

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)