### PR TITLE
Mayor/refinery: harden pre-merge revalidation against stale queue drift

### DIFF
--- a/sgt
+++ b/sgt
@@ -252,6 +252,22 @@ _mayor_pre_dispatch_revalidate() {
   return 0
 }
 
+_pr_head_sha() {
+  local repo="${1:-}" pr="${2:-}"
+  [[ -n "$repo" && -n "$pr" ]] || return 1
+  gh pr view "$pr" --repo "$repo" --json headRefOid --jq '.headRefOid // ""' 2>/dev/null || true
+}
+
+_merge_queue_set_head_sha() {
+  local queue_file="${1:-}" head_sha="${2:-}"
+  [[ -n "$queue_file" && -f "$queue_file" ]] || return 1
+  if grep -q '^HEAD_SHA=' "$queue_file"; then
+    sed -i -E "s/^HEAD_SHA=.*/HEAD_SHA=${head_sha}/" "$queue_file"
+  else
+    printf 'HEAD_SHA=%s\n' "$head_sha" >> "$queue_file"
+  fi
+}
+
 _find_recent_duplicate_issue() {
   local repo="${1:-}" title="${2:-}" cooldown_secs="${3:-0}"
   shift 3 || true
@@ -1239,6 +1255,8 @@ _witness_loop() {
           log_event "WITNESS_PR_READY $pname pr=#$pr_number"
 
           mkdir -p "$SGT_CONFIG/merge-queue"
+          local pr_head_sha
+          pr_head_sha="$(_pr_head_sha "$p_repo" "$pr_number")"
           cat > "$SGT_CONFIG/merge-queue/$pname" <<MQSTATE
 POLECAT=$pname
 RIG=$rig
@@ -1246,6 +1264,7 @@ REPO=$p_repo
 BRANCH=$p_branch
 ISSUE=$p_issue
 PR=$pr_number
+HEAD_SHA=$pr_head_sha
 AUTO_MERGE=$p_auto_merge
 BACKEND=${BACKEND:-$(_ai_backend_default)}
 TYPE=polecat
@@ -1361,6 +1380,8 @@ MQSTATE
           log_event "WITNESS_ORPHAN_PR pr=#$pr_num branch=$pr_branch"
 
           mkdir -p "$SGT_CONFIG/merge-queue"
+          local orphan_head_sha
+          orphan_head_sha="$(_pr_head_sha "$repo" "$pr_num")"
           cat > "$SGT_CONFIG/merge-queue/$orphan_pname" <<MQSTATE
 POLECAT=$orphan_pname
 RIG=$rig
@@ -1368,6 +1389,7 @@ REPO=$repo
 BRANCH=$pr_branch
 ISSUE=${orphan_issue:-0}
 PR=$pr_num
+HEAD_SHA=$orphan_head_sha
 AUTO_MERGE=true
 TYPE=polecat
 QUEUED=$(date -Iseconds)
@@ -1695,8 +1717,8 @@ _refinery_loop() {
       local mqname
       mqname="$(basename "$f")"
 
-      local mq_pr="" mq_repo="" mq_branch="" mq_issue="" mq_polecat="" mq_auto_merge="" mq_type="" mq_backend=""
-      eval "$(grep -E '^(PR|REPO|BRANCH|ISSUE|POLECAT|AUTO_MERGE|TYPE|BACKEND)=' "$f")"
+      local mq_pr="" mq_repo="" mq_branch="" mq_issue="" mq_polecat="" mq_auto_merge="" mq_type="" mq_backend="" mq_head_sha=""
+      eval "$(grep -E '^(PR|REPO|BRANCH|ISSUE|POLECAT|AUTO_MERGE|TYPE|BACKEND|HEAD_SHA)=' "$f")"
       mq_pr="${PR:-}"
       mq_repo="${REPO:-$repo}"
       mq_branch="${BRANCH:-}"
@@ -1705,6 +1727,7 @@ _refinery_loop() {
       mq_auto_merge="${AUTO_MERGE:-false}"
       mq_type="${TYPE:-polecat}"
       mq_backend="${BACKEND:-$(_ai_backend_default)}"
+      mq_head_sha="${HEAD_SHA:-}"
 
       echo "[refinery/$rig] processing $mq_type: PR #$mq_pr ($mq_branch)"
       local mq_owner_repo mq_pr_title mq_pr_title_field mq_pr_url mq_issue_url mq_wake_title
@@ -1787,6 +1810,26 @@ _refinery_loop() {
       # === AI REVIEW ===
       REFINERY_REJECT_REASON=""
       if _refinery_review_pr "$mq_repo" "$mq_pr" "$mq_issue" "$rig" "$mq_backend"; then
+        # Revalidate immediately before merge to prevent stale queue merges.
+        local live_snapshot live_state live_head_sha premerge_reason=""
+        live_snapshot=$(gh pr view "$mq_pr" --repo "$mq_repo" --json state,headRefOid --jq '.state + "|" + (.headRefOid // "")' 2>/dev/null || true)
+        if [[ -z "$live_snapshot" || "$live_snapshot" != *"|"* ]]; then
+          premerge_reason="unable to query live PR state"
+        else
+          IFS='|' read -r live_state live_head_sha <<< "$live_snapshot"
+          if [[ "$live_state" != "OPEN" ]]; then
+            premerge_reason="pr state drifted to ${live_state:-unknown}"
+          elif [[ -n "$mq_head_sha" && "$live_head_sha" != "$mq_head_sha" ]]; then
+            premerge_reason="head sha drifted queued=${mq_head_sha:-unknown} live=${live_head_sha:-unknown}"
+            _merge_queue_set_head_sha "$f" "$live_head_sha" || true
+          fi
+        fi
+        if [[ -n "$premerge_reason" ]]; then
+          echo "[refinery/$rig] PR #$mq_pr pre-merge revalidation drift — skipping ($premerge_reason)"
+          log_event "REFINERY_PREMERGE_SKIP pr=#$mq_pr reason=\"$(_escape_quotes "$premerge_reason")\""
+          continue
+        fi
+
         # APPROVED — merge
         echo "[refinery/$rig] merging PR #$mq_pr..."
         local merge_result
@@ -2557,12 +2600,15 @@ _mayor_loop() {
               local mqf="$SGT_CONFIG/merge-queue/${rname}-pr${pr_num}"
               if [[ ! -f "$mqf" ]]; then
                 mkdir -p "$SGT_CONFIG/merge-queue"
+                local orphan_head_sha
+                orphan_head_sha="$(_pr_head_sha "$repo" "$pr_num")"
                 cat > "$mqf" <<MQORPHAN
 RIG=$rname
 REPO=$repo
 PR=$pr_num
 BRANCH=$pr_branch
 ISSUE=${linked_issue}
+HEAD_SHA=$orphan_head_sha
 TYPE=polecat
 AUTO_MERGE=true
 QUEUED=$(date -Iseconds)

--- a/test_mayor_wake_replay_regression.sh
+++ b/test_mayor_wake_replay_regression.sh
@@ -65,4 +65,7 @@ echo "=== duplicate sling suppression during cooldown ==="
 echo "=== stale snapshot dispatch race guard ==="
 "$REPO_ROOT/test_mayor_stale_dispatch_race.sh"
 
+echo "=== refinery stale queue item guard ==="
+"$REPO_ROOT/test_refinery_stale_queue_item.sh"
+
 echo "ALL TESTS PASSED"

--- a/test_refinery_stale_queue_item.sh
+++ b/test_refinery_stale_queue_item.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# test_refinery_stale_queue_item.sh — Regression checks for refinery pre-merge stale queue revalidation.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+HOME_DIR="$TMP_ROOT/home"
+MOCK_BIN="$TMP_ROOT/mockbin"
+MERGE_MARKER="$TMP_ROOT/merge-called"
+mkdir -p "$HOME_DIR/.local/bin" "$MOCK_BIN"
+cp "$SGT_SCRIPT" "$HOME_DIR/.local/bin/sgt"
+chmod +x "$HOME_DIR/.local/bin/sgt"
+
+cat > "$MOCK_BIN/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+MERGE_MARKER="${SGT_MOCK_MERGE_MARKER:?missing SGT_MOCK_MERGE_MARKER}"
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+  echo "sgt-authorized"
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+  shift 2
+  json_fields=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json)
+        json_fields="${2:-}"
+        shift 2
+        ;;
+      --jq)
+        shift 2
+        ;;
+      --repo)
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  case "$json_fields" in
+    title)
+      echo "Stale queue regression PR"
+      ;;
+    state)
+      echo "OPEN"
+      ;;
+    mergeable)
+      echo "MERGEABLE"
+      ;;
+    state,headRefOid)
+      echo "OPEN|live999"
+      ;;
+    *)
+      echo ""
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "checks" ]]; then
+  echo "all checks pass"
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "diff" ]]; then
+  # Empty diff -> refinery treats as pass and proceeds to pre-merge revalidation.
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "merge" ]]; then
+  touch "$MERGE_MARKER"
+  echo "merged"
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "comment" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "comment" ]]; then
+  exit 0
+fi
+
+echo "mock gh unsupported: $*" >&2
+exit 1
+GH
+chmod +x "$MOCK_BIN/gh"
+
+ENV_PREFIX=(
+  env -i
+  HOME="$HOME_DIR"
+  PATH="$MOCK_BIN:$HOME_DIR/.local/bin:/usr/local/bin:/usr/bin:/bin"
+  TERM="${TERM:-xterm}"
+  SGT_ROOT="$HOME_DIR/sgt"
+  SGT_MOCK_MERGE_MARKER="$MERGE_MARKER"
+)
+
+"${ENV_PREFIX[@]}" bash --noprofile --norc -c '
+set -euo pipefail
+
+sgt init >/dev/null
+mkdir -p "$SGT_ROOT/rigs/test"
+printf "https://github.com/acme/demo\n" > "$SGT_ROOT/.sgt/rigs/test"
+
+cat > "$SGT_ROOT/.sgt/merge-queue/test-pr123" <<MQ
+POLECAT=test-pr123
+RIG=test
+REPO=https://github.com/acme/demo
+BRANCH=sgt/test-pr123
+ISSUE=77
+PR=123
+HEAD_SHA=queued111
+AUTO_MERGE=true
+TYPE=polecat
+QUEUED=$(date -Iseconds)
+MQ
+
+timeout 6 sgt _refinery test > "$SGT_ROOT/refinery.out" 2>&1 &
+pid=$!
+
+for _ in $(seq 1 120); do
+  fifo="$SGT_ROOT/.sgt/refinery-test.fifo"
+  if [[ -p "$fifo" ]]; then
+    printf "test-wake\n" > "$fifo"
+    break
+  fi
+  sleep 0.05
+done
+
+wait "$pid" || true
+'
+
+if [[ -f "$MERGE_MARKER" ]]; then
+  echo "expected refinery to skip merge on stale queue head SHA drift, but merge was attempted" >&2
+  exit 1
+fi
+
+OUT_FILE="$HOME_DIR/sgt/refinery.out"
+if ! grep -q 'pre-merge revalidation drift — skipping' "$OUT_FILE"; then
+  echo "expected refinery output to report pre-merge drift skip" >&2
+  exit 1
+fi
+
+LOG_FILE="$HOME_DIR/sgt/sgt.log"
+if ! grep -q 'REFINERY_PREMERGE_SKIP pr=#123' "$LOG_FILE"; then
+  echo "expected activity log entry for pre-merge skip" >&2
+  exit 1
+fi
+
+QUEUE_FILE="$HOME_DIR/sgt/.sgt/merge-queue/test-pr123"
+if ! grep -q '^HEAD_SHA=live999$' "$QUEUE_FILE"; then
+  echo "expected queue HEAD_SHA to refresh to live head after drift" >&2
+  exit 1
+fi
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Closes #51\n\n- capture PR head SHA when queuing merge items\n- revalidate PR is still OPEN and head SHA is unchanged immediately before merge\n- skip + log on drift and refresh queued HEAD_SHA for re-review\n- add regression coverage for stale merge-queue item drift