### PR TITLE
Witness/refinery stale-close dispatch hard stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,6 @@
 - Added refinery merge resilience regression coverage for transient-then-success and retry-time head-drift skip paths in `test_refinery_merge_retry_resilience.sh`.
 - `sgt status` now guards terminal-width initialization for non-TTY/narrow environments, avoids nounset crashes in PR-title truncation, and always exits `0` after rendering.
 - Added regression coverage for status rendering with unset/narrow `COLUMNS` in `test_status_non_tty_term_cols_guard.sh`.
+- Witness/refinery stale-event re-sling now enforces a dispatch-instant hard-stop gate that aborts spawn when the issue is no longer `OPEN` or the source PR is not `OPEN`/`MERGEABLE`.
+- Structured stale-skip activity logs now include `gate`, `source_event_key`, and normalized `skip_reason` fields alongside the human-readable reason for forensic traceability.
+- Added regression coverage for late `MERGED`/`CLOSED` replay against stale queued dispatch candidates in `test_refinery_stale_close_event_hard_stop.sh`.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,12 @@ export SGT_REQUIRE_AUTH_LABEL=0
 Witness/refinery re-dispatches also apply live stale-event guards immediately before spawning a new polecat:
 - Re-sling revalidates that the linked issue is still `OPEN`.
 - For stale refinery queue events, re-sling also revalidates the source PR state and skips if it already drifted to `MERGED` or `CLOSED`.
-- Skips emit explicit operator-visible reasons (`[resling] stale event ... — skipping: ...`) and structured activity log events (`RESLING_SKIP_STALE ...`).
+- Re-sling now applies a final dispatch-instant hard-stop gate immediately before spawn: abort when issue is not `OPEN`, or when source PR is not `OPEN`/`MERGEABLE`.
+- Skips emit explicit operator-visible reasons (`[resling] stale event ... — skipping: ...` / `... dispatch hard-stop: ...`) and structured activity log events (`RESLING_SKIP_STALE ...`) with forensic fields:
+  - `gate=<pre-dispatch|dispatch-instant>`
+  - `source_event_key=<event key before | metadata>`
+  - `skip_reason=<normalized reason key>`
+  - `reason="<human-readable detail>"`
 
 ## OpenClaw notifications
 

--- a/sgt
+++ b/sgt
@@ -875,6 +875,60 @@ _resling_pre_dispatch_revalidate() {
   fi
 }
 
+_resling_final_dispatch_revalidate() {
+  local repo="${1:-}" issue_number="${2:-}" source_pr="${3:-}"
+  local issue_state live_snapshot pr_state pr_mergeable
+
+  issue_state=$(gh issue view "$issue_number" --repo "$repo" --json state --jq '.state' 2>/dev/null || true)
+  if [[ -z "$issue_state" ]]; then
+    echo "unable to query live issue state for #$issue_number"
+    return 1
+  fi
+  if [[ "$issue_state" != "OPEN" ]]; then
+    echo "issue #$issue_number state=$issue_state"
+    return 1
+  fi
+
+  if [[ -n "$source_pr" && "$source_pr" != "0" ]]; then
+    live_snapshot=$(gh pr view "$source_pr" --repo "$repo" --json state,mergeable --jq '.state + "|" + (.mergeable // "")' 2>/dev/null || true)
+    if [[ -z "$live_snapshot" || "$live_snapshot" != *"|"* ]]; then
+      echo "unable to query live PR state/mergeable for #$source_pr"
+      return 1
+    fi
+    IFS='|' read -r pr_state pr_mergeable <<< "$live_snapshot"
+    if [[ "$pr_state" != "OPEN" ]]; then
+      echo "source PR #$source_pr state=${pr_state:-unknown}"
+      return 1
+    fi
+    if [[ "$pr_mergeable" != "MERGEABLE" ]]; then
+      echo "source PR #$source_pr mergeable=${pr_mergeable:-unknown}"
+      return 1
+    fi
+  fi
+}
+
+_resling_skip_reason_key() {
+  local reason="${1:-}"
+  case "$reason" in
+    "unable to query live issue state for #"*) echo "issue-state-unavailable" ;;
+    "issue #"*" state="*) echo "issue-not-open" ;;
+    "unable to query live PR state for #"*) echo "source-pr-state-unavailable" ;;
+    "unable to query live PR state/mergeable for #"*) echo "source-pr-state-unavailable" ;;
+    "source PR #"*" state="*) echo "source-pr-not-open" ;;
+    "source PR #"*" mergeable="*) echo "source-pr-not-mergeable" ;;
+    *) echo "unknown" ;;
+  esac
+}
+
+_resling_log_skip_stale() {
+  local rig="${1:-}" issue_number="${2:-}" source_event="${3:-unknown}"
+  local source_pr="${4:-}" stale_reason="${5:-}" gate="${6:-pre-dispatch}"
+  local source_event_key reason_key
+  source_event_key="$(_wake_trigger_key "$source_event")"
+  reason_key="$(_resling_skip_reason_key "$stale_reason")"
+  log_event "RESLING_SKIP_STALE issue=#$issue_number rig=$rig gate=$gate source_event=$source_event source_event_key=${source_event_key:-none} source_pr=${source_pr:-none} skip_reason=$reason_key reason=\"$(_escape_quotes "$stale_reason")\""
+}
+
 _find_recent_duplicate_issue() {
   local repo="${1:-}" title="${2:-}" cooldown_secs="${3:-0}"
   shift 3 || true
@@ -2155,7 +2209,7 @@ _resling_existing_issue() {
   local stale_reason=""
   if ! stale_reason=$(_resling_pre_dispatch_revalidate "$repo" "$issue_number" "$source_pr"); then
     echo "[resling] stale event ($source_event) for issue #$issue_number — skipping: $stale_reason"
-    log_event "RESLING_SKIP_STALE issue=#$issue_number rig=$rig source_event=$source_event source_pr=${source_pr:-none} reason=\"$(_escape_quotes "$stale_reason")\""
+    _resling_log_skip_stale "$rig" "$issue_number" "$source_event" "$source_pr" "$stale_reason" "pre-dispatch"
     return 1
   fi
 
@@ -2185,6 +2239,15 @@ _resling_existing_issue() {
     cp "$rpath/CLAUDE.md" "$worktree/CLAUDE.md"
   fi
   _write_polecat_claude_md "$worktree" "$issue_number" "$task" "$repo" "$pname" "$branch" "$default_branch" "false"
+
+  local final_reason=""
+  if ! final_reason=$(_resling_final_dispatch_revalidate "$repo" "$issue_number" "$source_pr"); then
+    echo "[resling] stale event ($source_event) for issue #$issue_number — dispatch hard-stop: $final_reason"
+    _resling_log_skip_stale "$rig" "$issue_number" "$source_event" "$source_pr" "$final_reason" "dispatch-instant"
+    git -C "$rpath" worktree remove --force "$worktree" 2>/dev/null || rm -rf "$worktree"
+    git -C "$rpath" branch -D "$branch" 2>/dev/null || true
+    return 1
+  fi
 
   cat > "$SGT_POLECATS/$pname" <<PSTATE
 RIG=$rig

--- a/test_mayor_wake_replay_regression.sh
+++ b/test_mayor_wake_replay_regression.sh
@@ -86,4 +86,7 @@ echo "=== refinery stale queue item guard ==="
 echo "=== refinery stale post-merge redispatch guard ==="
 "$REPO_ROOT/test_refinery_stale_post_merge_redispatch.sh"
 
+echo "=== refinery stale-close dispatch hard-stop ==="
+"$REPO_ROOT/test_refinery_stale_close_event_hard_stop.sh"
+
 echo "ALL TESTS PASSED"

--- a/test_refinery_stale_close_event_hard_stop.sh
+++ b/test_refinery_stale_close_event_hard_stop.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# test_refinery_stale_close_event_hard_stop.sh — Regression checks for late CLOSED/MERGED replay hard-stop at dispatch instant.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+run_case() {
+  local final_pr_state="$1"
+  local case_root="$TMP_ROOT/${final_pr_state,,}"
+  local home_dir="$case_root/home"
+  local mock_bin="$case_root/mockbin"
+  local pr_state_calls="$case_root/pr-state-calls"
+  local tmux_new_session_marker="$case_root/tmux-new-session"
+  mkdir -p "$home_dir/.local/bin" "$mock_bin"
+  cp "$SGT_SCRIPT" "$home_dir/.local/bin/sgt"
+  chmod +x "$home_dir/.local/bin/sgt"
+  : > "$pr_state_calls"
+
+  cat > "$mock_bin/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+PR_STATE_CALLS_FILE="${SGT_MOCK_PR_STATE_CALLS:?missing SGT_MOCK_PR_STATE_CALLS}"
+FINAL_PR_STATE="${SGT_MOCK_FINAL_PR_STATE:?missing SGT_MOCK_FINAL_PR_STATE}"
+
+inc_file() {
+  local path="$1"
+  local n=0
+  if [[ -s "$path" ]]; then
+    n="$(cat "$path" 2>/dev/null || echo 0)"
+  fi
+  [[ "$n" =~ ^[0-9]+$ ]] || n=0
+  n=$((n + 1))
+  printf '%s\n' "$n" > "$path"
+  echo "$n"
+}
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+  shift 2
+  json_fields=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json)
+        json_fields="${2:-}"
+        shift 2
+        ;;
+      --jq)
+        shift 2
+        ;;
+      --repo)
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  case "$json_fields" in
+    labels) echo "sgt-authorized" ;;
+    title) echo "Stale close replay hard-stop issue" ;;
+    state) echo "OPEN" ;;
+    body) echo "Issue body" ;;
+    *) echo "" ;;
+  esac
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+  shift 2
+  json_fields=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json)
+        json_fields="${2:-}"
+        shift 2
+        ;;
+      --jq)
+        shift 2
+        ;;
+      --repo)
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  case "$json_fields" in
+    title)
+      echo "Stale close replay hard-stop PR"
+      ;;
+    state)
+      call_n="$(inc_file "$PR_STATE_CALLS_FILE")"
+      if [[ "$call_n" -le 2 ]]; then
+        echo "OPEN"
+      else
+        echo "$FINAL_PR_STATE"
+      fi
+      ;;
+    state,mergeable)
+      call_n="$(inc_file "$PR_STATE_CALLS_FILE")"
+      if [[ "$call_n" -le 2 ]]; then
+        echo "OPEN|MERGEABLE"
+      else
+        echo "${FINAL_PR_STATE}|UNKNOWN"
+      fi
+      ;;
+    mergeable)
+      # Trigger refinery conflict handling and queued redispatch path.
+      echo "CONFLICTING"
+      ;;
+    *)
+      echo ""
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "checks" ]]; then
+  echo "all checks pass"
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "comment" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "close" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "reopen" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "comment" ]]; then
+  exit 0
+fi
+
+echo "mock gh unsupported: $*" >&2
+exit 1
+GH
+  chmod +x "$mock_bin/gh"
+
+  cat > "$mock_bin/tmux" <<'TMUX'
+#!/usr/bin/env bash
+set -euo pipefail
+
+MARKER="${SGT_MOCK_TMUX_NEW_SESSION_MARKER:?missing SGT_MOCK_TMUX_NEW_SESSION_MARKER}"
+
+if [[ "${1:-}" == "new-session" ]]; then
+  touch "$MARKER"
+  exit 0
+fi
+
+if [[ "${1:-}" == "has-session" ]]; then
+  exit 1
+fi
+
+exit 0
+TMUX
+  chmod +x "$mock_bin/tmux"
+
+  cat > "$mock_bin/git" <<'GIT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+args=("$@")
+if [[ "${args[0]:-}" == "-C" ]]; then
+  args=("${args[@]:2}")
+fi
+
+if [[ "${args[0]:-}" == "symbolic-ref" ]]; then
+  echo "refs/remotes/origin/main"
+  exit 0
+fi
+
+if [[ "${args[0]:-}" == "fetch" ]]; then
+  exit 0
+fi
+
+if [[ "${args[0]:-}" == "worktree" && "${args[1]:-}" == "add" ]]; then
+  target=""
+  for ((i=0; i<${#args[@]}; i++)); do
+    if [[ "${args[$i]}" == "-b" ]]; then
+      target="${args[$((i + 2))]:-}"
+      break
+    fi
+  done
+  [[ -n "$target" ]] && mkdir -p "$target"
+  exit 0
+fi
+
+if [[ "${args[0]:-}" == "worktree" && "${args[1]:-}" == "remove" ]]; then
+  last_idx=$(( ${#args[@]} - 1 ))
+  rm -rf "${args[$last_idx]:-}"
+  exit 0
+fi
+
+if [[ "${args[0]:-}" == "branch" ]]; then
+  exit 0
+fi
+
+exit 0
+GIT
+  chmod +x "$mock_bin/git"
+
+  env -i \
+    HOME="$home_dir" \
+    PATH="$mock_bin:$home_dir/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+    TERM="${TERM:-xterm}" \
+    SGT_ROOT="$home_dir/sgt" \
+    SGT_MOCK_PR_STATE_CALLS="$pr_state_calls" \
+    SGT_MOCK_FINAL_PR_STATE="$final_pr_state" \
+    SGT_MOCK_TMUX_NEW_SESSION_MARKER="$tmux_new_session_marker" \
+    bash --noprofile --norc -c '
+set -euo pipefail
+
+sgt init >/dev/null
+mkdir -p "$SGT_ROOT/rigs/test"
+printf "https://github.com/acme/demo\n" > "$SGT_ROOT/.sgt/rigs/test"
+
+cat > "$SGT_ROOT/.sgt/merge-queue/test-pr123" <<MQ
+POLECAT=test-pr123
+RIG=test
+REPO=https://github.com/acme/demo
+BRANCH=sgt/test-pr123
+ISSUE=77
+PR=123
+HEAD_SHA=abc123
+AUTO_MERGE=true
+TYPE=polecat
+QUEUED=$(date -Iseconds)
+MQ
+
+timeout 6 sgt _refinery test > "$SGT_ROOT/refinery.out" 2>&1 &
+pid=$!
+
+for _ in $(seq 1 120); do
+  fifo="$SGT_ROOT/.sgt/refinery-test.fifo"
+  if [[ -p "$fifo" ]]; then
+    printf "test-wake\n" > "$fifo"
+    break
+  fi
+  sleep 0.05
+done
+
+wait "$pid" || true
+'
+
+  local out_file="$home_dir/sgt/refinery.out"
+  local log_file="$home_dir/sgt/sgt.log"
+
+  if [[ -f "$tmux_new_session_marker" ]]; then
+    echo "expected dispatch hard-stop for late $final_pr_state replay, but new session was spawned" >&2
+    exit 1
+  fi
+
+  if ! grep -q 'dispatch hard-stop' "$out_file"; then
+    echo "expected dispatch hard-stop message in refinery output for $final_pr_state replay" >&2
+    exit 1
+  fi
+
+  if ! grep -q "source PR #123 state=$final_pr_state" "$out_file"; then
+    echo "expected stale-close reason to include source PR state=$final_pr_state" >&2
+    exit 1
+  fi
+
+  if ! grep -q 'RESLING_SKIP_STALE issue=#77 rig=test gate=dispatch-instant source_event=refinery-conflict source_event_key=refinery-conflict source_pr=123 skip_reason=source-pr-not-open' "$log_file"; then
+    echo "expected structured dispatch-instant stale skip log entry for $final_pr_state replay" >&2
+    exit 1
+  fi
+
+  if [[ -n "$(ls -A "$home_dir/sgt/.sgt/polecats" 2>/dev/null || true)" ]]; then
+    echo "expected no new polecat state files after dispatch hard-stop ($final_pr_state)" >&2
+    exit 1
+  fi
+}
+
+run_case "MERGED"
+run_case "CLOSED"
+
+echo "ALL TESTS PASSED"

--- a/test_refinery_stale_post_merge_redispatch.sh
+++ b/test_refinery_stale_post_merge_redispatch.sh
@@ -235,7 +235,7 @@ if [[ "$(cat "$ISSUE_STATE_CALLS" 2>/dev/null || echo 0)" -lt 1 ]]; then
   exit 1
 fi
 
-if ! grep -q 'RESLING_SKIP_STALE issue=#77 rig=test source_event=refinery-conflict source_pr=123' "$LOG_FILE"; then
+if ! grep -q 'RESLING_SKIP_STALE issue=#77 rig=test gate=pre-dispatch source_event=refinery-conflict source_event_key=refinery-conflict source_pr=123 skip_reason=source-pr-not-open' "$LOG_FILE"; then
   echo "expected structured stale redispatch skip entry in activity log" >&2
   exit 1
 fi


### PR DESCRIPTION
Closes #78

## Summary
- add dispatch-instant hard-stop revalidation before re-sling spawn
- enforce source PR OPEN + MERGEABLE check at final gate
- persist structured stale-skip logging fields (`gate`, `source_event_key`, `skip_reason`)
- add regression coverage for late MERGED/CLOSED replay stale queue candidates
- document stale-close hard-stop and observability fields
