### PR TITLE
Fix bash here-doc parse warnings in sgt startup

### DIFF
--- a/sgt
+++ b/sgt
@@ -119,7 +119,8 @@ _notify_openclaw() {
   local notify_out=""
 
   if command -v python3 &>/dev/null; then
-    notify_out=$(python3 - "$SGT_NOTIFY" <<'PY' 2>/dev/null) || return 0
+    notify_out="$(
+      python3 - "$SGT_NOTIFY" 2>/dev/null <<'PY'
 import json
 import sys
 
@@ -147,8 +148,10 @@ print(channel)
 print(to)
 print(reply_to)
 PY
+    )" || return 0
   elif command -v python &>/dev/null; then
-    notify_out=$(python - "$SGT_NOTIFY" <<'PY' 2>/dev/null) || return 0
+    notify_out="$(
+      python - "$SGT_NOTIFY" 2>/dev/null <<'PY'
 import json
 import sys
 
@@ -176,6 +179,7 @@ print(channel)
 print(to)
 print(reply_to)
 PY
+    )" || return 0
   else
     return 0
   fi

--- a/test_bash_startup_warnings.sh
+++ b/test_bash_startup_warnings.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# test_bash_startup_warnings.sh — Ensure startup commands emit no bash parse warnings.
+
+set -euo pipefail
+
+SGT_SCRIPT="$(dirname "$0")/sgt"
+WARN_RE='warning: command substitution: [0-9]+ unterminated here-document'
+FAIL=0
+
+check_command() {
+  local name="$1"
+  shift
+
+  local stderr_file
+  stderr_file="$(mktemp)"
+
+  if bash -lc "\"$SGT_SCRIPT\" $*" >/dev/null 2>"$stderr_file"; then
+    :
+  else
+    # This regression focuses on parse warnings, not runtime preconditions.
+    :
+  fi
+
+  if grep -Eiq "$WARN_RE" "$stderr_file"; then
+    echo "FAIL: $name emitted bash parse warning"
+    cat "$stderr_file"
+    FAIL=1
+  else
+    echo "PASS: $name emitted no bash parse warning"
+  fi
+
+  rm -f "$stderr_file"
+}
+
+echo "=== bash startup warning regression ==="
+check_command "sgt help" help
+check_command "sgt status" status
+check_command "sgt rig list" rig list
+
+if [[ "$FAIL" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Summary
- Replace inline here-doc command substitutions in `_notify_openclaw` with multiline command substitution form that bash parses without warnings.
- Add `test_bash_startup_warnings.sh` regression check to fail if warning text appears for `sgt help`, `sgt status`, or `sgt rig list`.

## Root cause
Bash emits `warning: command substitution: ... unterminated here-document` when a here-doc is attached to a command written inline inside `$(...)` in this pattern. The script still executes, but the parser warning is printed on each invocation. Moving the here-doc into a multiline command-substitution block fixes parsing while preserving behavior.

## Validation
- `bash -n sgt` (no warnings)
- `./sgt help`, `./sgt status`, `./sgt rig list` (no parse warnings; exit codes preserved)
- `./test_bash_startup_warnings.sh`
- `./test_authorized_label.sh`
- `./test_mayor_notifications.sh`

Closes #31
