### PR TITLE
Fix mayor bootstrap flapping and startup validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Mayor bootstrap now validates that each tmux spawn actually reaches `_mayor_loop` via a durable startup receipt, logs explicit `MAYOR_SPAWN_FAILED` events plus a persisted startup warning state when validation fails, and writes bootstrap output to `~/.sgt/mayor-start.log` for postmortem inspection.
+- Mayor tmux spawns now use the resolved `sgt` executable path instead of a bare PATH-dependent `sgt` command, which fixes deacon/mayor flapping when background sessions do not inherit the caller's shell PATH.
+- Added regression coverage for mayor startup validation and spawn-failure observability in `test_mayor_startup_validation.sh` (wired into `test_mayor_wake_replay_regression.sh`).
 - Added shared per-rig memory commands: `sgt context path/add/index/search`, backed by repo-local `SGT_CONTEXT.md` files and local embedding indexes under `~/.sgt/context/<rig>/index.json`.
 - `sgt context index/search` now use the OpenAI Embeddings API (default model `text-embedding-3-small`) and fail explicitly when `OPENAI_API_KEY` is missing; `sgt context add` still appends notes even when indexing prerequisites are unavailable.
 - Spawned worker instructions now tell polecats, dogs, CI-fix workers, and crew to read `SGT_CONTEXT.md` before work, use `sgt context search` when useful, and append durable notes with `sgt context add` before wrapping up.

--- a/sgt
+++ b/sgt
@@ -139,6 +139,29 @@ log_event() {
   echo "[$(date -Iseconds)] $*" >> "$SGT_LOG"
 }
 
+_sgt_exec_path() {
+  if [[ -n "${SGT_EXEC_PATH:-}" ]]; then
+    printf '%s\n' "$SGT_EXEC_PATH"
+    return 0
+  fi
+
+  local source_path="${BASH_SOURCE[0]:-$0}"
+  local resolved=""
+  if [[ "$source_path" == */* ]]; then
+    if resolved="$(cd "$(dirname "$source_path")" 2>/dev/null && pwd -P)"; then
+      printf '%s/%s\n' "$resolved" "$(basename "$source_path")"
+      return 0
+    fi
+  fi
+
+  if command -v sgt >/dev/null 2>&1; then
+    command -v sgt
+    return 0
+  fi
+
+  printf '%s\n' "$source_path"
+}
+
 _MAYOR_DECISION_LOG_LAST_ERROR=""
 _MAYOR_DISPATCH_TRIGGER_KEY=""
 _MAYOR_DISPATCH_TRIGGER_FILE=""
@@ -218,6 +241,107 @@ _mayor_decision_log_failure_state_write() {
 
 _mayor_decision_log_failure_state_clear() {
   rm -f "$SGT_MAYOR_DECISION_LOG_ALERT_STATE"
+}
+
+_mayor_start_receipt_file() {
+  echo "$SGT_CONFIG/mayor-start.receipt"
+}
+
+_mayor_start_log_file() {
+  echo "$SGT_CONFIG/mayor-start.log"
+}
+
+_mayor_start_failure_state_file() {
+  echo "$SGT_CONFIG/mayor-start-failure.state"
+}
+
+_mayor_start_failure_state_read() {
+  local ts="" reason_code="" attempt="" log_path="" detail=""
+  local state_file
+  state_file="$(_mayor_start_failure_state_file)"
+  if [[ -f "$state_file" ]]; then
+    IFS='|' read -r ts reason_code attempt log_path detail < "$state_file" 2>/dev/null || true
+  fi
+  if [[ ! "$ts" =~ ^[0-9]+$ ]]; then
+    ts=""
+  fi
+  printf '%s|%s|%s|%s|%s\n' "$ts" "$reason_code" "$attempt" "$log_path" "$detail"
+}
+
+_mayor_start_failure_state_write() {
+  local ts="${1:-}" reason_code="${2:-}" attempt="${3:-}" log_path="${4:-}" detail="${5:-}"
+  local state_file state_tmp
+  state_file="$(_mayor_start_failure_state_file)"
+  state_tmp="${state_file}.tmp.$$"
+  printf '%s|%s|%s|%s|%s\n' \
+    "$ts" \
+    "$(_escape_wake_value "$reason_code")" \
+    "$(_escape_wake_value "$attempt")" \
+    "$(_escape_wake_value "$log_path")" \
+    "$(_escape_wake_value "$detail")" > "$state_tmp"
+  mv "$state_tmp" "$state_file"
+}
+
+_mayor_start_failure_state_clear() {
+  rm -f "$(_mayor_start_failure_state_file)"
+}
+
+_mayor_start_receipt_write() {
+  local attempt="${1:-}" pid="${2:-$$}" now_epoch now_iso receipt_file receipt_tmp
+  receipt_file="$(_mayor_start_receipt_file)"
+  receipt_tmp="${receipt_file}.tmp.$$"
+  now_epoch="$(date +%s)"
+  now_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  cat > "$receipt_tmp" <<EOF
+ATTEMPT=$attempt
+PID=$pid
+STARTED_AT=$now_iso
+STARTED_EPOCH=$now_epoch
+EOF
+  mv "$receipt_tmp" "$receipt_file"
+}
+
+_mayor_start_receipt_matches() {
+  local expected_attempt="${1:-}"
+  local receipt_file receipt_attempt
+  receipt_file="$(_mayor_start_receipt_file)"
+  [[ -f "$receipt_file" ]] || return 1
+  receipt_attempt="$(grep '^ATTEMPT=' "$receipt_file" 2>/dev/null | head -n1 | cut -d= -f2-)"
+  [[ -n "$receipt_attempt" && "$receipt_attempt" == "$expected_attempt" ]]
+}
+
+_mayor_start_validation_timeout_secs() {
+  local raw="${SGT_MAYOR_START_TIMEOUT_SECS:-8}"
+  if [[ ! "$raw" =~ ^[0-9]+$ || "$raw" -le 0 ]]; then
+    raw="8"
+  fi
+  printf '%s\n' "$raw"
+}
+
+_mayor_start_log_tail() {
+  local log_file
+  log_file="$(_mayor_start_log_file)"
+  if [[ -f "$log_file" ]]; then
+    tail -n 5 "$log_file" 2>/dev/null | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/[[:space:]]+$//'
+  fi
+}
+
+_mayor_wait_for_start() {
+  local session="${1:-sgt-mayor}" attempt="${2:-}" timeout_secs="${3:-$(_mayor_start_validation_timeout_secs)}"
+  local waited=0
+
+  while (( waited < timeout_secs )); do
+    if _mayor_start_receipt_matches "$attempt"; then
+      return 0
+    fi
+    if ! tmux has-session -t "$session" 2>/dev/null; then
+      return 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  _mayor_start_receipt_matches "$attempt"
 }
 
 _rfc3339_utc_now() {
@@ -5733,6 +5857,15 @@ _cmd_status_human() {
   else
     printf "  %-16s %s%s%s\n" "" "$(_dim)" "lock: state=$mayor_lock_state ownerPid=$mayor_lock_owner startedAt=$mayor_lock_started leaseUntil=$mayor_lock_until" "$(_reset)"
   fi
+  local mayor_start_fail_ts mayor_start_fail_reason mayor_start_fail_attempt mayor_start_fail_log mayor_start_fail_detail mayor_start_fail_age
+  IFS='|' read -r mayor_start_fail_ts mayor_start_fail_reason mayor_start_fail_attempt mayor_start_fail_log mayor_start_fail_detail <<< "$(_mayor_start_failure_state_read)"
+  if [[ "$mayor_start_fail_ts" =~ ^[0-9]+$ ]]; then
+    mayor_start_fail_age=$(( $(date +%s) - mayor_start_fail_ts ))
+    if [[ "$mayor_start_fail_age" -lt 0 ]]; then
+      mayor_start_fail_age=0
+    fi
+    printf "  %-16s %s%s%s\n" "" "$(_fg_yellow)" "startup warning: ${mayor_start_fail_age}s ago reason=$mayor_start_fail_reason detail=$mayor_start_fail_detail log=$mayor_start_fail_log" "$(_reset)"
+  fi
   local log_fail_ts log_fail_context log_fail_workspace log_fail_error log_fail_age
   IFS='|' read -r log_fail_ts log_fail_context log_fail_workspace log_fail_error <<< "$(_mayor_decision_log_failure_state_read)"
   if [[ "$log_fail_ts" =~ ^[0-9]+$ ]]; then
@@ -8736,6 +8869,8 @@ _mayor_exit_receipt() {
 
 _mayor_loop() {
   set +e  # Mayor loop must never exit on errors
+  _mayor_start_receipt_write "${SGT_MAYOR_START_TOKEN:-unknown}" "$$" || true
+  _mayor_start_failure_state_clear || true
   log_event "MAYOR_START"
   local lock_claim lock_rc lock_decision lock_owner lock_started lock_until lock_reason
   lock_claim="$(_mayor_lock_claim)"
@@ -9520,11 +9655,48 @@ cmd_mayor_start() {
   # Create FIFO for event-driven wake
   [[ -p "$SGT_MAYOR_FIFO" ]] || mkfifo "$SGT_MAYOR_FIFO"
 
-  tmux new-session -d -s "$session" \
-    "SGT_ROOT='$SGT_ROOT' SGT_MAYOR_INTERVAL='$SGT_MAYOR_INTERVAL' sgt _mayor"
+  local sgt_exec mayor_log attempt_token spawn_cmd startup_timeout startup_detail
+  sgt_exec="$(_sgt_exec_path)"
+  mayor_log="$(_mayor_start_log_file)"
+  attempt_token="mayor-start-$(date +%s)-$$"
+  startup_timeout="$(_mayor_start_validation_timeout_secs)"
 
-  log_event "MAYOR_SPAWN"
-  info "mayor started (session: $session, event-driven + fallback every ${SGT_MAYOR_INTERVAL}s)"
+  mkdir -p "$(dirname "$mayor_log")"
+  {
+    printf '[%s] MAYOR_SPAWN_ATTEMPT attempt=%s exec=%s root=%s\n' \
+      "$(date -Iseconds)" \
+      "$attempt_token" \
+      "$sgt_exec" \
+      "$SGT_ROOT"
+  } >> "$mayor_log"
+
+  printf -v spawn_cmd 'SGT_ROOT=%q SGT_MAYOR_INTERVAL=%q SGT_MAYOR_START_TOKEN=%q exec %q _mayor >> %q 2>&1' \
+    "$SGT_ROOT" \
+    "$SGT_MAYOR_INTERVAL" \
+    "$attempt_token" \
+    "$sgt_exec" \
+    "$mayor_log"
+
+  tmux new-session -d -s "$session" "$spawn_cmd"
+
+  log_event "MAYOR_SPAWN attempt=$attempt_token exec_path=\"$(_escape_quotes "$sgt_exec")\""
+  if _mayor_wait_for_start "$session" "$attempt_token" "$startup_timeout"; then
+    info "mayor started (session: $session, event-driven + fallback every ${SGT_MAYOR_INTERVAL}s)"
+    return 0
+  fi
+
+  startup_detail="$(_mayor_start_log_tail)"
+  if [[ -z "$startup_detail" ]]; then
+    startup_detail="startup receipt missing after ${startup_timeout}s"
+  fi
+  _mayor_start_failure_state_write \
+    "$(date +%s)" \
+    "startup-validation-failed" \
+    "$attempt_token" \
+    "$mayor_log" \
+    "$startup_detail"
+  log_event "MAYOR_SPAWN_FAILED reason_code=startup-validation-failed attempt=$attempt_token timeout=${startup_timeout}s log_path=\"$(_escape_quotes "$mayor_log")\" detail=\"$(_escape_quotes "$startup_detail")\""
+  warn "mayor spawn failed validation (attempt=$attempt_token, timeout=${startup_timeout}s). See $mayor_log"
 }
 
 cmd_mayor_stop() {

--- a/test_mayor_startup_validation.sh
+++ b/test_mayor_startup_validation.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# test_mayor_startup_validation.sh — Regression checks for mayor bootstrap validation and spawn failure logging.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+
+extract_fn() {
+  local name="$1"
+  awk -v n="$name" '
+    $0 ~ "^" n "\\(\\) \\{" {in_fn=1}
+    in_fn {print}
+    in_fn && $0 == "}" {exit}
+  ' "$SGT_SCRIPT"
+}
+
+echo "=== mayor startup validation failure logging ==="
+bash -s "$SGT_SCRIPT" <<'BASH'
+set -euo pipefail
+SGT_SCRIPT="$1"
+
+extract_fn() {
+  local name="$1"
+  awk -v n="$name" '
+    $0 ~ "^" n "\\(\\) \\{" {in_fn=1}
+    in_fn {print}
+    in_fn && $0 == "}" {exit}
+  ' "$SGT_SCRIPT"
+}
+
+eval "$(extract_fn _mayor_start_log_file)"
+eval "$(extract_fn _mayor_start_failure_state_file)"
+eval "$(extract_fn _mayor_start_failure_state_read)"
+eval "$(extract_fn _mayor_start_failure_state_write)"
+eval "$(extract_fn _mayor_start_validation_timeout_secs)"
+eval "$(extract_fn _mayor_start_log_tail)"
+eval "$(extract_fn cmd_mayor_start)"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+SGT_ROOT="$TMP_ROOT/root"
+SGT_CONFIG="$SGT_ROOT/.sgt"
+SGT_MAYOR_FIFO="$SGT_CONFIG/mayor.fifo"
+SGT_MAYOR_INTERVAL="600"
+EVENT_LOG="$TMP_ROOT/events.log"
+TMUX_LOG="$TMP_ROOT/tmux.log"
+STDERR_LOG="$TMP_ROOT/stderr.log"
+mkdir -p "$SGT_CONFIG"
+export SGT_ROOT SGT_CONFIG SGT_MAYOR_FIFO SGT_MAYOR_INTERVAL EVENT_LOG TMUX_LOG STDERR_LOG
+
+ensure_init() { :; }
+info() { :; }
+warn() { echo "$*" >> "$STDERR_LOG"; }
+_escape_quotes() { printf '%s' "$1"; }
+_escape_wake_value() { printf '%s' "$1"; }
+_sgt_exec_path() { printf '%s\n' "/tmp/sgt-worktree/bin/sgt"; }
+_mayor_wait_for_start() { return 1; }
+log_event() { echo "$*" >> "$EVENT_LOG"; }
+
+tmux() {
+  if [[ "${1:-}" == "has-session" && "${2:-}" == "-t" ]]; then
+    return 1
+  fi
+  if [[ "${1:-}" == "new-session" ]]; then
+    printf '%s\n' "${5:-}" > "$TMUX_LOG"
+    return 0
+  fi
+  return 0
+}
+
+cmd_mayor_start
+
+if ! grep -q 'MAYOR_SPAWN attempt=mayor-start-' "$EVENT_LOG"; then
+  echo "expected structured MAYOR_SPAWN event" >&2
+  exit 1
+fi
+if ! grep -q 'MAYOR_SPAWN_FAILED reason_code=startup-validation-failed' "$EVENT_LOG"; then
+  echo "expected explicit mayor spawn failure event" >&2
+  exit 1
+fi
+if [[ ! -f "$SGT_CONFIG/mayor-start-failure.state" ]]; then
+  echo "expected durable mayor startup failure state file" >&2
+  exit 1
+fi
+if ! grep -q 'startup-validation-failed' "$SGT_CONFIG/mayor-start-failure.state"; then
+  echo "expected failure state reason code" >&2
+  exit 1
+fi
+if ! grep -q "$SGT_CONFIG/mayor-start.log" "$SGT_CONFIG/mayor-start-failure.state"; then
+  echo "expected failure state to include mayor startup log path" >&2
+  exit 1
+fi
+if ! grep -q '/tmp/sgt-worktree/bin/sgt _mayor' "$TMUX_LOG"; then
+  echo "expected mayor tmux spawn command to use resolved executable path" >&2
+  exit 1
+fi
+if grep -q ' sgt _mayor' "$TMUX_LOG"; then
+  echo "expected mayor tmux spawn command to avoid bare PATH-dependent 'sgt _mayor'" >&2
+  exit 1
+fi
+if ! grep -q 'mayor spawn failed validation' "$STDERR_LOG"; then
+  echo "expected operator-visible mayor spawn validation warning" >&2
+  exit 1
+fi
+BASH
+
+echo "ALL TESTS PASSED"

--- a/test_mayor_wake_replay_regression.sh
+++ b/test_mayor_wake_replay_regression.sh
@@ -113,6 +113,9 @@ echo "=== mayor stale witness/refinery heartbeat watchdog ==="
 echo "=== mayor supervision and exit receipts ==="
 "$REPO_ROOT/test_mayor_supervision_and_exit_receipt.sh"
 
+echo "=== mayor startup validation and spawn failure logging ==="
+"$REPO_ROOT/test_mayor_startup_validation.sh"
+
 echo "=== mayor stale required CI check watchdog ==="
 "$REPO_ROOT/test_mayor_ci_check_watchdog.sh"
 


### PR DESCRIPTION
Closes #187

## Summary
- spawn mayor tmux sessions via the resolved sgt executable path instead of a bare PATH-dependent command
- validate each mayor spawn with a durable startup receipt and persist/log explicit startup failures to ~/.sgt/mayor-start.log and status output
- add regression coverage for startup validation failure logging and wire it into the mayor wake replay suite