### PR TITLE
Fix inert refinery queue stalls

### DIFF
--- a/sgt
+++ b/sgt
@@ -2039,6 +2039,68 @@ _agent_heartbeat_path() {
   echo "$SGT_CONFIG/${agent}-${rig}-heartbeat.json"
 }
 
+_merge_queue_count_for_rig() {
+  local rig="${1:-}"
+  local merge_dir="$SGT_CONFIG/merge-queue"
+  local mq_count=0
+  [[ -n "$rig" && -d "$merge_dir" ]] || {
+    echo "0"
+    return 0
+  }
+
+  local mqf mq_rig
+  for mqf in "$merge_dir"/*; do
+    [[ -f "$mqf" ]] || continue
+    mq_rig=""
+    while IFS='=' read -r k v; do
+      case "$k" in
+        RIG) mq_rig="$v" ;;
+      esac
+    done < <(grep -E '^(RIG)=' "$mqf" 2>/dev/null || true)
+    [[ "$mq_rig" == "$rig" ]] || continue
+    mq_count=$((mq_count + 1))
+  done
+  echo "$mq_count"
+}
+
+_merge_queue_oldest_age_for_rig() {
+  local rig="${1:-}"
+  local merge_dir="$SGT_CONFIG/merge-queue"
+  local now oldest_age
+  [[ -n "$rig" && -d "$merge_dir" ]] || {
+    echo "0"
+    return 0
+  }
+
+  now="$(date +%s)"
+  oldest_age=0
+
+  local mqf mq_rig queued_at queued_epoch age
+  for mqf in "$merge_dir"/*; do
+    [[ -f "$mqf" ]] || continue
+    mq_rig=""
+    queued_at=""
+    while IFS='=' read -r k v; do
+      case "$k" in
+        RIG) mq_rig="$v" ;;
+        QUEUED) queued_at="$v" ;;
+      esac
+    done < <(grep -E '^(RIG|QUEUED)=' "$mqf" 2>/dev/null || true)
+    [[ "$mq_rig" == "$rig" ]] || continue
+    queued_epoch="$(date -d "${queued_at:-1970-01-01T00:00:00Z}" +%s 2>/dev/null || echo 0)"
+    [[ "$queued_epoch" =~ ^[0-9]+$ ]] || queued_epoch=0
+    age=$((now - queued_epoch))
+    if [[ "$age" -lt 0 ]]; then
+      age=0
+    fi
+    if [[ "$age" -gt "$oldest_age" ]]; then
+      oldest_age="$age"
+    fi
+  done
+
+  echo "$oldest_age"
+}
+
 _heartbeat_snapshot_file() {
   local heartbeat_file="${1:-}"
   if [[ -z "$heartbeat_file" || ! -f "$heartbeat_file" ]]; then
@@ -2176,6 +2238,43 @@ _deacon_heartbeat_health() {
   else
     echo "healthy"
   fi
+}
+
+_deacon_refinery_watchdog_state() {
+  local rig="${1:-}"
+  local queue_count oldest_age hb_age hb_ts hb_state hb_stale_secs
+  [[ -n "$rig" ]] || {
+    echo "skip|missing-rig|0|0|-1||missing|$(_agent_heartbeat_stale_secs)"
+    return 0
+  }
+
+  queue_count="$(_merge_queue_count_for_rig "$rig")"
+  [[ "$queue_count" =~ ^[0-9]+$ ]] || queue_count=0
+  oldest_age="$(_merge_queue_oldest_age_for_rig "$rig")"
+  [[ "$oldest_age" =~ ^[0-9]+$ ]] || oldest_age=0
+  hb_stale_secs="$(_agent_heartbeat_stale_secs)"
+  IFS='|' read -r hb_age hb_ts hb_state <<< "$(_agent_heartbeat_snapshot "refinery" "$rig")"
+
+  if [[ "$queue_count" -le 0 ]]; then
+    echo "ok|queue-empty|$queue_count|$oldest_age|${hb_age:--1}|$hb_ts|${hb_state:-missing}|$hb_stale_secs"
+    return 0
+  fi
+
+  case "${hb_state:-missing}" in
+    ok)
+      if [[ "$hb_age" =~ ^[0-9]+$ && "$hb_age" -gt "$hb_stale_secs" ]]; then
+        echo "restart|heartbeat-stale|$queue_count|$oldest_age|$hb_age|$hb_ts|$hb_state|$hb_stale_secs"
+      else
+        echo "ok|heartbeat-fresh|$queue_count|$oldest_age|${hb_age:--1}|$hb_ts|$hb_state|$hb_stale_secs"
+      fi
+      ;;
+    missing)
+      echo "restart|heartbeat-missing|$queue_count|$oldest_age|${hb_age:--1}|$hb_ts|$hb_state|$hb_stale_secs"
+      ;;
+    *)
+      echo "restart|heartbeat-invalid|$queue_count|$oldest_age|${hb_age:--1}|$hb_ts|$hb_state|$hb_stale_secs"
+      ;;
+  esac
 }
 
 _mayor_critical_alert_signature() {
@@ -6360,10 +6459,44 @@ _cmd_status_human() {
     local rig_name
     rig_name="$(basename "$rig_file")"
     local w_alive="off" r_alive="off"
+    local w_hb_age w_hb_ts w_hb_state
+    local r_hb_age r_hb_ts r_hb_state
+    local agent_hb_stale_secs refinery_queue_count refinery_oldest_age
+    local refinery_badge
     tmux has-session -t "sgt-witness-${rig_name}" 2>/dev/null && w_alive="on"
     tmux has-session -t "sgt-refinery-${rig_name}" 2>/dev/null && r_alive="on"
+    agent_hb_stale_secs="$(_agent_heartbeat_stale_secs)"
+    IFS='|' read -r w_hb_age w_hb_ts w_hb_state <<< "$(_agent_heartbeat_snapshot "witness" "$rig_name")"
+    IFS='|' read -r r_hb_age r_hb_ts r_hb_state <<< "$(_agent_heartbeat_snapshot "refinery" "$rig_name")"
+    refinery_badge="$r_alive"
+    if [[ "$w_alive" == "on" && "$w_hb_state" == "ok" && "$w_hb_age" =~ ^[0-9]+$ && "$w_hb_age" -gt "$agent_hb_stale_secs" ]]; then
+      w_alive="degraded"
+    elif [[ "$w_alive" == "on" && "$w_hb_state" != "ok" ]]; then
+      w_alive="degraded"
+    fi
+    refinery_queue_count="$(_merge_queue_count_for_rig "$rig_name")"
+    refinery_oldest_age="$(_merge_queue_oldest_age_for_rig "$rig_name")"
+    if [[ "$refinery_badge" == "on" && "$r_hb_state" == "ok" && "$r_hb_age" =~ ^[0-9]+$ && "$r_hb_age" -gt "$agent_hb_stale_secs" ]]; then
+      refinery_badge="degraded"
+    elif [[ "$refinery_badge" == "on" && "$r_hb_state" != "ok" ]]; then
+      refinery_badge="degraded"
+    fi
+    if [[ "$refinery_badge" == "on" && "$refinery_queue_count" =~ ^[0-9]+$ && "$refinery_queue_count" -gt 0 && "$r_hb_state" != "ok" ]]; then
+      refinery_badge="degraded"
+    fi
     printf "  %-16s %s\n" "witness/$rig_name"  "$(_status_badge "$w_alive")"
-    printf "  %-16s %s\n" "refinery/$rig_name" "$(_status_badge "$r_alive")"
+    if [[ "$w_hb_state" == "ok" ]]; then
+      printf "  %-16s %s%s%s\n" "" "$(_dim)" "last heartbeat: $w_hb_ts (${w_hb_age}s ago, stale>${agent_hb_stale_secs}s)" "$(_reset)"
+    fi
+    printf "  %-16s %s\n" "refinery/$rig_name" "$(_status_badge "$refinery_badge")"
+    if [[ "$r_hb_state" == "ok" ]]; then
+      printf "  %-16s %s%s%s\n" "" "$(_dim)" "last heartbeat: $r_hb_ts (${r_hb_age}s ago, stale>${agent_hb_stale_secs}s)" "$(_reset)"
+    elif [[ "$r_alive" == "on" ]]; then
+      printf "  %-16s %s%s%s\n" "" "$(_fg_yellow)" "heartbeat: ${r_hb_state:-missing} (stale>${agent_hb_stale_secs}s)" "$(_reset)"
+    fi
+    if [[ "$refinery_queue_count" =~ ^[0-9]+$ && "$refinery_queue_count" -gt 0 ]]; then
+      printf "  %-16s %s%s%s\n" "" "$(_dim)" "queue watchdog: pending=${refinery_queue_count} oldest=${refinery_oldest_age}s" "$(_reset)"
+    fi
   done
 
   local mayor_alive="off"
@@ -8704,6 +8837,16 @@ HEARTBEAT
         log_event "DEACON_RESTART_REFINERY rig=$rig_name"
         cmd_refinery_start "$rig_name"
         actions=$((actions + 1))
+      else
+        local refinery_watch_action refinery_watch_reason refinery_queue_count refinery_oldest_age refinery_hb_age refinery_hb_ts refinery_hb_state refinery_hb_stale_secs
+        IFS='|' read -r refinery_watch_action refinery_watch_reason refinery_queue_count refinery_oldest_age refinery_hb_age refinery_hb_ts refinery_hb_state refinery_hb_stale_secs <<< "$(_deacon_refinery_watchdog_state "$rig_name")"
+        if [[ "$refinery_watch_action" == "restart" ]]; then
+          echo "[deacon] refinery/$rig_name watchdog restart — reason=$refinery_watch_reason queue_count=$refinery_queue_count oldest_queue_age=${refinery_oldest_age}s heartbeat_state=${refinery_hb_state:-missing} heartbeat_age=${refinery_hb_age}s"
+          log_event "DEACON_RESTART_REFINERY rig=$rig_name reason=$refinery_watch_reason queue_count=$refinery_queue_count oldest_queue_age=${refinery_oldest_age}s heartbeat_state=${refinery_hb_state:-missing} heartbeat_age=${refinery_hb_age}s heartbeat_threshold=${refinery_hb_stale_secs}s last_heartbeat=\"$(_escape_quotes "${refinery_hb_ts:-}")\""
+          cmd_refinery_stop "$rig_name" 2>/dev/null || true
+          cmd_refinery_start "$rig_name"
+          actions=$((actions + 1))
+        fi
       fi
     done
 

--- a/test_mayor_wake_replay_regression.sh
+++ b/test_mayor_wake_replay_regression.sh
@@ -110,6 +110,9 @@ echo "=== mayor stalled refinery REVIEW_UNCLEAR watchdog ==="
 echo "=== mayor stale witness/refinery heartbeat watchdog ==="
 "$REPO_ROOT/test_mayor_agent_heartbeat_watchdog.sh"
 
+echo "=== refinery inert queued-work watchdog ==="
+bash "$REPO_ROOT/test_refinery_inert_watchdog.sh"
+
 echo "=== mayor supervision and exit receipts ==="
 "$REPO_ROOT/test_mayor_supervision_and_exit_receipt.sh"
 

--- a/test_refinery_inert_watchdog.sh
+++ b/test_refinery_inert_watchdog.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# test_refinery_inert_watchdog.sh — Regression checks for queued-work refinery stall restart + status visibility.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+echo "=== deacon queued-work refinery watchdog decision ==="
+bash -s "$SGT_SCRIPT" "$TMP_ROOT" <<'BASH'
+set -euo pipefail
+SGT_SCRIPT="$1"
+TMP_ROOT="$2"
+HOME_DIR="$TMP_ROOT/helper-home"
+SGT_ROOT="$HOME_DIR/sgt"
+SGT_CONFIG="$SGT_ROOT/.sgt"
+mkdir -p "$SGT_CONFIG/merge-queue"
+
+extract_fn() {
+  local name="$1"
+  awk -v n="$name" '
+    $0 ~ "^" n "\\(\\) \\{" {in_fn=1}
+    in_fn {print}
+    in_fn && $0 == "}" {exit}
+  ' "$SGT_SCRIPT"
+}
+
+eval "$(extract_fn _agent_heartbeat_stale_secs)"
+eval "$(extract_fn _agent_heartbeat_path)"
+eval "$(extract_fn _merge_queue_count_for_rig)"
+eval "$(extract_fn _merge_queue_oldest_age_for_rig)"
+eval "$(extract_fn _heartbeat_snapshot_file)"
+eval "$(extract_fn _agent_heartbeat_snapshot)"
+eval "$(extract_fn _deacon_refinery_watchdog_state)"
+
+old_ts="$(date -u -d "@$(( $(date +%s) - 240 ))" +%Y-%m-%dT%H:%M:%S+00:00)"
+cat > "$SGT_CONFIG/refinery-demo-heartbeat.json" <<HB
+{
+  "timestamp": "$old_ts",
+  "cycle": 4,
+  "pid": 4242,
+  "agent": "refinery",
+  "rig": "demo"
+}
+HB
+
+cat > "$SGT_CONFIG/merge-queue/demo-pr123" <<MQ
+RIG=demo
+PR=123
+QUEUED=$(date -u -d "@$(( $(date +%s) - 600 ))" +%Y-%m-%dT%H:%M:%S+00:00)
+MQ
+
+IFS='|' read -r action reason queue_count oldest_age hb_age hb_ts hb_state hb_stale_secs <<< "$(_deacon_refinery_watchdog_state demo)"
+
+if [[ "$action" != "restart" || "$reason" != "heartbeat-stale" ]]; then
+  echo "expected restart|heartbeat-stale, got $action|$reason" >&2
+  exit 1
+fi
+if [[ "$queue_count" != "1" ]]; then
+  echo "expected queue_count=1, got $queue_count" >&2
+  exit 1
+fi
+if [[ ! "$oldest_age" =~ ^[0-9]+$ || "$oldest_age" -lt 500 ]]; then
+  echo "expected oldest queue age >= 500s, got $oldest_age" >&2
+  exit 1
+fi
+if [[ ! "$hb_age" =~ ^[0-9]+$ || "$hb_age" -lt "$hb_stale_secs" ]]; then
+  echo "expected stale heartbeat age >= threshold, got age=$hb_age threshold=$hb_stale_secs" >&2
+  exit 1
+fi
+
+rm -f "$SGT_CONFIG/merge-queue/demo-pr123"
+IFS='|' read -r action reason queue_count oldest_age hb_age hb_ts hb_state hb_stale_secs <<< "$(_deacon_refinery_watchdog_state demo)"
+if [[ "$action" != "ok" || "$reason" != "queue-empty" ]]; then
+  echo "expected ok|queue-empty once queue is clear, got $action|$reason" >&2
+  exit 1
+fi
+BASH
+
+echo "=== status surfaces degraded refinery with queued backlog ==="
+HOME_DIR="$TMP_ROOT/status-home"
+MOCK_BIN="$TMP_ROOT/mockbin"
+mkdir -p "$HOME_DIR/.local/bin" "$MOCK_BIN"
+cp "$SGT_SCRIPT" "$HOME_DIR/.local/bin/sgt"
+chmod +x "$HOME_DIR/.local/bin/sgt"
+
+cat > "$MOCK_BIN/tmux" <<'TMUX'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "has-session" && "${2:-}" == "-t" ]]; then
+  case "${3:-}" in
+    sgt-witness-demo|sgt-refinery-demo)
+      exit 0
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+fi
+
+exit 1
+TMUX
+chmod +x "$MOCK_BIN/tmux"
+
+env -i \
+  HOME="$HOME_DIR" \
+  PATH="$MOCK_BIN:$HOME_DIR/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+  TERM="${TERM:-xterm}" \
+  SGT_ROOT="$HOME_DIR/sgt" \
+  bash --noprofile --norc -c '
+set -euo pipefail
+
+sgt init >/dev/null
+mkdir -p "$SGT_ROOT/.sgt/rigs"
+printf "https://github.com/acme/demo\n" > "$SGT_ROOT/.sgt/rigs/demo"
+
+old_ts="$(date -u -d "@$(( $(date +%s) - 240 ))" +%Y-%m-%dT%H:%M:%S+00:00)"
+cat > "$SGT_ROOT/.sgt/refinery-demo-heartbeat.json" <<HB
+{
+  "timestamp": "$old_ts",
+  "cycle": 7,
+  "pid": 5252,
+  "agent": "refinery",
+  "rig": "demo"
+}
+HB
+
+cat > "$SGT_ROOT/.sgt/witness-demo-heartbeat.json" <<HB
+{
+  "timestamp": "$old_ts",
+  "cycle": 7,
+  "pid": 6262,
+  "agent": "witness",
+  "rig": "demo"
+}
+HB
+
+cat > "$SGT_ROOT/.sgt/merge-queue/demo-pr123" <<MQ
+POLECAT=demo-pr123
+RIG=demo
+PR=123
+QUEUED=$(date -u -d "@$(( $(date +%s) - 600 ))" +%Y-%m-%dT%H:%M:%S+00:00)
+MQ
+
+sgt status > "$SGT_ROOT/status.out"
+'
+
+STATUS_OUT="$HOME_DIR/sgt/status.out"
+if ! grep -q 'refinery/demo' "$STATUS_OUT"; then
+  echo "expected refinery/demo in status output" >&2
+  exit 1
+fi
+if ! grep -q 'degraded' "$STATUS_OUT"; then
+  echo "expected degraded badge in status output" >&2
+  exit 1
+fi
+if ! grep -q 'queue watchdog: pending=1' "$STATUS_OUT"; then
+  echo "expected queue watchdog summary in status output" >&2
+  exit 1
+fi
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Closes #212

## Summary
- restart refinery from deacon when queued work exists but the refinery heartbeat is stale, missing, or invalid
- surface degraded refinery heartbeat plus queued backlog watchdog details in `sgt status`
- add regression coverage for the deacon watchdog decision and status visibility