### PR TITLE
Mayor action receipts: post-side-effect live verification fence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Mayor orphan-PR queueing now live-revalidates PR state (`OPEN` required) immediately before queueing; stale open-list snapshots that already became `MERGED`/`CLOSED` are skipped with explicit reason logging (`MAYOR_ORPHAN_SKIP_STALE`).
 - Added regression coverage for stale orphan PR snapshot false-positives in `test_mayor_orphan_stale_snapshot_guard.sh`.
+- Mayor side-effect decisions (`dispatch`, `nuke`, `merge`) now require an immediate post-action live verification receipt before success is declared, with durable structured receipt fields (`action`, `target`, `expected_state`, `observed_state`, `verified_at`) under `~/.sgt/mayor-action-receipts/`.
+- Receipt mismatches now append explicit non-success decision-log entries with retry/no-op hints, and replayed action keys suppress conflicting success receipts (`reason=replayed-action-key-existing-success`).
+- Added `sgt mayor merge <pr#> --repo <repo>` so mayor merge actions run through the same receipt fence and live verification path.
+- Added regression coverage for dispatch post-action drift and replayed merge action-key behavior in `test_mayor_action_receipt_fence.sh` (wired into `test_mayor_wake_replay_regression.sh`).
 - Mayor dispatch hardening: added a pre-dispatch live revalidation guard to `sgt sling` (mayor context) that atomically checks for open PRs and open `sgt-authorized` issues before issue creation.
 - Mayor decision flow now skips dispatch when revalidation is dirty/stale and logs a clear reason in both terminal output and `~/.sgt/mayor-decisions.log`.
 - Added regression coverage for stale snapshot races and no-duplicate dispatch behavior in `test_mayor_stale_dispatch_race.sh`.

--- a/sgt
+++ b/sgt
@@ -142,6 +142,14 @@ _MAYOR_PRE_DISPATCH_REASON=""
 _MAYOR_PRE_DISPATCH_MISMATCH_CATEGORIES=""
 _MAYOR_PRE_DISPATCH_SNAPSHOT_SUMMARY=""
 _MAYOR_PRE_DISPATCH_LIVE_SUMMARY=""
+_MAYOR_ACTION_RECEIPT_FILE=""
+_MAYOR_ACTION_RECEIPT_ACTION=""
+_MAYOR_ACTION_RECEIPT_TARGET=""
+_MAYOR_ACTION_RECEIPT_ACTION_KEY=""
+_MAYOR_ACTION_RECEIPT_EXPECTED_STATE=""
+_MAYOR_ACTION_RECEIPT_OBSERVED_STATE=""
+_MAYOR_ACTION_RECEIPT_VERIFIED_AT=""
+_MAYOR_ACTION_RECEIPT_STATUS=""
 _REFINERY_MERGE_ATTEMPT_KEY=""
 _REFINERY_MERGE_ATTEMPT_FILE=""
 _REFINERY_REVIEW_UNCLEAR_REASON=""
@@ -453,6 +461,131 @@ _dedupe_wake_reasons() {
 _wake_requires_dispatch_decision() {
   local reason="${1:-}"
   [[ "$reason" == merged:* || "$reason" == dog-approved:* ]]
+}
+
+_mayor_action_fence_enabled() {
+  [[ "${SGT_MAYOR_ACTION_FENCE:-0}" == "1" ]]
+}
+
+_mayor_action_receipts_dir() {
+  echo "$SGT_CONFIG/mayor-action-receipts"
+}
+
+_mayor_action_receipt_summary() {
+  printf 'action=%s target=%s expected_state=%s observed_state=%s verified_at=%s action_key=%s' \
+    "${_MAYOR_ACTION_RECEIPT_ACTION:-unknown}" \
+    "${_MAYOR_ACTION_RECEIPT_TARGET:-unknown}" \
+    "$(_escape_quotes "${_MAYOR_ACTION_RECEIPT_EXPECTED_STATE:-unknown}")" \
+    "$(_escape_quotes "${_MAYOR_ACTION_RECEIPT_OBSERVED_STATE:-unknown}")" \
+    "${_MAYOR_ACTION_RECEIPT_VERIFIED_AT:-unknown}" \
+    "$(_escape_quotes "${_MAYOR_ACTION_RECEIPT_ACTION_KEY:-unknown}")"
+}
+
+_mayor_action_receipt_load() {
+  local file="${1:-}"
+  [[ -n "$file" && -f "$file" ]] || return 1
+  _MAYOR_ACTION_RECEIPT_FILE="$file"
+  eval "$(grep -E '^(ACTION|TARGET|ACTION_KEY|EXPECTED_STATE|OBSERVED_STATE|VERIFIED_AT|RECEIPT_STATUS)=' "$file" 2>/dev/null || true)"
+  _MAYOR_ACTION_RECEIPT_ACTION="${ACTION:-}"
+  _MAYOR_ACTION_RECEIPT_TARGET="${TARGET:-}"
+  _MAYOR_ACTION_RECEIPT_ACTION_KEY="${ACTION_KEY:-}"
+  _MAYOR_ACTION_RECEIPT_EXPECTED_STATE="${EXPECTED_STATE:-}"
+  _MAYOR_ACTION_RECEIPT_OBSERVED_STATE="${OBSERVED_STATE:-}"
+  _MAYOR_ACTION_RECEIPT_VERIFIED_AT="${VERIFIED_AT:-}"
+  _MAYOR_ACTION_RECEIPT_STATUS="${RECEIPT_STATUS:-}"
+  return 0
+}
+
+_mayor_action_receipt_has_success() {
+  local action_key="${1:-}" key_id dir file
+  _MAYOR_ACTION_RECEIPT_FILE=""
+  _MAYOR_ACTION_RECEIPT_STATUS=""
+  [[ -n "$action_key" ]] || return 1
+  key_id="$(_mayor_dispatch_trigger_key_id "$action_key")"
+  dir="$(_mayor_action_receipts_dir)"
+  file="$dir/$key_id.state"
+  if ! _mayor_action_receipt_load "$file"; then
+    return 1
+  fi
+  [[ "${_MAYOR_ACTION_RECEIPT_STATUS:-}" == "success" ]]
+}
+
+_mayor_action_receipt_record() {
+  local action="${1:-}" action_key="${2:-}" target="${3:-}" expected_state="${4:-}" observed_state="${5:-}" status_override="${6:-}"
+  local key_id dir file now_iso status existing_status receipt_tmp
+  _MAYOR_ACTION_RECEIPT_FILE=""
+  _MAYOR_ACTION_RECEIPT_ACTION=""
+  _MAYOR_ACTION_RECEIPT_TARGET=""
+  _MAYOR_ACTION_RECEIPT_ACTION_KEY=""
+  _MAYOR_ACTION_RECEIPT_EXPECTED_STATE=""
+  _MAYOR_ACTION_RECEIPT_OBSERVED_STATE=""
+  _MAYOR_ACTION_RECEIPT_VERIFIED_AT=""
+  _MAYOR_ACTION_RECEIPT_STATUS=""
+  [[ -n "$action" && -n "$action_key" && -n "$target" ]] || return 1
+  if [[ -n "$status_override" ]]; then
+    status="$status_override"
+  elif [[ "$expected_state" == "$observed_state" ]]; then
+    status="success"
+  else
+    status="mismatch"
+  fi
+  key_id="$(_mayor_dispatch_trigger_key_id "$action_key")"
+  dir="$(_mayor_action_receipts_dir)"
+  file="$dir/$key_id.state"
+  mkdir -p "$dir" || return 1
+
+  existing_status=""
+  if [[ -f "$file" ]]; then
+    existing_status="$(grep -E '^RECEIPT_STATUS=' "$file" 2>/dev/null | cut -d= -f2- || true)"
+  fi
+  if [[ "$status" == "success" && "$existing_status" == "success" ]]; then
+    _mayor_action_receipt_load "$file" || return 1
+    return 2
+  fi
+
+  now_iso="$(date -Iseconds)"
+  receipt_tmp="${file}.tmp.$$"
+  cat > "$receipt_tmp" <<EOF
+ACTION=$(_escape_wake_value "$action")
+TARGET=$(_escape_wake_value "$target")
+ACTION_KEY=$(_escape_wake_value "$action_key")
+EXPECTED_STATE=$(_escape_wake_value "$expected_state")
+OBSERVED_STATE=$(_escape_wake_value "$observed_state")
+VERIFIED_AT=$(_escape_wake_value "$now_iso")
+RECEIPT_STATUS=$(_escape_wake_value "$status")
+EOF
+  mv "$receipt_tmp" "$file"
+  _mayor_action_receipt_load "$file" || return 1
+  return 0
+}
+
+_mayor_action_verify_and_log() {
+  local action="${1:-}" action_key="${2:-}" target="${3:-}" expected_state="${4:-}" observed_state="${5:-}" status="${6:-}" mismatch_reason="${7:-}" mismatch_retry="${8:-}"
+  local receipt_summary context record_rc
+  context="mayor-action-receipt-${action:-unknown}"
+  _mayor_action_receipt_record "$action" "$action_key" "$target" "$expected_state" "$observed_state" "$status"
+  record_rc=$?
+  if [[ "$record_rc" -ne 0 ]]; then
+    if [[ "$record_rc" -eq 2 ]]; then
+      receipt_summary="$(_mayor_action_receipt_summary)"
+      _mayor_record_decision "MAYOR ACTION RECEIPT non-success reason=replayed-action-key-existing-success retry=no-op $receipt_summary" "$context" "$SGT_ROOT" || true
+      log_event "MAYOR_ACTION_RECEIPT replay action=$action reason=replayed-action-key-existing-success retry=no-op $receipt_summary"
+      return 0
+    fi
+    _mayor_record_decision "MAYOR ACTION RECEIPT non-success reason=receipt-write-failed retry=retry-next-mayor-cycle action=$action target=$target action_key=$action_key" "$context" "$SGT_ROOT" || true
+    log_event "MAYOR_ACTION_RECEIPT non-success reason=receipt-write-failed action=$action target=$target action_key=\"$(_escape_quotes "$action_key")\""
+    return 1
+  fi
+
+  receipt_summary="$(_mayor_action_receipt_summary)"
+  if [[ "${_MAYOR_ACTION_RECEIPT_STATUS:-mismatch}" == "success" ]]; then
+    _mayor_record_decision "MAYOR ACTION RECEIPT success $receipt_summary" "$context" "$SGT_ROOT" || true
+    log_event "MAYOR_ACTION_RECEIPT success $receipt_summary"
+    return 0
+  fi
+  _mayor_record_decision "MAYOR ACTION RECEIPT non-success reason=${mismatch_reason:-post-action-live-mismatch} retry=${mismatch_retry:-retry-next-mayor-cycle} $receipt_summary" "$context" "$SGT_ROOT" || true
+  log_event "MAYOR_ACTION_RECEIPT non-success reason=${mismatch_reason:-post-action-live-mismatch} retry=${mismatch_retry:-retry-next-mayor-cycle} $receipt_summary"
+  return 1
 }
 
 _mayor_dispatch_trigger_key() {
@@ -3152,6 +3285,43 @@ PSTATE
   log_event "SLING $pname rig=$rig issue=#$issue_number branch=$branch"
   _wake_refinery "$rig" "sling:$pname:#$issue_number"
 
+  if _mayor_action_fence_enabled; then
+    local dispatch_owner_repo dispatch_target dispatch_action_key dispatch_issue_state dispatch_active_polecat dispatch_session_alive dispatch_worker_state
+    local dispatch_expected_state dispatch_observed_state dispatch_status dispatch_reason dispatch_retry
+    dispatch_owner_repo="$(_repo_owner_repo "$repo")"
+    dispatch_target="${dispatch_owner_repo}#${issue_number}"
+    dispatch_action_key="dispatch|${dispatch_owner_repo}|issue=${issue_number}|trigger=${mayor_dispatch_trigger_key:-manual}"
+    dispatch_issue_state="$(gh issue view "$issue_number" --repo "$repo" --json state --jq '.state // ""' 2>/dev/null || true)"
+    dispatch_active_polecat="$(_resling_find_existing_issue_polecat "$rig" "$repo" "$issue_number" 2>/dev/null || true)"
+    dispatch_session_alive="false"
+    if tmux has-session -t "$session_name" 2>/dev/null; then
+      dispatch_session_alive="true"
+    fi
+    dispatch_worker_state="absent"
+    if [[ -n "$dispatch_active_polecat" || "$dispatch_session_alive" == "true" ]]; then
+      dispatch_worker_state="present"
+    fi
+    dispatch_expected_state="issue_state=OPEN;worker=present"
+    dispatch_observed_state="issue_state=${dispatch_issue_state:-unknown};worker=${dispatch_worker_state};active_polecat=${dispatch_active_polecat:-none};session_alive=${dispatch_session_alive}"
+    dispatch_status="mismatch"
+    dispatch_reason="post-action-live-state-drift"
+    dispatch_retry="retry-next-mayor-cycle"
+    if [[ "$dispatch_issue_state" == "OPEN" && "$dispatch_worker_state" == "present" ]]; then
+      dispatch_status="success"
+      dispatch_reason=""
+      dispatch_retry=""
+    elif [[ "$dispatch_issue_state" != "OPEN" ]]; then
+      dispatch_reason="post-action-drift-issue-state"
+    else
+      dispatch_reason="post-action-no-active-worker"
+      dispatch_retry="retry-dispatch-verify-replay"
+    fi
+    if ! _mayor_action_verify_and_log "dispatch" "$dispatch_action_key" "$dispatch_target" "$dispatch_expected_state" "$dispatch_observed_state" "$dispatch_status" "$dispatch_reason" "$dispatch_retry"; then
+      echo "[mayor] dispatch receipt mismatch action_key=$dispatch_action_key reason=$dispatch_reason retry=$dispatch_retry"
+      return 1
+    fi
+  fi
+
   info ""
   info "polecat $pname dispatched"
   info "  issue:   $issue_url"
@@ -3439,8 +3609,44 @@ cmd_nuke() {
   ensure_init
 
   local pfile="$SGT_POLECATS/$pname"
-  [[ -f "$pfile" ]] || die "polecat '$pname' not found"
+  local nuke_action_key nuke_target
+  nuke_action_key="nuke|polecat=$pname"
+  nuke_target="$pname"
+  if _mayor_action_fence_enabled && _mayor_action_receipt_has_success "$nuke_action_key"; then
+    _mayor_record_decision "MAYOR ACTION RECEIPT non-success reason=replayed-action-key-existing-success retry=no-op $(_mayor_action_receipt_summary)" "mayor-action-receipt-nuke" "$SGT_ROOT" || true
+    log_event "MAYOR_ACTION_RECEIPT replay action=nuke reason=replayed-action-key-existing-success retry=no-op $(_mayor_action_receipt_summary)"
+    info "polecat $pname already verified as nuked (no-op replay)"
+    return 0
+  fi
+  if [[ ! -f "$pfile" ]]; then
+    if _mayor_action_fence_enabled; then
+      local missing_session missing_expected missing_observed missing_status missing_reason missing_retry
+      missing_session="absent"
+      if tmux has-session -t "sgt-$pname" 2>/dev/null; then
+        missing_session="present"
+      fi
+      missing_expected="state_file=missing;session=absent"
+      missing_observed="state_file=missing;session=${missing_session};worktree=unknown"
+      missing_status="success"
+      missing_reason=""
+      missing_retry=""
+      if [[ "$missing_session" != "absent" ]]; then
+        missing_status="mismatch"
+        missing_reason="post-action-session-still-active"
+        missing_retry="retry-nuke-manual"
+      fi
+      if ! _mayor_action_verify_and_log "nuke" "$nuke_action_key" "$nuke_target" "$missing_expected" "$missing_observed" "$missing_status" "$missing_reason" "$missing_retry"; then
+        die "nuke receipt mismatch for absent polecat '$pname': reason=${missing_reason:-post-action-live-state-drift}"
+      fi
+      info "polecat $pname already absent"
+      return 0
+    fi
+    die "polecat '$pname' not found"
+  fi
 
+  local nuke_session="" nuke_worktree=""
+  nuke_session="$(grep -E '^SESSION=' "$pfile" 2>/dev/null | cut -d= -f2- || true)"
+  nuke_worktree="$(grep -E '^WORKTREE=' "$pfile" 2>/dev/null | cut -d= -f2- || true)"
   (
     source "$pfile"
     if tmux has-session -t "$SESSION" 2>/dev/null; then
@@ -3458,6 +3664,36 @@ cmd_nuke() {
 
   rm -f "$pfile"
   log_event "NUKE $pname"
+
+  if _mayor_action_fence_enabled; then
+    local nuke_session_state nuke_worktree_state nuke_state_file_state nuke_expected_state nuke_observed_state nuke_status nuke_reason nuke_retry
+    nuke_session_state="absent"
+    if [[ -n "$nuke_session" ]] && tmux has-session -t "$nuke_session" 2>/dev/null; then
+      nuke_session_state="present"
+    fi
+    nuke_worktree_state="missing"
+    if [[ -n "$nuke_worktree" && -d "$nuke_worktree" ]]; then
+      nuke_worktree_state="present"
+    fi
+    nuke_state_file_state="missing"
+    if [[ -f "$pfile" ]]; then
+      nuke_state_file_state="present"
+    fi
+    nuke_expected_state="state_file=missing;session=absent;worktree=missing"
+    nuke_observed_state="state_file=${nuke_state_file_state};session=${nuke_session_state};worktree=${nuke_worktree_state}"
+    nuke_status="success"
+    nuke_reason=""
+    nuke_retry=""
+    if [[ "$nuke_state_file_state" != "missing" || "$nuke_session_state" != "absent" || "$nuke_worktree_state" != "missing" ]]; then
+      nuke_status="mismatch"
+      nuke_reason="post-action-residue-detected"
+      nuke_retry="retry-nuke-manual"
+    fi
+    if ! _mayor_action_verify_and_log "nuke" "$nuke_action_key" "$nuke_target" "$nuke_expected_state" "$nuke_observed_state" "$nuke_status" "$nuke_reason" "$nuke_retry"; then
+      die "nuke receipt mismatch for polecat '$pname': reason=${nuke_reason:-post-action-live-state-drift}"
+    fi
+  fi
+
   info "polecat $pname nuked"
 }
 
@@ -5783,7 +6019,7 @@ $(cat "$briefing")
 - \`sgt sling <rig> "<task>"\` — Dispatch work
 - \`sgt nuke <polecat>\` — Kill stuck worker
 - \`sgt sweep\` — Clean finished workers
-- \`gh pr merge <pr#> --repo <repo> --squash --delete-branch\` — Merge PR
+- \`sgt mayor merge <pr#> --repo <repo>\` — Merge PR with post-action live receipt fence
 
 Decide what to do. Log decisions to $SGT_CONFIG/mayor-decisions.log. Be fast.
 
@@ -5796,7 +6032,7 @@ MAYORMD
 
       local backend="$(_ai_backend_default)"
 
-      if timeout 300 bash -c "SGT_MAYOR_DISPATCH_REVALIDATE=1 SGT_MAYOR_DISPATCH_SNAPSHOT_FILE='$dispatch_snapshot_file' SGT_MAYOR_DISPATCH_TRIGGER_KEY='$ai_dispatch_trigger_key' SGT_MAYOR_DISPATCH_TRIGGER_REASON='$ai_dispatch_trigger_reason' _ai_prompt '$backend' '$mayor_workspace' 'Read CLAUDE.md. Handle the issues described. Be decisive and fast. Log your actions.'" 
+      if timeout 300 bash -c "SGT_MAYOR_DISPATCH_REVALIDATE=1 SGT_MAYOR_ACTION_FENCE=1 SGT_MAYOR_DISPATCH_SNAPSHOT_FILE='$dispatch_snapshot_file' SGT_MAYOR_DISPATCH_TRIGGER_KEY='$ai_dispatch_trigger_key' SGT_MAYOR_DISPATCH_TRIGGER_REASON='$ai_dispatch_trigger_reason' _ai_prompt '$backend' '$mayor_workspace' 'Read CLAUDE.md. Handle the issues described. Be decisive and fast. Log your actions.'" 
         </dev/null 2>&1 | tail -5; then
         log_event "MAYOR_AI_CYCLE completed"
         echo "[mayor] AI decision cycle complete"
@@ -5826,6 +6062,85 @@ _mayor_notify_rigger() {
 cmd_mayor_notify() {
   local message="${1:?usage: sgt mayor notify \"<message>\"}"
   _mayor_notify_rigger "$message"
+}
+
+cmd_mayor_merge() {
+  local pr="${1:-}" repo="" use_auto="false"
+  shift || true
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo)
+        repo="${2:-}"
+        shift 2
+        ;;
+      --auto)
+        use_auto="true"
+        shift
+        ;;
+      *)
+        die "usage: sgt mayor merge <pr#> --repo <repo> [--auto]"
+        ;;
+    esac
+  done
+  [[ -n "$pr" ]] || die "usage: sgt mayor merge <pr#> --repo <repo> [--auto]"
+  [[ -n "$repo" ]] || die "usage: sgt mayor merge <pr#> --repo <repo> [--auto]"
+  pr="${pr#\#}"
+  [[ "$pr" =~ ^[0-9]+$ ]] || die "invalid PR number '$pr'"
+  ensure_init
+
+  local owner_repo action_key target merge_expected_state
+  owner_repo="$(_repo_owner_repo "$repo")"
+  target="${owner_repo}#${pr}"
+  action_key="merge|${owner_repo}|pr=${pr}"
+  merge_expected_state="pr_state=MERGED"
+
+  if _mayor_action_fence_enabled && _mayor_action_receipt_has_success "$action_key"; then
+    _mayor_record_decision "MAYOR ACTION RECEIPT non-success reason=replayed-action-key-existing-success retry=no-op $(_mayor_action_receipt_summary)" "mayor-action-receipt-merge" "$SGT_ROOT" || true
+    log_event "MAYOR_ACTION_RECEIPT replay action=merge reason=replayed-action-key-existing-success retry=no-op $(_mayor_action_receipt_summary)"
+    info "merge no-op for $target (existing success receipt)"
+    return 0
+  fi
+
+  local -a merge_cmd
+  local merge_out merge_rc pr_state merged_at merge_observed_state merge_status merge_reason merge_retry
+  merge_cmd=(gh pr merge "$pr" --repo "$repo" --squash --delete-branch)
+  if [[ "$use_auto" == "true" ]]; then
+    merge_cmd+=(--auto)
+  fi
+  set +e
+  merge_out="$("${merge_cmd[@]}" 2>&1)"
+  merge_rc=$?
+  set -e
+  pr_state="$(gh pr view "$pr" --repo "$repo" --json state --jq '.state // ""' 2>/dev/null || true)"
+  merged_at="$(gh pr view "$pr" --repo "$repo" --json mergedAt --jq '.mergedAt // ""' 2>/dev/null || true)"
+  merge_observed_state="pr_state=${pr_state:-unknown};merged_at=${merged_at:-none};merge_rc=${merge_rc}"
+  merge_status="success"
+  merge_reason=""
+  merge_retry=""
+  if [[ "$pr_state" != "MERGED" ]]; then
+    merge_status="mismatch"
+    if [[ "$merge_rc" -ne 0 ]]; then
+      merge_reason="merge-command-failed-live-not-merged"
+    else
+      merge_reason="post-action-live-state-drift"
+    fi
+    merge_retry="retry-merge-manual"
+  fi
+
+  if ! _mayor_action_verify_and_log "merge" "$action_key" "$target" "$merge_expected_state" "$merge_observed_state" "$merge_status" "$merge_reason" "$merge_retry"; then
+    warn "merge receipt mismatch for $target (reason=${merge_reason:-post-action-live-state-drift} retry=${merge_retry:-retry-merge-manual})"
+    if [[ -n "$merge_out" ]]; then
+      warn "gh pr merge output: $(_one_line "$merge_out")"
+    fi
+    return 1
+  fi
+
+  if [[ "$merge_rc" -eq 0 ]]; then
+    info "merged PR #$pr on $owner_repo"
+  else
+    info "PR #$pr on $owner_repo already merged (live verification confirmed)"
+  fi
+  return 0
 }
 
 cmd_mayor_start() {
@@ -6684,7 +6999,7 @@ Agent Commands:
   deacon start|stop             Control the health monitor
   witness start|stop <rig>      Control per-rig polecat monitor
   refinery start|stop <rig>     Control per-rig merge queue
-  mayor start|stop|notify       Control the AI coordinator
+  mayor start|stop|notify|merge Control the AI coordinator
   wake-mayor [reason]           Wake the mayor on demand (event-driven)
   nudge <target> <message>      Send message to agent's tmux session
 
@@ -6740,6 +7055,7 @@ Environment:
   SGT_MAYOR_DISPATCH_COOLDOWN  Suppress duplicate dispatches for N seconds (default: 21600, set 0 to disable)
   SGT_MAYOR_DISPATCH_MAX_PARALLEL  Max proactive mayor in-flight budget (open sgt-authorized issues/polecats, default: 3, set 0 to disable)
   SGT_MAYOR_DISPATCH_VERIFY_TIMEOUT_SECS  Verify post-dispatch active work within N seconds before one retry (default: 120, set 0 for immediate timeout)
+  SGT_MAYOR_ACTION_FENCE       Enable mayor post-action receipt verification fence for dispatch/nuke/merge (default: 0)
   SGT_MAYOR_LOCK_LEASE_SECS    Mayor lock lease length in seconds (default: SGT_MAYOR_INTERVAL + 120, set >0)
   SGT_MAYOR_WAKE_DEDUPE_TTL    Suppress identical wake trigger keys for N seconds (default: 15, set 0 to disable)
   SGT_MAYOR_DECISION_LOG_ALERT_COOLDOWN  Suppress repeated mayor decision-log failure notifications for N seconds (default: 600, set 0 to disable)
@@ -6849,7 +7165,8 @@ main() {
         start)   cmd_mayor_start ;;
         stop)    cmd_mayor_stop ;;
         notify)  cmd_mayor_notify "$@" ;;
-        *)       die "unknown mayor command: $sub (try: start, stop, notify)" ;;
+        merge)   cmd_mayor_merge "$@" ;;
+        *)       die "unknown mayor command: $sub (try: start, stop, notify, merge)" ;;
       esac
       ;;
     wake-mayor) cmd_wake_mayor "$@" ;;

--- a/test_mayor_action_receipt_fence.sh
+++ b/test_mayor_action_receipt_fence.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# test_mayor_action_receipt_fence.sh — Regression checks for mayor post-action receipt fence (drift + replay).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+run_dispatch_drift_case() {
+  local case_root="$TMP_ROOT/dispatch-drift"
+  local home_dir="$case_root/home"
+  local mock_bin="$case_root/mockbin"
+  mkdir -p "$home_dir/.local/bin" "$mock_bin"
+  cp "$SGT_SCRIPT" "$home_dir/.local/bin/sgt"
+  chmod +x "$home_dir/.local/bin/sgt"
+
+  cat > "$mock_bin/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "label" && "${2:-}" == "create" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
+  echo "https://github.com/acme/demo/issues/101"
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+  if [[ "$*" == *"--json state"* ]]; then
+    echo "CLOSED"
+    exit 0
+  fi
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "edit" ]]; then
+  exit 0
+fi
+
+echo "mock gh unsupported: $*" >&2
+exit 1
+GH
+  chmod +x "$mock_bin/gh"
+
+  cat > "$mock_bin/git" <<'GIT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "-C" ]]; then
+  shift 2
+fi
+
+case "${1:-}" in
+  fetch)
+    exit 0
+    ;;
+  symbolic-ref)
+    echo "refs/remotes/origin/master"
+    exit 0
+    ;;
+  worktree)
+    if [[ "${2:-}" == "add" ]]; then
+      mkdir -p "${5:-}"
+      exit 0
+    fi
+    ;;
+esac
+
+echo "mock git unsupported: $*" >&2
+exit 1
+GIT
+  chmod +x "$mock_bin/git"
+
+  cat > "$mock_bin/tmux" <<'TMUX'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "has-session" ]]; then
+  exit 1
+fi
+if [[ "${1:-}" == "new-session" || "${1:-}" == "kill-session" ]]; then
+  exit 0
+fi
+
+echo "mock tmux unsupported: $*" >&2
+exit 1
+TMUX
+  chmod +x "$mock_bin/tmux"
+
+  env -i \
+    HOME="$home_dir" \
+    PATH="$mock_bin:$home_dir/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+    TERM="${TERM:-xterm}" \
+    SGT_ROOT="$home_dir/sgt" \
+    SGT_MAYOR_ACTION_FENCE=1 \
+    SGT_MAYOR_DISPATCH_COOLDOWN=0 \
+    bash --noprofile --norc -c '
+set -euo pipefail
+sgt init >/dev/null
+mkdir -p "$SGT_ROOT/rigs/test"
+printf "https://github.com/acme/demo\n" > "$SGT_ROOT/.sgt/rigs/test"
+if sgt sling test "Receipt drift regression" --label high >/tmp/sgt-dispatch-drift.out 2>/tmp/sgt-dispatch-drift.err; then
+  echo "expected dispatch drift case to fail receipt verification" >&2
+  exit 1
+fi
+'
+
+  local decision_log="$home_dir/sgt/.sgt/mayor-decisions.log"
+  local receipt_dir="$home_dir/sgt/.sgt/mayor-action-receipts"
+  [[ -f "$decision_log" ]] || { echo "expected decision log for dispatch drift case" >&2; exit 1; }
+  [[ -d "$receipt_dir" ]] || { echo "expected receipt dir for dispatch drift case" >&2; exit 1; }
+
+  grep -q 'MAYOR ACTION RECEIPT non-success reason=post-action-drift-issue-state retry=retry-next-mayor-cycle' "$decision_log" || {
+    echo "expected explicit non-success drift reason and retry hint for dispatch" >&2
+    exit 1
+  }
+  grep -q 'action=dispatch target=acme/demo#101 expected_state=' "$decision_log" || {
+    echo "expected structured dispatch receipt fields in decision log" >&2
+    exit 1
+  }
+  grep -q 'observed_state=' "$decision_log" || {
+    echo "expected observed_state field in dispatch receipt entry" >&2
+    exit 1
+  }
+  grep -q 'verified_at=' "$decision_log" || {
+    echo "expected verified_at field in dispatch receipt entry" >&2
+    exit 1
+  }
+
+  local receipt_file
+  receipt_file="$(find "$receipt_dir" -type f | head -n1)"
+  [[ -n "$receipt_file" ]] || { echo "expected at least one dispatch receipt file" >&2; exit 1; }
+  grep -q '^ACTION=dispatch$' "$receipt_file" || { echo "expected dispatch receipt ACTION field" >&2; exit 1; }
+  grep -q '^RECEIPT_STATUS=mismatch$' "$receipt_file" || { echo "expected dispatch receipt mismatch status" >&2; exit 1; }
+}
+
+run_merge_replay_case() {
+  local case_root="$TMP_ROOT/merge-replay"
+  local home_dir="$case_root/home"
+  local mock_bin="$case_root/mockbin"
+  local merge_calls="$case_root/merge-calls"
+  mkdir -p "$home_dir/.local/bin" "$mock_bin"
+  : > "$merge_calls"
+  cp "$SGT_SCRIPT" "$home_dir/.local/bin/sgt"
+  chmod +x "$home_dir/.local/bin/sgt"
+
+  cat > "$mock_bin/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+CALLS_FILE="${SGT_MAYOR_MERGE_CALLS_FILE:?missing SGT_MAYOR_MERGE_CALLS_FILE}"
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "merge" ]]; then
+  current="$(cat "$CALLS_FILE" 2>/dev/null || echo 0)"
+  if [[ -z "$current" ]]; then
+    current=0
+  fi
+  current=$((current + 1))
+  printf '%s\n' "$current" > "$CALLS_FILE"
+  echo "merged"
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+  if [[ "$*" == *"--json state"* ]]; then
+    echo "MERGED"
+    exit 0
+  fi
+  if [[ "$*" == *"--json mergedAt"* ]]; then
+    echo "2026-02-10T00:00:00Z"
+    exit 0
+  fi
+fi
+
+echo "mock gh unsupported: $*" >&2
+exit 1
+GH
+  chmod +x "$mock_bin/gh"
+
+  cat > "$mock_bin/tmux" <<'TMUX'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+TMUX
+  chmod +x "$mock_bin/tmux"
+
+  env -i \
+    HOME="$home_dir" \
+    PATH="$mock_bin:$home_dir/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+    TERM="${TERM:-xterm}" \
+    SGT_ROOT="$home_dir/sgt" \
+    SGT_MAYOR_ACTION_FENCE=1 \
+    SGT_MAYOR_MERGE_CALLS_FILE="$merge_calls" \
+    bash --noprofile --norc -c '
+set -euo pipefail
+sgt init >/dev/null
+sgt mayor merge 77 --repo https://github.com/acme/demo >/tmp/sgt-merge-replay-1.out
+sgt mayor merge 77 --repo https://github.com/acme/demo >/tmp/sgt-merge-replay-2.out
+'
+
+  if [[ "$(cat "$merge_calls" | tr -d '[:space:]')" != "1" ]]; then
+    echo "expected replayed merge action key to suppress duplicate gh pr merge side effect" >&2
+    exit 1
+  fi
+
+  local decision_log="$home_dir/sgt/.sgt/mayor-decisions.log"
+  local receipt_dir="$home_dir/sgt/.sgt/mayor-action-receipts"
+  [[ -f "$decision_log" ]] || { echo "expected decision log for merge replay case" >&2; exit 1; }
+  [[ -d "$receipt_dir" ]] || { echo "expected receipt dir for merge replay case" >&2; exit 1; }
+
+  if [[ "$(grep -c 'MAYOR ACTION RECEIPT success action=merge' "$decision_log" || true)" -ne 1 ]]; then
+    echo "expected exactly one merge success receipt decision entry" >&2
+    exit 1
+  fi
+  grep -q 'MAYOR ACTION RECEIPT non-success reason=replayed-action-key-existing-success retry=no-op action=merge' "$decision_log" || {
+    echo "expected explicit replay no-op decision entry for merge action key" >&2
+    exit 1
+  }
+
+  if [[ "$(find "$receipt_dir" -type f | wc -l | tr -d ' ')" -ne 1 ]]; then
+    echo "expected exactly one durable receipt file for replayed merge action key" >&2
+    exit 1
+  fi
+  local receipt_file
+  receipt_file="$(find "$receipt_dir" -type f | head -n1)"
+  grep -q '^ACTION=merge$' "$receipt_file" || { echo "expected merge receipt ACTION field" >&2; exit 1; }
+  grep -q '^ACTION_KEY=merge/acme/demo/pr=77$' "$receipt_file" || { echo "expected stable merge action key in receipt" >&2; exit 1; }
+  grep -q '^RECEIPT_STATUS=success$' "$receipt_file" || { echo "expected merge receipt success status" >&2; exit 1; }
+}
+
+run_dispatch_drift_case
+run_merge_replay_case
+
+echo "ALL TESTS PASSED"

--- a/test_mayor_wake_replay_regression.sh
+++ b/test_mayor_wake_replay_regression.sh
@@ -71,6 +71,9 @@ echo "=== mayor post-merge dispatch durable dedupe fence ==="
 echo "=== mayor dispatch-start verification fence ==="
 "$REPO_ROOT/test_mayor_dispatch_start_verification_fence.sh"
 
+echo "=== mayor action receipt fence (drift + replay) ==="
+"$REPO_ROOT/test_mayor_action_receipt_fence.sh"
+
 echo "=== mayor cycle lease lock recovery ==="
 "$REPO_ROOT/test_mayor_cycle_lock_lease.sh"
 


### PR DESCRIPTION
Closes #130\n\n## Summary\n- add mayor action-evidence receipt fence for dispatch/nuke/merge with immediate live recheck\n- log structured receipt fields in durable decision entries and mark mismatches as non-success with explicit retry/no-op hints\n- prevent replayed action keys from writing conflicting success receipts\n- add regression coverage for post-action drift and replay behavior\n- document action-receipt contract and troubleshooting steps