### PR TITLE
Mayor snapshot freshness guard for stale CLAUDE.md state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@
 - Mayor dispatch hardening: added a pre-dispatch live revalidation guard to `sgt sling` (mayor context) that atomically checks for open PRs and open `sgt-authorized` issues before issue creation.
 - Mayor decision flow now skips dispatch when revalidation is dirty/stale and logs a clear reason in both terminal output and `~/.sgt/mayor-decisions.log`.
 - Added regression coverage for stale snapshot races and no-duplicate dispatch behavior in `test_mayor_stale_dispatch_race.sh`.
+- Mayor merge-queue snapshot freshness guard now performs one live revalidation pass before surfacing active issues in mayor `CLAUDE.md`; when stale and live diverge, live state deterministically wins and stale snapshot details are recorded in decision output.
+- Mayor now emits explicit snapshot guard status lines containing `snapshot`, `live`, `chosen`, `source`, and `status` values for merge-queue decisions.
+- Added regression coverage for stale-vs-live precedence in both directions (`stale=1/live=0`, `stale=0/live=1`) in `test_mayor_snapshot_freshness_guard.sh`.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ Mayor AI dispatches also include a stale-state revalidation immediately before i
 - If either count is non-zero (or live state cannot be confirmed), dispatch is skipped.
 - A reasoned operator-visible line is emitted (`[mayor] dispatch skipped ...`) and a corresponding entry is appended to `~/.sgt/mayor-decisions.log`.
 
+Mayor cycle decisions also protect against stale snapshot text in generated `CLAUDE.md`:
+- Merge-queue count now performs a one-time live revalidation immediately before issue surfacing.
+- Deterministic precedence rules:
+  - if live count is available and differs from snapshot, `live` wins (`status=stale-snapshot`);
+  - if live is unavailable, snapshot is kept (`status=live-unavailable`);
+  - if both match, snapshot is accepted (`status=in-sync`).
+- Mayor emits an explicit status line with both values and chosen source:
+  - `[mayor] snapshot guard merge_queue_count snapshot=<n> live=<n> chosen=<n> source=<snapshot|live> status=<...>`
+- When a stale snapshot is detected, mayor records a `Snapshot Freshness` note in decision output instead of treating the stale snapshot value as an active issue.
+
 Mayor decision logging is durable:
 - Decision entries are appended atomically under a file lock.
 - Each entry is prefixed with a UTC ISO-8601 timestamp and `workspace=<path>`.

--- a/sgt
+++ b/sgt
@@ -267,6 +267,58 @@ _wake_trigger_should_suppress() {
   [[ "$age" -lt "$ttl" ]]
 }
 
+_mayor_merge_queue_count() {
+  local mq_count=0
+  if [[ -d "$SGT_CONFIG/merge-queue" ]]; then
+    local mqf
+    for mqf in "$SGT_CONFIG/merge-queue"/*; do
+      [[ -f "$mqf" ]] || continue
+      mq_count=$((mq_count + 1))
+    done
+  fi
+  echo "$mq_count"
+}
+
+_mayor_snapshot_resolve_counts() {
+  local snapshot_raw="${1:-}" live_raw="${2:-}"
+  local snapshot="$snapshot_raw" live="$live_raw"
+  local chosen source status
+
+  [[ "$snapshot" =~ ^[0-9]+$ ]] || snapshot=-1
+  [[ "$live" =~ ^[0-9]+$ ]] || live=-1
+
+  # Deterministic precedence:
+  # 1) If live is available and differs, live wins (stale snapshot).
+  # 2) If live is unavailable, snapshot is kept.
+  # 3) If both are available and equal, snapshot is accepted as in-sync.
+  if [[ "$live" -lt 0 ]]; then
+    chosen="$snapshot"
+    source="snapshot"
+    status="live-unavailable"
+  elif [[ "$snapshot" -lt 0 ]]; then
+    chosen="$live"
+    source="live"
+    status="snapshot-invalid"
+  elif [[ "$snapshot" -eq "$live" ]]; then
+    chosen="$snapshot"
+    source="snapshot"
+    status="in-sync"
+  else
+    chosen="$live"
+    source="live"
+    status="stale-snapshot"
+  fi
+
+  echo "${snapshot}|${live}|${chosen}|${source}|${status}"
+}
+
+_mayor_merge_queue_revalidate_once() {
+  local snapshot_count="${1:-}"
+  local live_count
+  live_count="$(_mayor_merge_queue_count)"
+  _mayor_snapshot_resolve_counts "$snapshot_count" "$live_count"
+}
+
 _normalize_label() {
   local label="${1:-}"
   label="$(_one_line "$label")"
@@ -2689,6 +2741,7 @@ _mayor_loop() {
     local issues_found=""
     local actions_taken=""
     local notify_rigger=""
+    local snapshot_freshness=""
 
     if [[ "$wake_reason" != "periodic" ]]; then
       local event_reason wake_summary event_key now_ts last_seen age skip_reason
@@ -2780,14 +2833,17 @@ _mayor_loop() {
     done
 
     # === 2. Check merge queue (refinery handles review + merge) ===
-    local mq_count=0
-    if [[ -d "$SGT_CONFIG/merge-queue" ]]; then
-      for mqf in "$SGT_CONFIG/merge-queue"/*; do
-        [[ -f "$mqf" ]] || continue
-        mq_count=$((mq_count + 1))
-      done
+    local mq_snapshot_count mq_live_count mq_count mq_source mq_status mq_resolution mq_guard_line
+    mq_snapshot_count="$(_mayor_merge_queue_count)"
+    mq_resolution="$(_mayor_merge_queue_revalidate_once "$mq_snapshot_count")"
+    IFS='|' read -r mq_snapshot_count mq_live_count mq_count mq_source mq_status <<< "$mq_resolution"
+    mq_guard_line="merge_queue_count snapshot=$mq_snapshot_count live=$mq_live_count chosen=$mq_count source=$mq_source status=$mq_status"
+    echo "[mayor] snapshot guard $mq_guard_line"
+    log_event "MAYOR_SNAPSHOT_GUARD $mq_guard_line"
+    if [[ "$mq_status" == "stale-snapshot" ]]; then
+      snapshot_freshness+="  - stale snapshot: $mq_guard_line\n"
     fi
-    if [[ "$mq_count" -gt 0 ]]; then
+    if [[ "$mq_count" =~ ^[0-9]+$ && "$mq_count" -gt 0 ]]; then
       issues_found+="  - merge queue has $mq_count item(s)\n"
     fi
 
@@ -2926,6 +2982,9 @@ MQORPHAN
       if [[ -n "$actions_taken" ]]; then
         cycle_entry+="$(printf '  Actions:\n%b' "$actions_taken")"
       fi
+      if [[ -n "$snapshot_freshness" ]]; then
+        cycle_entry+="$(printf '  Snapshot Freshness:\n%b' "$snapshot_freshness")"
+      fi
       if _mayor_record_decision "$cycle_entry" "cycle-summary" "$SGT_ROOT"; then
         echo "[mayor] logged issues/actions"
       fi
@@ -2953,6 +3012,9 @@ $(echo -e "$issues_found")
 
 Recent actions already taken:
 $(echo -e "$actions_taken")
+
+Snapshot freshness notes:
+$(echo -e "${snapshot_freshness:-  - none}")
 
 ## System State
 $(cat "$briefing")

--- a/test_mayor_snapshot_freshness_guard.sh
+++ b/test_mayor_snapshot_freshness_guard.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# test_mayor_snapshot_freshness_guard.sh — Regression checks for mayor snapshot stale-vs-live precedence.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+
+extract_fn() {
+  local name="$1"
+  awk -v n="$name" '
+    $0 ~ "^" n "\\(\\) \\{" {in_fn=1}
+    in_fn {print}
+    in_fn && $0 == "}" {exit}
+  ' "$SGT_SCRIPT"
+}
+
+bash -s "$SGT_SCRIPT" <<'BASH'
+set -euo pipefail
+SGT_SCRIPT="$1"
+
+extract_fn() {
+  local name="$1"
+  awk -v n="$name" '
+    $0 ~ "^" n "\\(\\) \\{" {in_fn=1}
+    in_fn {print}
+    in_fn && $0 == "}" {exit}
+  ' "$SGT_SCRIPT"
+}
+
+eval "$(extract_fn _mayor_snapshot_resolve_counts)"
+eval "$(extract_fn _mayor_merge_queue_revalidate_once)"
+
+LIVE_CALLS_FILE="$(mktemp)"
+_mayor_merge_queue_count() {
+  echo "1" >> "$LIVE_CALLS_FILE"
+  echo "$MOCK_LIVE"
+}
+
+assert_resolution() {
+  local stale="$1" live="$2" expected="$3"
+  MOCK_LIVE="$live"
+  : > "$LIVE_CALLS_FILE"
+  local got
+  got="$(_mayor_merge_queue_revalidate_once "$stale")"
+  if [[ "$got" != "$expected" ]]; then
+    echo "unexpected resolution for stale=$stale live=$live" >&2
+    echo "expected: $expected" >&2
+    echo "got:      $got" >&2
+    exit 1
+  fi
+  local live_calls
+  live_calls=$(wc -l < "$LIVE_CALLS_FILE" | tr -d ' ')
+  if [[ "$live_calls" -ne 1 ]]; then
+    echo "expected exactly one live revalidation call, got $live_calls" >&2
+    exit 1
+  fi
+}
+
+# stale=1/live=0 => prefer live and mark stale snapshot.
+assert_resolution "1" "0" "1|0|0|live|stale-snapshot"
+
+# stale=0/live=1 => prefer live and surface active issue.
+assert_resolution "0" "1" "0|1|1|live|stale-snapshot"
+
+# in-sync => snapshot remains source of truth.
+assert_resolution "2" "2" "2|2|2|snapshot|in-sync"
+
+rm -f "$LIVE_CALLS_FILE"
+BASH
+
+if ! grep -q '\[mayor\] snapshot guard \$mq_guard_line' "$SGT_SCRIPT"; then
+  echo "expected explicit mayor snapshot guard status line in output path" >&2
+  exit 1
+fi
+if ! grep -q 'mq_guard_line="merge_queue_count snapshot=\$mq_snapshot_count live=\$mq_live_count chosen=\$mq_count source=\$mq_source status=\$mq_status"' "$SGT_SCRIPT"; then
+  echo "expected snapshot guard line to include snapshot/live/chosen/source/status values" >&2
+  exit 1
+fi
+
+echo "ALL TESTS PASSED"

--- a/test_mayor_wake_replay_regression.sh
+++ b/test_mayor_wake_replay_regression.sh
@@ -68,6 +68,9 @@ echo "=== duplicate sling suppression during cooldown ==="
 echo "=== stale snapshot dispatch race guard ==="
 "$REPO_ROOT/test_mayor_stale_dispatch_race.sh"
 
+echo "=== mayor snapshot freshness guard ==="
+"$REPO_ROOT/test_mayor_snapshot_freshness_guard.sh"
+
 echo "=== mayor critical alert cooldown dedupe ==="
 "$REPO_ROOT/test_mayor_critical_alert_cooldown.sh"
 


### PR DESCRIPTION
Closes #60

## Summary
- add deterministic stale-vs-live precedence for mayor merge-queue snapshot revalidation
- emit explicit snapshot guard status line with snapshot/live/chosen/source/status
- mark stale snapshot details in mayor decision output instead of surfacing stale issue state
- add regression coverage for stale=1/live=0 and stale=0/live=1
- document behavior in README and CHANGELOG