### PR TITLE
Inject plan completion context into worker prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ Acceptance status values:
 - `blocked`: waiting on an external condition; mayor should not mark all-clear
 - `waived`: a human explicitly waived the condition
 
+### Recommended operator pattern
+
+Declare the end condition in `SGT_PLAN.json`, not just the task list:
+- set `completion_condition` to the real repo-level definition of done
+- set `acceptance.status` and `acceptance.details` to the current verification state
+
+Use blockers only for verified red acceptance after merges:
+- when intermediate PRs merge but fresh verification is still red, run `sgt create blocker <rig> ...`
+- resolve that blocker only after the acceptance condition is truly green with `sgt blocker resolve <blocker-id> --note "..."`
+
+How SGT relays this:
+- mayor uses `completion_condition`, `acceptance`, and active blockers to decide whether the rig is actually done or still needs follow-up
+- coding-worker prompts (`sling` and re-sling) inject the same completion condition, acceptance status/details, blocker summary, and a warning that merged intermediate work is not enough while acceptance is still pending or blocked
+
 ### Manual control
 
 ```bash

--- a/SGT_CONTEXT.md
+++ b/SGT_CONTEXT.md
@@ -19,3 +19,14 @@ Useful commands:
 ## 2026-03-11
 - 2026-03-11T11:31:38+01:00 — 2026-03-11T00:00:00Z — Added durable acceptance blockers via 'sgt create blocker' / 'sgt blocker resolve'. Mayor now treats open blockers as unresolved acceptance state, suppresses idle-green all-clear, and re-invokes follow-up when a blocker exists with no open issues, PRs, polecats, or pending plan requests.
 - 2026-03-11T11:39:05+01:00 — Repo plans now support completion_condition plus acceptance status in SGT_PLAN.json; plan-state persists completion.rollup/status, and mayor treats tasks-exhausted-awaiting-acceptance as unresolved work instead of all-clear.
+- 2026-03-11T11:46:54+01:00 — Deacon now supervises the mayor tmux session and restarts it when sgt-mayor is missing; mayor exit paths also append durable MAYOR_STOP receipts with reason_code/exit_code/signal/unexpected fields for silent-exit forensics.
+- 2026-03-11T16:28:42+01:00 — 2026-03-11T00:00:00Z — CI regression guard forbids heredocs inside command substitution in the main sgt script; use printf -v for multiline evidence/comment bodies instead.
+
+## 2026-03-12
+- 2026-03-12T03:57:21+01:00 — Repo plan hardening: cmd_sling now auto-creates all requested labels (including plan / plan-<task> labels); mayor request completion syncs SGT_PLAN.json into plan-state and precreates future plan labels; plan tick records durable movement blockers under ~/.sgt/plan-blockers on sync/dispatch failures; mayor treats dispatch failures or ready pending tasks with inflight=0 as unresolved plan movement instead of idle-green.
+- 2026-03-12T04:05:09+01:00 — Worker prompts now inject repo-plan completion context on both sling and re-sling paths: completion_condition, acceptance status/details, unresolved blocker summary, and a reminder that merged intermediate work is not full rig completion while acceptance remains pending or blocked.
+- 2026-03-11T11:46:54+01:00 — Deacon now supervises the mayor tmux session and restarts it when sgt-mayor is missing; mayor exit paths also append durable MAYOR_STOP receipts with reason_code/exit_code/signal/unexpected fields for silent-exit forensics.
+- 2026-03-11T16:28:42+01:00 — 2026-03-11T00:00:00Z — CI regression guard forbids heredocs inside command substitution in the main sgt script; use printf -v for multiline evidence/comment bodies instead.
+
+## 2026-03-12
+- 2026-03-12T03:57:21+01:00 — Repo plan hardening: cmd_sling now auto-creates all requested labels (including plan / plan-<task> labels); mayor request completion syncs SGT_PLAN.json into plan-state and precreates future plan labels; plan tick records durable movement blockers under ~/.sgt/plan-blockers on sync/dispatch failures; mayor treats dispatch failures or ready pending tasks with inflight=0 as unresolved plan movement instead of idle-green.

--- a/sgt
+++ b/sgt
@@ -5902,20 +5902,8 @@ PSTATE
   # ── 5. Spawn AI agent in tmux ──
   info "spawning polecat $pname in tmux session $session_name..."
 
-  # Include project README context in the polecat prompt (truncated).
-  local readme_prompt=""
-  if [[ -f "$rpath/README.md" ]]; then
-    # Keep it bounded to avoid huge prompts.
-    local readme_max_bytes=12000
-    local readme_excerpt
-    readme_excerpt=$(head -c "$readme_max_bytes" "$rpath/README.md" 2>/dev/null || true)
-    if [[ -n "$readme_excerpt" ]]; then
-      readme_prompt=$'\n\n---\nProject README (excerpt)\n\n'"$readme_excerpt"$'\n---\n'
-    fi
-  fi
-
   local polecat_prompt
-  polecat_prompt="Read the CLAUDE.md and SGT_CONTEXT.md in this directory before you start. Search shared rig context first with 'sgt context search ${rig} \"<query>\"' for any questions, unknowns, or prior decisions instead of guessing. Your task is described in GitHub issue #${issue_number}. The issue title is: ${task}. Work on branch ${branch}. Before you finish, add any durable project context you learned with 'sgt context add ${rig} \"<note>\"'. When done, commit your changes, push the branch, and open a PR that closes #${issue_number}."  polecat_prompt+="$readme_prompt"
+  polecat_prompt="$(_build_polecat_runtime_prompt "$rig" "$issue_number" "$task" "$branch" "$rpath")"
 
   tmux new-session -d -s "$session_name" -c "$worktree" \
     "$( _ai_cmd "$backend" "$polecat_prompt" ); echo '[SGT] polecat exited'; sgt _wake-refinery '${rig}' 'polecat-done:${pname}:#${issue_number}' 2>/dev/null"
@@ -7302,8 +7290,10 @@ CREATED=$(date -Iseconds)
 STATUS=running
 PSTATE
 
+  local polecat_prompt
+  polecat_prompt="$(_build_polecat_runtime_prompt "$rig" "$issue_number" "$task" "$branch" "$rpath")"
   tmux new-session -d -s "$session_name" -c "$worktree" \
-    "$( _ai_cmd "$backend" "Read the CLAUDE.md and SGT_CONTEXT.md in this directory before you start. Search shared rig context first with 'sgt context search ${rig} \"<query>\"' for any questions, unknowns, or prior decisions instead of guessing. Your task is described in GitHub issue #${issue_number}. The issue title is: ${task}. Work on branch ${branch}. Before you finish, add any durable project context you learned with 'sgt context add ${rig} \"<note>\"'. When done, commit your changes, push the branch, and open a PR that closes #${issue_number}." ); echo '[SGT] polecat exited'; sgt _wake-refinery '${rig}' 'polecat-done:${pname}:#${issue_number}' 2>/dev/null"
+    "$( _ai_cmd "$backend" "$polecat_prompt" ); echo '[SGT] polecat exited'; sgt _wake-refinery '${rig}' 'polecat-done:${pname}:#${issue_number}' 2>/dev/null"
   _RESLING_LAST_POLECAT="$pname"
   log_event "RESLING $pname rig=$rig issue=#$issue_number branch=$branch"
 }
@@ -11048,17 +11038,103 @@ Useful commands:
 
 1. Read your assigned GitHub issue for the task description
 2. Read `SGT_CONTEXT.md` for durable project context
-3. Work on your feature branch
-4. Commit frequently with clear messages
-5. Push your branch
-6. Open a PR that references the issue (use "Closes #N")
-7. Before exit, add any durable new context with `sgt context add <rig> "<note>"`
-8. Exit when done
+3. If the repo has `SGT_PLAN.json`, pay attention to any injected rig-level completion/acceptance context in worker instructions
+4. Work on your feature branch
+5. Commit frequently with clear messages
+6. Push your branch
+7. Open a PR that references the issue (use "Closes #N")
+8. Before exit, add any durable new context with `sgt context add <rig> "<note>"`
+9. Exit when done
 CLMD
+}
+
+_worker_plan_completion_context_md() {
+  local rig="${1:-}" plan_file="${2:-}" status="not_declared" rollup="not_declared" condition="" acceptance_json="{}" details="" blocked_reason=""
+  [[ -n "$rig" ]] || return 0
+  if [[ -z "$plan_file" ]]; then
+    plan_file="$(_plan_file_path "$rig")"
+  fi
+  [[ -f "$plan_file" ]] || return 0
+
+  while IFS=$'\x1f' read -r record_type c1 c2 c3 c4 c5 c6 c7 c8 c9; do
+    [[ -n "$record_type" ]] || continue
+    case "$record_type" in
+      CONFIG)
+        status="${c2:-not_declared}"
+        rollup="${c3:-not_declared}"
+        condition="${c4:-}"
+        acceptance_json="${c5:-{}}"
+        details="${c6:-}"
+        blocked_reason="${c7:-}"
+        ;;
+    esac
+  done < <(_plan_state_snapshot "$rig" "$plan_file" 2>/dev/null || true)
+
+  if [[ "$status" == "not_declared" && -z "$condition" && "${acceptance_json:-{}}" == "{}" ]]; then
+    return 0
+  fi
+
+  local blocker_count blocker_id
+  blocker_count=0
+  while IFS='|' read -r blocker_id _; do
+    [[ -n "$blocker_id" ]] || continue
+    blocker_count=$((blocker_count + 1))
+  done < <(_acceptance_blocker_list_active "$rig" 2>/dev/null || true)
+
+  cat <<EOF
+## Rig Completion Context
+
+This rig has a repo-local \`SGT_PLAN.json\` with a larger completion target beyond this single issue.
+
+- **Completion condition**: ${condition:-not declared}
+- **Acceptance status**: ${status:-not_declared}
+- **Acceptance rollup**: ${rollup:-not_declared}
+- **Acceptance details**: ${details:-none recorded}
+EOF
+  if [[ -n "$blocked_reason" ]]; then
+    printf '%s\n' "- **Blocked reason**: $blocked_reason"
+  fi
+  if [[ "$blocker_count" -gt 0 ]]; then
+    printf '%s\n' "- **Unresolved acceptance blockers**: yes (${blocker_count} active)"
+  else
+    printf '%s\n' "- **Unresolved acceptance blockers**: no"
+  fi
+  cat <<EOF
+- **Rule**: merged intermediate work is not rig completion while acceptance remains \`pending\` or \`blocked\`. Only verified acceptance, or an explicit human waiver, closes the plan-level requirement.
+- **If acceptance stays red after merges**: record durable evidence with \`sgt create blocker $rig "<evidence>"\`.
+EOF
+}
+
+_polecat_readme_prompt() {
+  local rpath="${1:-}"
+  local readme_prompt="" readme_excerpt
+  [[ -n "$rpath" ]] || return 0
+  if [[ -f "$rpath/README.md" ]]; then
+    readme_excerpt=$(head -c 12000 "$rpath/README.md" 2>/dev/null || true)
+    if [[ -n "$readme_excerpt" ]]; then
+      readme_prompt=$'\n\n---\nProject README (excerpt)\n\n'"$readme_excerpt"$'\n---\n'
+    fi
+  fi
+  printf '%s' "$readme_prompt"
+}
+
+_build_polecat_runtime_prompt() {
+  local rig="$1" issue="$2" task="$3" branch="$4" rpath="$5"
+  local prompt readme_prompt completion_context
+  readme_prompt="$(_polecat_readme_prompt "$rpath")"
+  completion_context="$(_worker_plan_completion_context_md "$rig")"
+  prompt="Read the CLAUDE.md and SGT_CONTEXT.md in this directory before you start. Search shared rig context first with 'sgt context search ${rig} \"<query>\"' for any questions, unknowns, or prior decisions instead of guessing. Your task is described in GitHub issue #${issue}. The issue title is: ${task}. Work on branch ${branch}. Pay close attention to any 'Rig Completion Context' section in CLAUDE.md; merged intermediate work is not enough when plan acceptance is still pending or blocked. Before you finish, add any durable project context you learned with 'sgt context add ${rig} \"<note>\"'. When done, commit your changes, push the branch, and open a PR that closes #${issue}."
+  if [[ -n "$completion_context" ]]; then
+    prompt+=$'\n\n---\nRig Completion Context\n\n'"$completion_context"
+  fi
+  prompt+="$readme_prompt"
+  printf '%s' "$prompt"
 }
 
 _write_polecat_claude_md() {
   local worktree="$1" rig="$2" issue="$3" task="$4" repo="$5" pname="$6" branch="$7" default_branch="$8" auto_merge="$9"
+  local completion_context
+  completion_context="$(_worker_plan_completion_context_md "$rig")"
 
   cat >> "$worktree/CLAUDE.md" <<CLMD
 
@@ -11080,21 +11156,25 @@ You are polecat \`$pname\`, an ephemeral coding agent.
 - Append durable shared notes with \`sgt context add $rig "<note>"\`
 - Before task completion, make sure any durable project context worth keeping has been added
 
+${completion_context}
+
 ## Protocol
 
 1. Read the issue description for full context
 2. Read \`SGT_CONTEXT.md\` for durable project context
-3. Implement the requested changes
-4. Write tests if appropriate
-5. If you learn something future agents should know, append it with \`sgt context add $rig "<note>"\`
-6. Commit your work with clear commit messages referencing #$issue
-7. Push your branch: \`git push -u origin $branch\`
-8. Open a PR: \`gh pr create --title "<concise title>" --body "Closes #$issue" --base $default_branch\`
-9. Exit the session
+3. Read any \`Rig Completion Context\` section below as the plan-level success criteria for this task
+4. Implement the requested changes
+5. Write tests if appropriate
+6. If you learn something future agents should know, append it with \`sgt context add $rig "<note>"\`
+7. Commit your work with clear commit messages referencing #$issue
+8. Push your branch: \`git push -u origin $branch\`
+9. Open a PR: \`gh pr create --title "<concise title>" --body "Closes #$issue" --base $default_branch\`
+10. Exit the session
 
 ## Rules
 
 - Stay focused on the issue — don't scope-creep
+- If the rig-level acceptance state is still \`pending\` or \`blocked\`, do not treat a merged intermediate PR as full rig completion
 - If blocked, comment on the issue explaining the blocker, then exit
 - Never force-push or modify the default branch directly
 - Keep commits atomic and well-described

--- a/test_worker_prompt_completion_context.sh
+++ b/test_worker_prompt_completion_context.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# test_worker_prompt_completion_context.sh — Worker prompts must include plan completion context on sling and re-sling paths.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+mkdir -p "$TMP_HOME/mock-bin" "$TMP_HOME/state/issues"
+
+cat > "$TMP_HOME/mock-bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+STATE_DIR="${GH_STATE_DIR:?missing GH_STATE_DIR}"
+ISSUES_DIR="$STATE_DIR/issues"
+NEXT_FILE="$STATE_DIR/next-issue"
+mkdir -p "$ISSUES_DIR"
+
+cmd="${1:-}"
+sub="${2:-}"
+shift 2 || true
+
+case "$cmd:$sub" in
+  label:create)
+    exit 0
+    ;;
+  issue:create)
+    next=1
+    if [[ -f "$NEXT_FILE" ]]; then
+      next="$(cat "$NEXT_FILE")"
+    fi
+    title=""
+    body=""
+    repo=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --repo)
+          repo="$2"
+          shift 2
+          ;;
+        --title)
+          title="$2"
+          shift 2
+          ;;
+        --body)
+          body="$2"
+          shift 2
+          ;;
+        --label)
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    printf 'STATE=%q\nTITLE=%q\nBODY=%q\nREPO=%q\nLABELS=%q\n' \
+      "OPEN" "$title" "$body" "$repo" "sgt-authorized" > "$ISSUES_DIR/$next.env"
+    echo $((next + 1)) > "$NEXT_FILE"
+    printf 'https://github.com/acme/demo/issues/%s\n' "$next"
+    ;;
+  issue:view)
+    issue_number="${1:-}"
+    issue_number="${issue_number#\#}"
+    shift || true
+    issue_file="$ISSUES_DIR/$issue_number.env"
+    [[ -f "$issue_file" ]] || exit 1
+    # shellcheck disable=SC1090
+    source "$issue_file"
+    json=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --json)
+          json="$2"
+          shift 2
+          ;;
+        --jq)
+          shift 2
+          ;;
+        --repo)
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    case "$json" in
+      state)
+        printf '%s\n' "${STATE:-OPEN}"
+        ;;
+      title)
+        printf '%s\n' "${TITLE:-}"
+        ;;
+      labels)
+        printf '%s\n' "sgt-authorized"
+        ;;
+      body)
+        printf '%s\n' "${BODY:-}"
+        ;;
+      *)
+        printf '%s\n' "${STATE:-OPEN}"
+        ;;
+    esac
+    ;;
+  issue:list|issue:edit|issue:comment|pr:view|pr:list|api:*)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+chmod +x "$TMP_HOME/mock-bin/gh"
+
+cat > "$TMP_HOME/mock-bin/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LOG_FILE="${TMUX_LOG_FILE:?missing TMUX_LOG_FILE}"
+case "${1:-}" in
+  has-session)
+    exit 1
+    ;;
+  new-session)
+    printf '%s\n' "$*" >> "$LOG_FILE"
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+chmod +x "$TMP_HOME/mock-bin/tmux"
+
+cat > "$TMP_HOME/mock-bin/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+chmod +x "$TMP_HOME/mock-bin/codex"
+
+LIB_SCRIPT="$TMP_HOME/sgt-lib.sh"
+sed '$d' "$SGT_SCRIPT" > "$LIB_SCRIPT"
+
+env -i \
+  HOME="$TMP_HOME" \
+  PATH="$TMP_HOME/mock-bin:/usr/local/bin:/usr/bin:/bin" \
+  TERM="${TERM:-xterm}" \
+  GH_STATE_DIR="$TMP_HOME/state" \
+  TMUX_LOG_FILE="$TMP_HOME/tmux.log" \
+  SGT_AI_BACKEND=codex \
+  SGT_MAYOR_DISPATCH_COOLDOWN=0 \
+  bash --noprofile --norc <<'BASH'
+set -euo pipefail
+
+source "$HOME/sgt-lib.sh"
+
+cmd_init >/dev/null
+mkdir -p "$HOME/sgt/.sgt/rigs" "$HOME/sgt/rigs/demo"
+printf '%s\n' 'https://github.com/acme/demo' > "$HOME/sgt/.sgt/rigs/demo"
+
+repo_dir="$HOME/sgt/rigs/demo"
+git -C "$repo_dir" init -b main >/dev/null
+git -C "$repo_dir" config user.name "SGT Test"
+git -C "$repo_dir" config user.email "sgt@example.com"
+cat > "$repo_dir/README.md" <<'EOF_README'
+# Demo
+
+This README excerpt should be present in worker prompts.
+EOF_README
+cat > "$repo_dir/CLAUDE.md" <<'EOF_CLAUDE'
+# Project Context
+EOF_CLAUDE
+cat > "$repo_dir/SGT_CONTEXT.md" <<'EOF_CONTEXT'
+# SGT Project Context
+EOF_CONTEXT
+cat > "$repo_dir/SGT_PLAN.json" <<'EOF_PLAN'
+{
+  "version": 1,
+  "rig": "demo",
+  "completion_condition": "Run a fresh-state verification on latest main and confirm the workflow succeeds.",
+  "acceptance": {
+    "status": "pending",
+    "details": "Fresh-state verification is still required after merges."
+  },
+  "tasks": [
+    { "id": "worker-prompts", "title": "Inject completion context into worker prompts" }
+  ]
+}
+EOF_PLAN
+git -C "$repo_dir" add README.md CLAUDE.md SGT_CONTEXT.md SGT_PLAN.json
+git -C "$repo_dir" commit -m "test fixture" >/dev/null
+
+_acceptance_blocker_write "demo" "Verified acceptance is still red after merge." "tester" "argv" >/dev/null
+
+cmd_sling "demo" "Inject completion context into worker prompts" --backend codex >/dev/null
+first_polecat="${_SGT_LAST_SLING_POLECAT:?missing first polecat}"
+first_claude="$HOME/sgt/polecats/$first_polecat/CLAUDE.md"
+
+grep -q '## Rig Completion Context' "$first_claude" || { echo "missing rig completion context in sling CLAUDE" >&2; exit 1; }
+grep -q 'Run a fresh-state verification on latest main and confirm the workflow succeeds.' "$first_claude" || { echo "missing completion condition in sling CLAUDE" >&2; exit 1; }
+grep -q '\*\*Acceptance status\*\*: pending' "$first_claude" || { echo "missing acceptance status in sling CLAUDE" >&2; exit 1; }
+grep -q '\*\*Unresolved acceptance blockers\*\*: yes (1 active)' "$first_claude" || { echo "missing acceptance blocker summary in sling CLAUDE" >&2; exit 1; }
+grep -q 'merged intermediate work is not rig completion' "$first_claude" || { echo "missing merged-work rule in sling CLAUDE" >&2; exit 1; }
+
+grep -q 'Rig Completion Context' "$HOME/tmux.log" || { echo "missing rig completion context in sling runtime prompt" >&2; exit 1; }
+grep -q 'Run a fresh-state verification on latest main and confirm the workflow succeeds.' "$HOME/tmux.log" || { echo "missing completion condition in sling runtime prompt" >&2; exit 1; }
+
+rm -f "$HOME/sgt/.sgt/polecats/$first_polecat"
+rm -rf "$HOME/sgt/polecats/$first_polecat"
+rm -f "$HOME/tmux.log"
+
+_resling_existing_issue "demo" "1" "Inject completion context into worker prompts" "https://github.com/acme/demo" "codex" "" "test-resling" "test-resling:issue-1"
+second_polecat="${_RESLING_LAST_POLECAT:?missing reslung polecat}"
+second_claude="$HOME/sgt/polecats/$second_polecat/CLAUDE.md"
+
+grep -q '## Rig Completion Context' "$second_claude" || { echo "missing rig completion context in resling CLAUDE" >&2; exit 1; }
+grep -q 'Run a fresh-state verification on latest main and confirm the workflow succeeds.' "$second_claude" || { echo "missing completion condition in resling CLAUDE" >&2; exit 1; }
+grep -q '\*\*Acceptance status\*\*: pending' "$second_claude" || { echo "missing acceptance status in resling CLAUDE" >&2; exit 1; }
+grep -q '\*\*Unresolved acceptance blockers\*\*: yes (1 active)' "$second_claude" || { echo "missing acceptance blocker summary in resling CLAUDE" >&2; exit 1; }
+
+grep -q 'Rig Completion Context' "$HOME/tmux.log" || { echo "missing rig completion context in resling runtime prompt" >&2; exit 1; }
+grep -q 'Run a fresh-state verification on latest main and confirm the workflow succeeds.' "$HOME/tmux.log" || { echo "missing completion condition in resling runtime prompt" >&2; exit 1; }
+
+echo "ALL TESTS PASSED"
+BASH


### PR DESCRIPTION
Closes #197

## Summary
- inject repo-plan completion/acceptance context into polecat CLAUDE.md and runtime prompts
- reuse the same prompt builder for sling and re-sling paths
- document the recommended completion-condition/blocker workflow and add regression coverage