### PR TITLE
Fix here-doc parser warning regression checks in sgt

### DIFF
--- a/sgt
+++ b/sgt
@@ -118,6 +118,8 @@ _notify_openclaw() {
   local channel="" to="" reply_to=""
   local notify_out=""
 
+  # Keep `2>/dev/null` before `<<'PY'` inside $(...) to avoid bash's
+  # "unterminated here-document" parser warning from the legacy ordering.
   if command -v python3 &>/dev/null; then
     notify_out="$(
       python3 - "$SGT_NOTIFY" 2>/dev/null <<'PY'


### PR DESCRIPTION
## Summary
- document the parser-safe here-doc form in `sgt` where `notify_out` is populated
- extend startup warning regression coverage to the acceptance commands: `sgt --help`, `sgt status`, and `sgt sweep`
- add a guard that fails if the legacy here-doc ordering (`<<'PY' 2>/dev/null` inside `$(...)`) is reintroduced

## Root Cause
Bash emits `warning: command substitution: ... unterminated here-document` when the here-doc redirection is placed in the legacy order inside command substitution (`$(python ... <<'PY' 2>/dev/null)`).

## Fix
Keep redirection before the heredoc token (`python ... 2>/dev/null <<'PY'`) and lock this in with regression tests.

## Validation
- `bash test_bash_startup_warnings.sh`
- `./sgt --help` (stderr empty)
- `./sgt status` (stderr empty)
- `./sgt sweep` (stderr empty)

Closes #33
