### PR TITLE
Fix persistent sgt bash warning noise from notify parser

### DIFF
--- a/sgt
+++ b/sgt
@@ -117,74 +117,37 @@ _notify_openclaw() {
 
   local channel="" to="" reply_to=""
   local notify_out=""
+  local py_bin=""
+  local py_parse_notify='import json, sys
+path = sys.argv[1]
+try:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(1)
+def get(keys):
+    for k in keys:
+        v = data.get(k)
+        if v is None:
+            continue
+        v = str(v).strip()
+        if v:
+            return v
+    return ""
+print(get(["channel"]))
+print(get(["to"]))
+print(get(["reply_to", "reply-to", "replyTo"]))'
 
-  # Keep `2>/dev/null` before `<<'PY'` inside $(...) to avoid bash's
-  # "unterminated here-document" parser warning from the legacy ordering.
+  # Avoid heredoc inside command substitution to prevent bash parser warnings.
   if command -v python3 &>/dev/null; then
-    notify_out="$(
-      python3 - "$SGT_NOTIFY" 2>/dev/null <<'PY'
-import json
-import sys
-
-path = sys.argv[1]
-try:
-    with open(path, "r", encoding="utf-8") as f:
-        data = json.load(f)
-except Exception:
-    sys.exit(1)
-
-def get(keys):
-    for k in keys:
-        v = data.get(k)
-        if v is None:
-            continue
-        v = str(v).strip()
-        if v:
-            return v
-    return ""
-
-channel = get(["channel"])
-to = get(["to"])
-reply_to = get(["reply_to", "reply-to", "replyTo"])
-print(channel)
-print(to)
-print(reply_to)
-PY
-    )" || return 0
+    py_bin="python3"
   elif command -v python &>/dev/null; then
-    notify_out="$(
-      python - "$SGT_NOTIFY" 2>/dev/null <<'PY'
-import json
-import sys
-
-path = sys.argv[1]
-try:
-    with open(path, "r", encoding="utf-8") as f:
-        data = json.load(f)
-except Exception:
-    sys.exit(1)
-
-def get(keys):
-    for k in keys:
-        v = data.get(k)
-        if v is None:
-            continue
-        v = str(v).strip()
-        if v:
-            return v
-    return ""
-
-channel = get(["channel"])
-to = get(["to"])
-reply_to = get(["reply_to", "reply-to", "replyTo"])
-print(channel)
-print(to)
-print(reply_to)
-PY
-    )" || return 0
+    py_bin="python"
   else
     return 0
   fi
+
+  notify_out="$("$py_bin" -c "$py_parse_notify" "$SGT_NOTIFY" 2>/dev/null)" || return 0
 
   local fields=()
   while IFS= read -r line; do fields+=("$line"); done <<< "$notify_out"

--- a/test_bash_startup_warnings.sh
+++ b/test_bash_startup_warnings.sh
@@ -1,20 +1,23 @@
 #!/usr/bin/env bash
-# test_bash_startup_warnings.sh — Ensure startup commands emit no bash parse warnings.
+# test_bash_startup_warnings.sh — Ensure startup commands emit zero stderr noise.
 
 set -euo pipefail
 
-SGT_SCRIPT="$(dirname "$0")/sgt"
-WARN_RE='unterminated here-document'
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
 FAIL=0
 
-check_no_legacy_heredoc_pattern() {
-  # Regression guard: redirection must appear before <<'PY' within $(...).
-  # The old form `$(python ... <<'PY' 2>/dev/null)` triggers parser warnings.
-  if grep -Eq 'notify_out=\$\(python3? - "\$SGT_NOTIFY" <<'\''PY'\'' 2>/dev/null\)' "$SGT_SCRIPT"; then
-    echo "FAIL: legacy here-doc pattern found in $SGT_SCRIPT"
+check_no_heredoc_in_notify_parser() {
+  if awk '
+    /_notify_openclaw[[:space:]]*\(\)[[:space:]]*\{/ { in_notify=1 }
+    in_notify && /^}/ { in_notify=0 }
+    in_notify && /<<'\''PY'\''/ { found=1 }
+    END { exit(found ? 0 : 1) }
+  ' "$SGT_SCRIPT"; then
+    echo "FAIL: found heredoc-based Python parser in _notify_openclaw"
     FAIL=1
   else
-    echo "PASS: no legacy here-doc pattern found in $SGT_SCRIPT"
+    echo "PASS: no heredoc-based Python parser in _notify_openclaw"
   fi
 }
 
@@ -32,28 +35,68 @@ check_bash_parse() {
     return
   fi
 
-  if grep -Eiq "$WARN_RE" "$stderr_file"; then
-    echo "FAIL: bash -n emitted parse warning"
+  if [[ -s "$stderr_file" ]]; then
+    echo "FAIL: bash -n emitted stderr output"
     cat "$stderr_file"
     FAIL=1
   else
-    echo "PASS: bash -n emitted no parse warning"
+    echo "PASS: bash -n emitted zero stderr output"
   fi
 
   rm -f "$stderr_file"
 }
 
-check_command() {
-  local name="$1"
-  local expected_exit="$2"
-  shift 2
-
-  local stdout_file stderr_file cmd_exit
+setup_clean_shell() {
+  local tmp_home="$1"
+  local stdout_file stderr_file init_exit
   stdout_file="$(mktemp)"
   stderr_file="$(mktemp)"
 
   set +e
-  "$SGT_SCRIPT" "$@" >"$stdout_file" 2>"$stderr_file"
+  env -i \
+    HOME="$tmp_home" \
+    PATH="$tmp_home/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+    TERM="${TERM:-xterm}" \
+    bash --noprofile --norc -c "sgt init" >"$stdout_file" 2>"$stderr_file"
+  init_exit=$?
+  set -e
+
+  if [[ "$init_exit" -ne 0 ]]; then
+    echo "FAIL: clean-shell setup 'sgt init' failed with exit $init_exit"
+    [[ -s "$stderr_file" ]] && cat "$stderr_file"
+    FAIL=1
+  else
+    echo "PASS: clean-shell setup 'sgt init' exited 0"
+  fi
+
+  if [[ -s "$stderr_file" ]]; then
+    echo "FAIL: clean-shell setup 'sgt init' emitted stderr output"
+    cat "$stderr_file"
+    FAIL=1
+  else
+    echo "PASS: clean-shell setup 'sgt init' emitted zero stderr output"
+  fi
+
+  rm -f "$stdout_file" "$stderr_file"
+}
+
+check_command_clean_shell() {
+  local name="$1"
+  local expected_exit="$2"
+  local subcommand="$3"
+  local tmp_home="$4"
+
+  local stdout_file stderr_file cmd_exit
+
+  stdout_file="$(mktemp)"
+  stderr_file="$(mktemp)"
+
+  set +e
+  env -i \
+    HOME="$tmp_home" \
+    PATH="$tmp_home/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+    TERM="${TERM:-xterm}" \
+    bash --noprofile --norc -c "sgt $subcommand" >"$stdout_file" 2>"$stderr_file"
   cmd_exit=$?
   set -e
 
@@ -64,12 +107,12 @@ check_command() {
     echo "PASS: $name exit code is $expected_exit"
   fi
 
-  if grep -Eiq "$WARN_RE" "$stderr_file"; then
-    echo "FAIL: $name emitted here-doc warning"
+  if [[ -s "$stderr_file" ]]; then
+    echo "FAIL: $name emitted stderr output"
     cat "$stderr_file"
     FAIL=1
   else
-    echo "PASS: $name emitted no here-doc warning"
+    echo "PASS: $name emitted zero stderr output"
   fi
 
   if [[ ! -s "$stdout_file" ]]; then
@@ -83,11 +126,17 @@ check_command() {
 }
 
 echo "=== bash startup warning regression ==="
-check_no_legacy_heredoc_pattern
+check_no_heredoc_in_notify_parser
 check_bash_parse
-check_command "sgt --help" 0 --help
-check_command "sgt status" 0 status
-check_command "sgt sweep" 0 sweep
+TMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+mkdir -p "$TMP_HOME/.local/bin"
+cp "$SGT_SCRIPT" "$TMP_HOME/.local/bin/sgt"
+chmod +x "$TMP_HOME/.local/bin/sgt"
+setup_clean_shell "$TMP_HOME"
+check_command_clean_shell "sgt --help" 0 "--help" "$TMP_HOME"
+check_command_clean_shell "sgt status" 0 "status" "$TMP_HOME"
+check_command_clean_shell "sgt sweep" 0 "sweep" "$TMP_HOME"
 
 if [[ "$FAIL" -ne 0 ]]; then
   exit 1


### PR DESCRIPTION
Closes #39

## Summary
- removed the `_notify_openclaw` heredoc-in-command-substitution parser path that triggers bash startup warnings
- switched notify JSON parsing to `python -c` / `python3 -c` with the same field extraction behavior
- strengthened `test_bash_startup_warnings.sh` into a deterministic clean-shell smoke check that:
  - initializes a temp HOME via `sgt init`
  - runs `sgt --help`, `sgt status`, `sgt sweep`
  - fails on any stderr output
  - fails if heredoc-based parser pattern returns in `_notify_openclaw`

## Before / After Evidence
### Before (installed stale script)
Command:
```bash
/home/aj/.local/bin/sgt --help >/tmp/before_help.out 2>/tmp/before_help.err
/home/aj/.local/bin/sgt status >/tmp/before_status.out 2>/tmp/before_status.err
/home/aj/.local/bin/sgt sweep >/tmp/before_sweep.out 2>/tmp/before_sweep.err
```

`stderr`:
```text
/home/aj/.local/bin/sgt: line 122: warning: command substitution: 1 unterminated here-document
/home/aj/.local/bin/sgt: line 151: warning: command substitution: 1 unterminated here-document
```
(reproduced for all three commands)

### After (this branch script, clean shell temp install)
Command:
```bash
tmp_home=$(mktemp -d)
mkdir -p "$tmp_home/.local/bin"
cp ./sgt "$tmp_home/.local/bin/sgt"
chmod +x "$tmp_home/.local/bin/sgt"
env -i HOME="$tmp_home" PATH="$tmp_home/.local/bin:/usr/local/bin:/usr/bin:/bin" TERM="${TERM:-xterm}" \
  bash --noprofile --norc -c 'sgt init >/tmp/after_init.out 2>/tmp/after_init.err; sgt --help >/tmp/after_help.out 2>/tmp/after_help.err; sgt status >/tmp/after_status.out 2>/tmp/after_status.err; sgt sweep >/tmp/after_sweep.out 2>/tmp/after_sweep.err'
```

`stderr` bytes:
```text
after_init.err: 0
after_help.err: 0
after_status.err: 0
after_sweep.err: 0
```

## Regression Coverage
Command:
```bash
./test_bash_startup_warnings.sh
```

Result:
```text
ALL TESTS PASSED
```
