### PR TITLE
Close #216 with latest-main proof coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ Run this on a fresh checkout of the latest `master`/mainline commit when you wan
 ./test_self_test_convoy_latest_main_proof.sh
 ```
 
+That proof bundle covers acceptance lifecycle state, worker completion-context relay, mayor follow-up behavior, and the mayor briefing budget/compaction contract on a latest-main checkout.
+
 This proof path intentionally bundles the three convoy checks that matter:
 - `test_plan_completion_acceptance_lifecycle.sh` proves repo plans keep `tasks exhausted + acceptance pending/blocked/verified/waived` states deterministic.
 - `test_worker_prompt_completion_context.sh` proves workers receive the larger completion condition plus acceptance context.

--- a/SGT_CONTEXT.md
+++ b/SGT_CONTEXT.md
@@ -179,3 +179,5 @@ Add a Mayor-side context compaction layer before prompt assembly so the effectiv
 
 This is a feature request against the `sgt` repo / Mayor control-plane behavior.
 ```
+- 2026-03-12T23:51:22+01:00 — 2026-03-12 — Mayor briefing assembly now enforces SGT_MAYOR_PROMPT_BUDGET_TOKENS (default 60000) with protected sections for system status, merge queue, open issues/PRs, active acceptance blockers, pending plan requests, and repo-plan state; noisy history is compacted into summaries and MAYOR_BRIEFING_BUDGET telemetry records budget use plus kept/summarized/omitted sections.
+- 2026-03-12T23:57:00+01:00 — 2026-03-12 — The repo-owned latest-main proof bundle now runs test_mayor_briefing_budget_contract.sh, so mayor prompt-budget/compaction acceptance is covered by ./test_self_test_convoy_latest_main_proof.sh instead of relying on a standalone test invocation.

--- a/test_self_test_convoy_latest_main_proof.sh
+++ b/test_self_test_convoy_latest_main_proof.sh
@@ -8,5 +8,6 @@ REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 bash "$REPO_ROOT/test_plan_completion_acceptance_lifecycle.sh"
 bash "$REPO_ROOT/test_worker_prompt_completion_context.sh"
 bash "$REPO_ROOT/test_mayor_completion_condition_regression.sh"
+bash "$REPO_ROOT/test_mayor_briefing_budget_contract.sh"
 
 echo "SELF-TEST CONVOY LATEST-MAIN PROOF PASSED"


### PR DESCRIPTION
Closes #216

## Summary
- add the mayor briefing budget contract regression to the repo-owned latest-main proof bundle
- document that the proof bundle now covers prompt-budget and compaction acceptance
- record the durable shared-context note for the proof-path update