### PR TITLE
Fix _term_cols unbound-variable crashes in non-interactive status

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,12 @@ Rig naming conventions for query/revalidation paths:
 - If queue/polecat metadata contains an unknown rig, missing repo, invalid repo format, or repo that does not match the rig mapping, SGT now hard-fails that query path instead of treating it as an empty result.
 - Resolver failures emit explicit telemetry: `RIG_REPO_RESOLVE_ERROR ... reason_code=<unknown-rig|missing-repo|invalid-repo|repo-mismatch|...>`.
 
+## Troubleshooting
+
+- Symptom: `sgt status` crashes in CI, cron, or other non-interactive shells with an unbound variable / terminal-width probe error.
+- Current behavior: terminal width detection is best-effort and non-fatal. If `COLUMNS` is unset/invalid or `TERM` is unset (so `tput cols` fails), SGT falls back to a safe width (`80`, with a minimum guarded render width of `40`) and `sgt status` continues.
+- Verify this path with `./test_status_non_tty_term_cols_guard.sh`, which covers non-tty runs with `TERM` unset and malformed/missing `COLUMNS`.
+
 ## Security gate (sgt-authorized label)
 
 By default, SGT requires issues/PRs to be linked to an issue labeled `sgt-authorized` before witnesses/refineries will queue or merge work.

--- a/sgt
+++ b/sgt
@@ -112,6 +112,7 @@ _section() {
   local title="$1"
   local cols fill
   cols=$(_term_cols)
+  [[ "$cols" =~ ^[0-9]+$ ]] || cols=80
   # "╭─ " + title + " " + fill + "╮"
   fill=$(( cols - ${#title} - 6 ))
   (( fill < 0 )) && fill=0

--- a/test_status_non_tty_term_cols_guard.sh
+++ b/test_status_non_tty_term_cols_guard.sh
@@ -46,6 +46,7 @@ chmod +x "$TMP_HOME/.local/bin/tmux"
 run_case() {
   local label="$1"
   local columns_mode="$2"
+  local term_mode="$3"
   local out_file err_file cmd_exit
   out_file="$(mktemp)"
   err_file="$(mktemp)"
@@ -54,7 +55,7 @@ run_case() {
   env -i \
     HOME="$TMP_HOME" \
     PATH="$TMP_HOME/.local/bin:/usr/bin:/bin" \
-    TERM=dumb \
+    TERM="$term_mode" \
     COLUMNS="$columns_mode" \
     bash --noprofile --norc -c '
       sgt init >/dev/null
@@ -64,6 +65,9 @@ REPO=acme/roadrunner
 BRANCH=feature/term-cols-guard
 ISSUE=69
 PSTATE
+      if [[ -z "${TERM:-}" ]]; then
+        unset TERM
+      fi
       if [[ -z "${COLUMNS:-}" ]]; then
         unset COLUMNS
       fi
@@ -108,8 +112,8 @@ PSTATE
 }
 
 echo "=== status term-cols guard regression ==="
-run_case "non-tty with COLUMNS unset" ""
-run_case "non-tty with narrow COLUMNS" "1"
-run_case "non-tty with non-numeric COLUMNS" "oops"
+run_case "non-tty with TERM unset and COLUMNS unset" "" ""
+run_case "non-tty with narrow COLUMNS" "1" "dumb"
+run_case "non-tty with non-numeric COLUMNS" "oops" "dumb"
 
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
Closes #157\n\n## Summary\n- ensure status rendering tolerates TERM/COLUMNS probe failures by guarding section width fallback\n- extend regression coverage to non-tty execution with TERM unset and invalid/missing COLUMNS\n- document terminal width fallback behavior in README troubleshooting