### PR TITLE
Fix bash here-doc parse warning hazards in CLI entrypoints

### DIFF
--- a/.github/workflows/bash-startup-warnings.yml
+++ b/.github/workflows/bash-startup-warnings.yml
@@ -1,0 +1,15 @@
+name: Bash Startup Warnings
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  startup-warning-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run bash startup warning regression test
+        run: ./test_bash_startup_warnings.sh

--- a/sgt
+++ b/sgt
@@ -513,20 +513,19 @@ cmd_sling() {
   done
 
   local issue_url issue_number
-  issue_url=$(gh issue create \
-    --repo "$repo" \
-    --title "$task" \
-    --body "$(cat <<EOF
-## Task
+  local issue_body
+  printf -v issue_body '## Task
 
-$task
+%s
 
 ---
 
-*Created by sgt — polecat: \`$pname\`*
-*Branch: \`$branch\`*
-EOF
-)" \
+*Created by sgt — polecat: `%s`*
+*Branch: `%s`*' "$task" "$pname" "$branch"
+  issue_url=$(gh issue create \
+    --repo "$repo" \
+    --title "$task" \
+    --body "$issue_body" \
     $label_args 2>&1) || die "failed to create issue: $issue_url"
 
   issue_number=$(echo "$issue_url" | grep -oP '/issues/\K[0-9]+')
@@ -2560,36 +2559,25 @@ cmd_dog() {
   info "creating issue for dog task..."
   _ensure_sgt_authorized_label "$repo"
   local issue_url issue_number
-  issue_url=$(gh issue create \
-    --repo "$repo" \
-    --title "[Dog] $task" \
-    --body "$(cat <<EOF
-## Research/Analysis Task
+  local issue_body
+  printf -v issue_body '## Research/Analysis Task
 
-$task
+%s
 
 ---
 
-*Created by sgt — dog: \`$dname\`*
-*Type: non-coding (results posted as comments)*
-EOF
-)" \
+*Created by sgt — dog: `%s`*
+*Type: non-coding (results posted as comments)*' "$task" "$dname"
+  issue_url=$(gh issue create \
+    --repo "$repo" \
+    --title "[Dog] $task" \
+    --body "$issue_body" \
     --label "dog" --label "sgt-authorized" 2>&1) || {
     # Label might not exist, try without dog label
     issue_url=$(gh issue create \
       --repo "$repo" \
       --title "[Dog] $task" \
-      --body "$(cat <<EOF
-## Research/Analysis Task
-
-$task
-
----
-
-*Created by sgt — dog: \`$dname\`*
-*Type: non-coding (results posted as comments)*
-EOF
-)" \
+      --body "$issue_body" \
     --label "sgt-authorized" 2>&1) || die "failed to create issue: $issue_url"
   }
 
@@ -3048,20 +3036,19 @@ cmd_molecule_run() {
 
       # Create issue with dependency info in body
       local issue_url issue_number
+      local issue_body
+      printf -v issue_body '## Molecule: %s (step %s)
+
+%s
+
+**Convoy:** %s
+
+---
+*Part of molecule run. Dispatched by sgt.*' "$molecule" "$step_idx" "$task" "$convoy_name"
       issue_url=$(gh issue create \
         --repo "$repo" \
         --title "[${molecule}/${step_idx}] $task" \
-        --body "$(cat <<EOF
-## Molecule: $molecule (step $step_idx)
-
-$task
-
-**Convoy:** $convoy_name
-
----
-*Part of molecule run. Dispatched by sgt.*
-EOF
-)" \
+        --body "$issue_body" \
         --label "sgt-authorized" 2>&1) || warn "failed to create issue for step $step_idx"
 
       if [[ -n "$issue_url" ]]; then

--- a/test_bash_startup_warnings.sh
+++ b/test_bash_startup_warnings.sh
@@ -21,6 +21,17 @@ check_no_heredoc_in_notify_parser() {
   fi
 }
 
+check_no_heredoc_in_command_substitution() {
+  if grep -nE '\$\(cat[[:space:]]*<<' "$SGT_SCRIPT" >/tmp/sgt_heredoc_subst_hits.$$; then
+    echo "FAIL: found heredoc within command substitution"
+    cat /tmp/sgt_heredoc_subst_hits.$$
+    FAIL=1
+  else
+    echo "PASS: no heredoc-within-command-substitution patterns found"
+  fi
+  rm -f /tmp/sgt_heredoc_subst_hits.$$
+}
+
 check_bash_parse() {
   local stderr_file
   stderr_file="$(mktemp)"
@@ -127,6 +138,7 @@ check_command_clean_shell() {
 
 echo "=== bash startup warning regression ==="
 check_no_heredoc_in_notify_parser
+check_no_heredoc_in_command_substitution
 check_bash_parse
 TMP_HOME="$(mktemp -d)"
 trap 'rm -rf "$TMP_HOME"' EXIT


### PR DESCRIPTION
Closes #43

## Summary
- Removed heredoc-inside-command-substitution patterns used for GitHub issue `--body` payloads in `sgt`.
- Replaced them with equivalent `printf -v` string assembly to avoid bash parser desync that can surface as `unterminated here-document` startup warnings.
- Hardened `test_bash_startup_warnings.sh` with a regression check that fails if `$(cat <<...)` reappears.
- Added CI workflow `.github/workflows/bash-startup-warnings.yml` to run this regression on pushes/PRs.

## Root Cause
Bash can emit misleading parse warnings (often around unrelated lines like 122/151) when heredocs are embedded inside command substitution in larger scripts. The prior `--body "$(cat <<EOF ... EOF)"` forms were the risky pattern.

## Before / After Evidence
Before (HEAD~1):
- Pattern present in `sgt` at 4 locations:
  - `458: --body "$(cat <<EOF`
  - `2459: --body "$(cat <<EOF`
  - `2475: --body "$(cat <<EOF`
  - `2947: --body "$(cat <<EOF`

After (this branch):
- `./test_bash_startup_warnings.sh` output includes:
  - `PASS: no heredoc-within-command-substitution patterns found`
  - `PASS: sgt --help emitted zero stderr output`
  - `PASS: sgt status emitted zero stderr output`
  - `PASS: sgt sweep emitted zero stderr output`

Local command evidence after patch:
- `sgt --help` stderr lines: `0`
- `sgt status` stderr lines: `0`
- `sgt sweep` stderr lines: `0`

## Local Validation
- `bash -n sgt`
- `./test_bash_startup_warnings.sh`
- `./test_authorized_label.sh`
- `./test_mayor_notifications.sh`
