### PR TITLE
Add latest-main Mayor compaction proof receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Verified Mayor context-compaction acceptance on latest `master` commit `bb6478e1ce0427f27e40d4de6adff2ccad82fcd7`: `./test_mayor_context_compaction_latest_main_proof.sh` and `./test_mayor_briefing_budget_contract.sh` both passed, confirming the configured budget stayed under cap while protected facts and operator-visible budget telemetry survived compaction.
 - Mayor briefing assembly now enforces a configurable prompt budget (`SGT_MAYOR_PROMPT_BUDGET_TOKENS`, default `60000`) with protected-fact sections for active work state, acceptance blockers, pending requests, and repo-plan status.
 - Briefing generation now compacts repeated recent activity / decision churn, records budget usage plus kept-vs-summarized sections inside `~/.sgt/mayor-briefing.md`, and emits structured `MAYOR_BRIEFING_BUDGET` telemetry for operators.
 - `sgt status` and `sgt status --json` now surface the latest mayor briefing budget snapshot so operators can see target/used/protected tokens plus kept-vs-summarized sections without opening the briefing file manually.


### PR DESCRIPTION
Closes #224

Evidence on latest `master` (`bb6478e1ce0427f27e40d4de6adff2ccad82fcd7`):
- `./test_mayor_context_compaction_latest_main_proof.sh` -> `ALL TESTS PASSED` / `MAYOR CONTEXT COMPACTION LATEST-MAIN PROOF PASSED`
- `./test_mayor_briefing_budget_contract.sh` -> `ALL TESTS PASSED`
- The contract test asserts the configured budget stays under cap while preserving active blockers, open issues, open PRs, repo-plan acceptance details, durable latest-main proof context, a recent still-relevant mayor decision, and operator-visible `MAYOR_BRIEFING_BUDGET` / `sgt status` evidence.

Repo note:
- This checkout does not contain a tracked `SGT_PLAN.json` or repo-local plan-state file to flip to `verified`, so the repo change is limited to a deterministic changelog proof receipt.