### PR TITLE
Fix malformed context index recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- `sgt context index` now writes through unique fsynced temp files before `os.replace`, avoiding concurrent rebuild corruption of `~/.sgt/context/<rig>/index.json`.
+- `sgt context search` now detects malformed context indexes, warns once, rebuilds from `SGT_CONTEXT.md`, and retries instead of surfacing a raw JSON decode traceback.
+- Added deterministic malformed-index recovery coverage to `test_context_cli.sh` with a mocked embeddings API.
 - Removed stale Mayor prompt-budget/context-compaction docs and regression hooks that no longer matched runtime behavior.
 - README and shared rig context now describe Mayor briefing generation as it actually exists on `master`: a fresh briefing file with system status, recent activity, queue state, issues/PRs, plan requests, repo plans, escalation rules, and recent decisions.
 - Dropped the nonexistent Mayor budget/compaction proof scripts from repo-owned proof bundles and wake-replay regression aggregation.

--- a/sgt
+++ b/sgt
@@ -4373,6 +4373,7 @@ import json
 import math
 import os
 import sys
+import tempfile
 import urllib.request
 
 rig, context_path, index_path, model, api_key = sys.argv[1:6]
@@ -4428,14 +4429,23 @@ doc = {
     "model": model,
     "source_path": context_path,
     "source_mtime": int(os.path.getmtime(context_path)),
-    "indexed_at": __import__("datetime").datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+    "indexed_at": __import__("datetime").datetime.now(__import__("datetime").timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
     "entries": entries,
 }
 
-tmp_path = index_path + ".tmp"
-with open(tmp_path, "w", encoding="utf-8") as fh:
-    json.dump(doc, fh, ensure_ascii=True)
-os.replace(tmp_path, index_path)
+index_dir = os.path.dirname(index_path) or "."
+tmp_fd, tmp_path = tempfile.mkstemp(prefix=".index.", suffix=".json.tmp", dir=index_dir)
+try:
+    with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+        json.dump(doc, fh, ensure_ascii=True)
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp_path, index_path)
+finally:
+    try:
+        os.unlink(tmp_path)
+    except FileNotFoundError:
+        pass
 print(index_path)
 PY
 }
@@ -4449,7 +4459,7 @@ _context_index_is_fresh() {
 }
 
 _context_search_run() {
-  local rig="${1:-}" query="${2:-}" index_path py_bin model api_key context_file
+  local rig="${1:-}" query="${2:-}" index_path py_bin model api_key context_file search_rc retrying err_file
   [[ -n "$query" ]] || die "usage: sgt context search <rig> <query>"
   context_file="$(_ensure_context_file "$rig")"
   if ! _context_index_is_fresh "$rig"; then
@@ -4460,7 +4470,11 @@ _context_search_run() {
   _require_context_api_key
   model="$(_context_embedding_model)"
   api_key="${OPENAI_API_KEY:-}"
-  "$py_bin" - "$rig" "$index_path" "$model" "$api_key" "$query" <<'PY'
+  retrying=0
+  err_file="$(mktemp)"
+  while true; do
+    set +e
+    "$py_bin" - "$rig" "$index_path" "$model" "$api_key" "$query" 2>"$err_file" <<'PY'
 import json
 import math
 import sys
@@ -4468,8 +4482,12 @@ import urllib.request
 
 rig, index_path, model, api_key, query = sys.argv[1:6]
 
-with open(index_path, "r", encoding="utf-8") as fh:
-    index = json.load(fh)
+try:
+    with open(index_path, "r", encoding="utf-8") as fh:
+        index = json.load(fh)
+except (OSError, json.JSONDecodeError) as exc:
+    print(f"malformed context index at {index_path}: {exc}", file=sys.stderr)
+    raise SystemExit(86)
 
 entries = index.get("entries") or []
 if not entries:
@@ -4519,6 +4537,27 @@ for score, entry in top:
     text = entry.get("text") or ""
     print(f"{score:.3f}\t{date}\tline {line}\t{text}")
 PY
+    search_rc=$?
+    set -e
+    if [[ "$search_rc" -eq 0 ]]; then
+      cat "$err_file" >&2
+      rm -f "$err_file"
+      return 0
+    fi
+    if [[ "$search_rc" -eq 86 ]] && [[ "$retrying" -eq 0 ]]; then
+      retrying=1
+      warn "context index for rig '$rig' was malformed; rebuilding"
+      _context_index_build "$rig" >/dev/null || die "failed to rebuild malformed context index for rig '$rig'"
+      continue
+    fi
+    if [[ "$search_rc" -eq 86 ]]; then
+      rm -f "$err_file"
+      die "context index for rig '$rig' is malformed and rebuild did not recover it"
+    fi
+    cat "$err_file" >&2
+    rm -f "$err_file"
+    return "$search_rc"
+  done
 }
 
 cmd_context() {

--- a/test_context_cli.sh
+++ b/test_context_cli.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# test_context_cli.sh — Validate context help/syntax and missing OPENAI_API_KEY failures.
+# test_context_cli.sh — Validate context CLI help/syntax, missing-key failures, and malformed-index recovery.
 
 set -euo pipefail
 
@@ -12,6 +12,55 @@ trap 'rm -rf "$TMP_HOME"' EXIT
 mkdir -p "$TMP_HOME/.local/bin"
 cp "$SGT_SCRIPT" "$TMP_HOME/.local/bin/sgt"
 chmod +x "$TMP_HOME/.local/bin/sgt"
+MOCK_PYTHONPATH="$TMP_HOME/mock-python"
+mkdir -p "$MOCK_PYTHONPATH"
+
+cat >"$MOCK_PYTHONPATH/sitecustomize.py" <<'PY'
+import json
+import urllib.request
+
+
+class _MockResponse:
+    def __init__(self, body):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def _embed_text(text):
+    total = sum(ord(ch) for ch in text)
+    length = len(text)
+    return [float(length or 1), float((total % 97) + 1), float((total % 53) + 1)]
+
+
+_real_urlopen = urllib.request.urlopen
+
+
+def _mock_urlopen(req, timeout=60):
+    url = getattr(req, "full_url", "")
+    if url == "https://api.openai.com/v1/embeddings":
+        payload = json.loads(req.data.decode("utf-8"))
+        input_value = payload.get("input")
+        if isinstance(input_value, list):
+            texts = input_value
+        else:
+            texts = [input_value]
+        body = {
+            "data": [{"embedding": _embed_text(text or "")} for text in texts],
+        }
+        return _MockResponse(json.dumps(body).encode("utf-8"))
+    return _real_urlopen(req, timeout=timeout)
+
+
+urllib.request.urlopen = _mock_urlopen
+PY
 
 run_cmd() {
   local command="$1"
@@ -25,6 +74,26 @@ run_cmd() {
     HOME="$TMP_HOME" \
     PATH="$TMP_HOME/.local/bin:/usr/local/bin:/usr/bin:/bin" \
     TERM="${TERM:-xterm}" \
+    bash --noprofile --norc -c "$command" >"$out_file" 2>"$err_file"
+  rc=$?
+  set -e
+  echo "$rc" >"$rc_file"
+}
+
+run_cmd_mock_embeddings() {
+  local command="$1"
+  local out_file="$2"
+  local err_file="$3"
+  local rc_file="$4"
+  local rc
+
+  set +e
+  env -i \
+    HOME="$TMP_HOME" \
+    PATH="$TMP_HOME/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+    TERM="${TERM:-xterm}" \
+    OPENAI_API_KEY="test-key" \
+    PYTHONPATH="$MOCK_PYTHONPATH" \
     bash --noprofile --norc -c "$command" >"$out_file" 2>"$err_file"
   rc=$?
   set -e
@@ -77,8 +146,11 @@ INDEX_RC="$(mktemp)"
 SEARCH_OUT="$(mktemp)"
 SEARCH_ERR="$(mktemp)"
 SEARCH_RC="$(mktemp)"
+RECOVER_OUT="$(mktemp)"
+RECOVER_ERR="$(mktemp)"
+RECOVER_RC="$(mktemp)"
 
-trap 'rm -rf "$TMP_HOME" "$BASE_OUT" "$BASE_ERR" "$BASE_RC" "$HELPFLAG_OUT" "$HELPFLAG_ERR" "$HELPFLAG_RC" "$HELPWORD_OUT" "$HELPWORD_ERR" "$HELPWORD_RC" "$BAD_OUT" "$BAD_ERR" "$BAD_RC" "$PATH_OUT" "$PATH_ERR" "$PATH_RC" "$INDEX_OUT" "$INDEX_ERR" "$INDEX_RC" "$SEARCH_OUT" "$SEARCH_ERR" "$SEARCH_RC"' EXIT
+trap 'rm -rf "$TMP_HOME" "$BASE_OUT" "$BASE_ERR" "$BASE_RC" "$HELPFLAG_OUT" "$HELPFLAG_ERR" "$HELPFLAG_RC" "$HELPWORD_OUT" "$HELPWORD_ERR" "$HELPWORD_RC" "$BAD_OUT" "$BAD_ERR" "$BAD_RC" "$PATH_OUT" "$PATH_ERR" "$PATH_RC" "$INDEX_OUT" "$INDEX_ERR" "$INDEX_RC" "$SEARCH_OUT" "$SEARCH_ERR" "$SEARCH_RC" "$RECOVER_OUT" "$RECOVER_ERR" "$RECOVER_RC"' EXIT
 
 run_cmd "sgt context" "$BASE_OUT" "$BASE_ERR" "$BASE_RC"
 run_cmd "sgt context --help" "$HELPFLAG_OUT" "$HELPFLAG_ERR" "$HELPFLAG_RC"
@@ -132,6 +204,12 @@ check_equals "context index without key writes no stdout" "$(wc -c <"$INDEX_OUT"
 check_equals "context search without key writes no stdout" "$(wc -c <"$SEARCH_OUT" | tr -d ' ')" "0"
 check_file_contains "context index missing key error is explicit" "$INDEX_ERR" "^sgt: OPENAI_API_KEY is required for 'sgt context index' and 'sgt context search'$"
 check_file_contains "context search missing key error is explicit" "$SEARCH_ERR" "^sgt: OPENAI_API_KEY is required for 'sgt context index' and 'sgt context search'$"
+
+run_cmd_mock_embeddings "sgt init >/dev/null && mkdir -p \"\$HOME/sgt/.sgt/rigs\" \"\$HOME/sgt/rigs/demo\" && printf '%s\n' 'https://github.com/acme/demo' > \"\$HOME/sgt/.sgt/rigs/demo\" && sgt context add demo 'remember the watchdog cooldown' >/dev/null && sgt context index demo >/dev/null && printf '%s' '}{broken-json' >> \"\$HOME/sgt/.sgt/context/demo/index.json\" && sgt context search demo 'watchdog cooldown'" "$RECOVER_OUT" "$RECOVER_ERR" "$RECOVER_RC"
+
+check_file_contains "context search recovers from malformed index exits 0" "$RECOVER_RC" '^0$'
+check_file_contains "context search recovery warns explicitly" "$RECOVER_ERR" "^⚠ context index for rig 'demo' was malformed; rebuilding$"
+check_file_contains "context search recovery returns the matching entry" "$RECOVER_OUT" 'watchdog cooldown'
 
 if [[ "$FAIL" -ne 0 ]]; then
   exit 1


### PR DESCRIPTION
Closes #240

## Summary
- rebuild malformed context indexes on search instead of crashing with JSON decode errors
- harden index writes with unique fsynced temp files before atomic replace
- add malformed-index recovery regression coverage with mocked embeddings