### PR TITLE
Refinery: auto-retry with --auto for merge-policy failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Refinery merge attempts now use bounded retry with jitter for transient `gh pr m
 
 - Retries only trigger for transient classes: `timeout`, `network`, `http-5xx`, and `secondary-rate-limit`.
 - Before each retry, refinery re-checks live PR state (`OPEN`) and head SHA; if either drifts, retry is skipped and the queue item is kept with refreshed `HEAD_SHA`.
+- If merge fails specifically because branch policy requires auto-merge, refinery revalidates PR state/head and retries exactly once with `--auto`.
 - Refinery also enforces a durable per-attempt idempotency key of `repo+PR+head SHA`, persisted under `~/.sgt/refinery-merge-attempts/`.
 - Once a merge action has been attempted for that key, the fence is kept across retries, future refinery cycles, and process restarts.
 - Duplicate PR-ready queue replays for the same key are skipped before any additional merge action runs.
@@ -185,6 +186,7 @@ export SGT_REFINERY_MERGE_RETRY_JITTER_MS=400
 Observability:
 - `REFINERY_MERGE_RETRY pr=#... attempt=<n>/<max> class=<class> delay_s=<seconds>`
 - `REFINERY_MERGE_RETRY_SKIP pr=#... attempt=<n>/<max> reason="..."`
+- `REFINERY_MERGE_RETRY_AUTO repo=<owner/repo> pr=#... reason=branch-policy-requires-auto-merge outcome=<success|failed|skipped> ...`
 - `REFINERY_MERGE_FAILED pr=#... attempt=<n>/<max> class=<class> transient=<true|false> error="..."`
 - `REFINERY_DUPLICATE_SKIP pr=#... issue=#... reason_code=duplicate-merge-attempt-key reason="duplicate merge-attempt key (repo+pr+head) already processed" key="owner/repo|pr=<n>|head=<sha>"`
 

--- a/sgt
+++ b/sgt
@@ -1082,6 +1082,16 @@ _refinery_merge_error_is_transient() {
   esac
 }
 
+_refinery_merge_error_requires_auto_retry_reason() {
+  local raw="${1:-}" lc
+  lc="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$lc" =~ requires?[[:space:]-]*auto[[:space:]-]*merge|auto[[:space:]-]*merge[[:space:]]+is[[:space:]]+required|must[[:space:]]+use[[:space:]-]*auto[[:space:]-]*merge|branch[[:space:]]+policy[^[:cntrl:]]*auto[[:space:]-]*merge|enable[[:space:]]+pull[[:space:]]+request[[:space:]-]*auto[[:space:]-]*merge|enablepullrequestautomerge ]]; then
+    echo "branch-policy-requires-auto-merge"
+    return 0
+  fi
+  return 1
+}
+
 _refinery_revalidate_pr_open_head() {
   local repo="${1:-}" pr="${2:-}" expected_head_sha="${3:-}" queue_file="${4:-}"
   local live_snapshot live_state live_head_sha
@@ -2861,6 +2871,7 @@ _refinery_loop() {
         # APPROVED — merge (bounded retry for transient errors).
         local merge_attempt max_attempts merge_result merge_error_class merge_success=false
         local merge_error_transient=false merge_skip_reason="" merge_expected_head_sha
+        local merge_auto_retry_attempted=false merge_auto_retry_reason=""
         max_attempts="$(_refinery_merge_retry_max_attempts)"
         merge_expected_head_sha="$live_head_sha"
         merge_attempt=1
@@ -2871,6 +2882,35 @@ _refinery_loop() {
             merge_success=true
             break
           fi
+
+          if [[ "$merge_auto_retry_attempted" != "true" ]] && merge_auto_retry_reason="$(_refinery_merge_error_requires_auto_retry_reason "$merge_result")"; then
+            local auto_retry_live_head
+            merge_auto_retry_attempted=true
+            if ! auto_retry_live_head=$(_refinery_revalidate_pr_open_head "$mq_repo" "$mq_pr" "$merge_expected_head_sha" "$f"); then
+              merge_skip_reason="$auto_retry_live_head"
+              echo "[refinery/$rig] PR #$mq_pr auto-merge retry skipped — $merge_skip_reason"
+              log_event "REFINERY_MERGE_RETRY_AUTO repo=$mq_owner_repo pr=#$mq_pr reason=$merge_auto_retry_reason outcome=skipped final_reason=\"$(_escape_quotes "$merge_skip_reason")\""
+              break
+            fi
+            merge_expected_head_sha="$auto_retry_live_head"
+
+            echo "[refinery/$rig] PR #$mq_pr merge failed due to branch policy requiring auto-merge — retrying once with --auto"
+            if merge_result=$(gh pr merge "$mq_pr" --repo "$mq_repo" --squash --delete-branch --auto 2>&1); then
+              merge_success=true
+              log_event "REFINERY_MERGE_RETRY_AUTO repo=$mq_owner_repo pr=#$mq_pr reason=$merge_auto_retry_reason outcome=success"
+              break
+            fi
+
+            merge_error_class="$(_refinery_merge_error_class "$merge_result")"
+            if _refinery_merge_error_is_transient "$merge_error_class"; then
+              merge_error_transient=true
+            else
+              merge_error_transient=false
+            fi
+            log_event "REFINERY_MERGE_RETRY_AUTO repo=$mq_owner_repo pr=#$mq_pr reason=$merge_auto_retry_reason outcome=failed final_class=$merge_error_class final_error=\"$(_escape_quotes "$merge_result")\""
+            break
+          fi
+
           merge_error_class="$(_refinery_merge_error_class "$merge_result")"
           if _refinery_merge_error_is_transient "$merge_error_class"; then
             merge_error_transient=true

--- a/test_refinery_merge_retry_auto_guardrail.sh
+++ b/test_refinery_merge_retry_auto_guardrail.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# test_refinery_merge_retry_auto_guardrail.sh — Regression checks for branch-policy auto-merge retry guardrail.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+
+run_case() {
+  local mode="$1"
+  local tmp_root home_dir mock_bin merge_calls state_head_calls
+  tmp_root="$(mktemp -d)"
+  trap 'rm -rf "$tmp_root"' RETURN
+
+  home_dir="$tmp_root/home"
+  mock_bin="$tmp_root/mockbin"
+  merge_calls="$tmp_root/merge-calls"
+  state_head_calls="$tmp_root/state-head-calls"
+  mkdir -p "$home_dir/.local/bin" "$mock_bin"
+  cp "$SGT_SCRIPT" "$home_dir/.local/bin/sgt"
+  chmod +x "$home_dir/.local/bin/sgt"
+  : > "$merge_calls"
+  : > "$state_head_calls"
+
+  cat > "$mock_bin/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${SGT_MOCK_MODE:?missing SGT_MOCK_MODE}"
+MERGE_CALLS_FILE="${SGT_MOCK_MERGE_CALLS:?missing SGT_MOCK_MERGE_CALLS}"
+STATE_HEAD_CALLS_FILE="${SGT_MOCK_STATE_HEAD_CALLS:?missing SGT_MOCK_STATE_HEAD_CALLS}"
+
+inc_file() {
+  local path="$1"
+  local n=0
+  if [[ -s "$path" ]]; then
+    n="$(cat "$path" 2>/dev/null || echo 0)"
+  fi
+  [[ "$n" =~ ^[0-9]+$ ]] || n=0
+  n=$((n + 1))
+  printf '%s\n' "$n" > "$path"
+  echo "$n"
+}
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+  echo "sgt-authorized"
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+  shift 2
+  json_fields=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json)
+        json_fields="${2:-}"
+        shift 2
+        ;;
+      --jq)
+        shift 2
+        ;;
+      --repo)
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  case "$json_fields" in
+    title)
+      echo "Auto retry guardrail regression PR"
+      ;;
+    state)
+      echo "OPEN"
+      ;;
+    mergeable)
+      echo "MERGEABLE"
+      ;;
+    state,headRefOid)
+      inc_file "$STATE_HEAD_CALLS_FILE" >/dev/null
+      echo "OPEN|live111"
+      ;;
+    *)
+      echo ""
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "checks" ]]; then
+  echo "all checks pass"
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "diff" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "merge" ]]; then
+  call_n="$(inc_file "$MERGE_CALLS_FILE")"
+  case "$MODE" in
+    auto_required_success)
+      if [[ "$call_n" -eq 1 ]]; then
+        echo "Branch policy requires auto-merge for this pull request" >&2
+        exit 1
+      fi
+      if [[ "$call_n" -eq 2 && " $* " == *" --auto "* ]]; then
+        echo "auto-merge enabled"
+        exit 0
+      fi
+      ;;
+    non_retry_unrelated)
+      if [[ "$call_n" -eq 1 ]]; then
+        echo "merge failed: required review is missing" >&2
+        exit 1
+      fi
+      ;;
+    duplicate_event_suppression)
+      if [[ "$call_n" -eq 1 ]]; then
+        echo "Branch policy requires auto-merge for this pull request" >&2
+        exit 1
+      fi
+      if [[ "$call_n" -eq 2 && " $* " == *" --auto "* ]]; then
+        echo "auto-merge enabled"
+        exit 0
+      fi
+      ;;
+  esac
+  echo "unexpected merge call #$call_n mode=$MODE args=$*" >&2
+  exit 2
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "comment" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "comment" ]]; then
+  exit 0
+fi
+
+echo "mock gh unsupported: $*" >&2
+exit 1
+GH
+  chmod +x "$mock_bin/gh"
+
+  env -i \
+    HOME="$home_dir" \
+    PATH="$mock_bin:$home_dir/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+    TERM="${TERM:-xterm}" \
+    SGT_ROOT="$home_dir/sgt" \
+    SGT_MOCK_MODE="$mode" \
+    SGT_MOCK_MERGE_CALLS="$merge_calls" \
+    SGT_MOCK_STATE_HEAD_CALLS="$state_head_calls" \
+    SGT_REFINERY_MERGE_MAX_ATTEMPTS=3 \
+    SGT_REFINERY_MERGE_RETRY_BASE_MS=0 \
+    SGT_REFINERY_MERGE_RETRY_JITTER_MS=0 \
+    bash --noprofile --norc -c '
+set -euo pipefail
+
+sgt init >/dev/null
+mkdir -p "$SGT_ROOT/rigs/test"
+printf "https://github.com/acme/demo\n" > "$SGT_ROOT/.sgt/rigs/test"
+
+queue_once() {
+  cat > "$SGT_ROOT/.sgt/merge-queue/test-pr123" <<MQ
+POLECAT=test-pr123
+RIG=test
+REPO=https://github.com/acme/demo
+BRANCH=sgt/test-pr123
+ISSUE=77
+PR=123
+HEAD_SHA=live111
+AUTO_MERGE=true
+TYPE=polecat
+QUEUED=$(date -Iseconds)
+MQ
+}
+
+run_refinery() {
+  timeout 6 sgt _refinery test > "$1" 2>&1 &
+  pid=$!
+  for _ in $(seq 1 120); do
+    fifo="$SGT_ROOT/.sgt/refinery-test.fifo"
+    if [[ -p "$fifo" ]]; then
+      printf "test-wake\n" > "$fifo"
+      break
+    fi
+    sleep 0.05
+  done
+  wait "$pid" || true
+}
+
+queue_once
+run_refinery "$SGT_ROOT/refinery-pass1.out"
+
+if [[ "$SGT_MOCK_MODE" == "duplicate_event_suppression" ]]; then
+  queue_once
+  run_refinery "$SGT_ROOT/refinery-pass2.out"
+fi
+'
+
+  case "$mode" in
+    auto_required_success)
+      if [[ "$(cat "$merge_calls")" != "2" ]]; then
+        echo "expected 2 merge calls for auto_required_success" >&2
+        return 1
+      fi
+      if ! grep -q 'merge failed due to branch policy requiring auto-merge — retrying once with --auto' "$home_dir/sgt/refinery-pass1.out"; then
+        echo "expected visible auto-merge retry message" >&2
+        return 1
+      fi
+      if ! grep -q 'REFINERY_MERGE_RETRY_AUTO repo=acme/demo pr=#123 reason=branch-policy-requires-auto-merge outcome=success' "$home_dir/sgt/sgt.log"; then
+        echo "expected structured auto retry success event" >&2
+        return 1
+      fi
+      if [[ -f "$home_dir/sgt/.sgt/merge-queue/test-pr123" ]]; then
+        echo "expected queue item to be removed after auto retry success" >&2
+        return 1
+      fi
+      ;;
+    non_retry_unrelated)
+      if [[ "$(cat "$merge_calls")" != "1" ]]; then
+        echo "expected exactly 1 merge call for unrelated non-retry failure" >&2
+        return 1
+      fi
+      if grep -q 'REFINERY_MERGE_RETRY_AUTO repo=acme/demo pr=#123' "$home_dir/sgt/sgt.log"; then
+        echo "did not expect auto-retry event for unrelated merge failure" >&2
+        return 1
+      fi
+      if ! grep -q 'REFINERY_MERGE_FAILED pr=#123 attempt=1/3 class=non-transient transient=false' "$home_dir/sgt/sgt.log"; then
+        echo "expected standard merge failure event for unrelated failure" >&2
+        return 1
+      fi
+      ;;
+    duplicate_event_suppression)
+      if [[ "$(cat "$merge_calls")" != "2" ]]; then
+        echo "expected exactly 2 merge calls across duplicate replay" >&2
+        return 1
+      fi
+      if ! grep -q 'duplicate merge skipped — reason_code=duplicate-merge-attempt-key' "$home_dir/sgt/refinery-pass2.out"; then
+        echo "expected duplicate merge attempt skip on replay" >&2
+        return 1
+      fi
+      auto_event_count="$(grep -c 'REFINERY_MERGE_RETRY_AUTO repo=acme/demo pr=#123 reason=branch-policy-requires-auto-merge' "$home_dir/sgt/sgt.log" || true)"
+      if [[ "$auto_event_count" != "1" ]]; then
+        echo "expected exactly one auto-retry event across duplicate replay, got $auto_event_count" >&2
+        return 1
+      fi
+      ;;
+    *)
+      echo "unsupported mode: $mode" >&2
+      return 1
+      ;;
+  esac
+}
+
+run_case auto_required_success
+run_case non_retry_unrelated
+run_case duplicate_event_suppression
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Closes #92

## Summary
- detect merge failures that indicate branch policy requires auto-merge
- revalidate PR open/head and retry exactly once with `--auto`
- emit structured `REFINERY_MERGE_RETRY_AUTO` events with repo/pr/reason/outcome
- add regression coverage for success, non-retry on unrelated failures, and duplicate-event suppression
- document the new guardrail and observability event in README
