### PR TITLE
fix: treat issue auto-close as successful merge in refinery verification

### DIFF
--- a/sgt
+++ b/sgt
@@ -3251,8 +3251,11 @@ _refinery_post_merge_verify_and_receipt() {
   if [[ "$pr_state" == "MERGED" && "$issue_state" == "OPEN" && "$branch_deleted" == "true" && -n "$merged_sha" && "$merged_sha" != "none" ]]; then
     outcome="success"
     retry_decision="no-op"
-  elif [[ "$pr_state" == "MERGED" && "$issue_state" != "OPEN" ]]; then
-    retry_decision="no-op-manual-issue-state-drift"
+  elif [[ "$pr_state" == "MERGED" && "$issue_state" != "OPEN" && -n "$merged_sha" && "$merged_sha" != "none" ]]; then
+    # GitHub auto-closes linked issues from "Closes #N" in PR body — issue_state=CLOSED
+    # is expected after merge, not a failure. Treat as success for notification purposes.
+    outcome="success"
+    retry_decision="no-op-issue-auto-closed"
   elif [[ "$pr_state" == "MERGED" && "$branch_deleted" == "unknown" ]]; then
     retry_decision="retry-post-merge-revalidate"
   elif [[ "$pr_state" == "MERGED" && "$branch_deleted" == "false" ]]; then

--- a/test_refinery_post_merge_verification_receipt_fence.sh
+++ b/test_refinery_post_merge_verification_receipt_fence.sh
@@ -64,7 +64,13 @@ if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
   done
   case "$json_fields" in
     labels) echo "sgt-authorized" ;;
-    state) echo "OPEN" ;;
+    state)
+      if [[ "$MODE" == "issue_auto_closed" ]]; then
+        echo "CLOSED"
+      else
+        echo "OPEN"
+      fi
+      ;;
     title) echo "Post merge verification issue" ;;
     body) echo "Issue body" ;;
     *) echo "" ;;
@@ -309,6 +315,26 @@ fi
         return 1
       fi
       ;;
+    issue_auto_closed)
+      # GitHub auto-closes linked issues from "Closes #N" in PR body.
+      # The merge should still be treated as success for notification purposes.
+      if [[ "$(cat "$merge_calls")" != "1" ]]; then
+        echo "expected one merge call for issue_auto_closed" >&2
+        return 1
+      fi
+      if [[ -f "$home_dir/sgt/.sgt/merge-queue/test-pr123" ]]; then
+        echo "expected queue removal on verified success despite issue auto-close" >&2
+        return 1
+      fi
+      if ! grep -q '^OUTCOME=success$' "$receipt_file"; then
+        echo "expected success outcome in receipt despite issue being auto-closed" >&2
+        return 1
+      fi
+      if ! grep -q 'merged successfully' "$home_dir/sgt/refinery-pass1.out"; then
+        echo "expected merged-success signal despite issue auto-close" >&2
+        return 1
+      fi
+      ;;
     *)
       echo "unsupported mode: $mode" >&2
       return 1
@@ -326,5 +352,6 @@ fi
 run_case normal_merge
 run_case stale_api_lag
 run_case partial_receipt_replay
+run_case issue_auto_closed
 
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Summary

- Fixes refinery post-merge verification treating GitHub's auto-close of linked issues (from "Closes #N" in PR body) as a merge failure
- When `pr_state=MERGED` and `issue_state!=OPEN` but merge SHA is valid, outcome is now `success` with `retry=no-op-issue-auto-closed`
- This ensures Mayor wake + agent notification fires correctly after merge

## Test plan

- [x] Added `issue_auto_closed` test case to `test_refinery_post_merge_verification_receipt_fence.sh`
- [x] All existing test cases (`normal_merge`, `stale_api_lag`, `partial_receipt_replay`) still pass
- [x] New test verifies: merge call fires, queue item removed, receipt outcome=success, "merged successfully" output

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)