### PR TITLE
fix: clean stale polecat state after failed spawn

### DIFF
--- a/sgt
+++ b/sgt
@@ -2011,6 +2011,33 @@ _mayor_stale_polecat_pr_snapshot() {
   echo "$snapshot"
 }
 
+_cleanup_failed_polecat_dispatch() {
+  local pfile="${1:-}" pname="${2:-}" rig="${3:-}" branch="${4:-}" session="${5:-}" worktree="${6:-}"
+  local rpath=""
+
+  if [[ -n "$session" ]] && tmux has-session -t "$session" 2>/dev/null; then
+    tmux kill-session -t "$session" 2>/dev/null || true
+  fi
+
+  if [[ -n "$rig" ]]; then
+    rpath="$(rig_path "$rig" 2>/dev/null || true)"
+  fi
+
+  if [[ -n "$worktree" && -d "$worktree" ]]; then
+    if [[ -n "$rpath" ]]; then
+      git -C "$rpath" worktree remove --force "$worktree" 2>/dev/null || rm -rf "$worktree" 2>/dev/null || true
+    else
+      rm -rf "$worktree" 2>/dev/null || true
+    fi
+  fi
+
+  rm -f "$pfile" 2>/dev/null || true
+
+  if [[ -n "$rpath" && -n "$branch" ]]; then
+    git -C "$rpath" branch -D "$branch" 2>/dev/null || true
+  fi
+}
+
 _mayor_cleanup_stale_polecat() {
   local pfile="${1:-}" pname="${2:-}" rig="${3:-}" repo="${4:-}" issue="${5:-}" branch="${6:-}" session="${7:-}" worktree="${8:-}" reason_code="${9:-}" issue_state="${10:-}" pr_number="${11:-}" pr_state="${12:-}"
   local owner_repo key key_id fence_dir cleanup_marker decision_marker action
@@ -2125,11 +2152,69 @@ _mayor_reconcile_stale_polecats() {
       reason_code="stale-pr-merged"
     elif [[ "$pr_state" == "CLOSED" ]]; then
       reason_code="stale-pr-closed"
+    elif [[ "$pr_number" == "0" && "$issue_state" == "OPEN" ]]; then
+      reason_code="stale-no-pr-dead-session"
     fi
     [[ -n "$reason_code" ]] || continue
 
     _mayor_cleanup_stale_polecat "$pfile" "$pname" "$rig" "$repo" "$issue" "$branch" "$session" "$worktree" "$reason_code" "$issue_state" "$pr_number" "$pr_state"
   done
+}
+
+_polecat_start_grace_secs() {
+  local raw="${SGT_POLECAT_START_GRACE_SECS:-15}"
+  if [[ ! "$raw" =~ ^[0-9]+$ ]]; then
+    raw="15"
+  fi
+  echo "$raw"
+}
+
+_polecat_counts_as_active() {
+  local pfile="${1:-}" rig_filter="${2:-}"
+  local pname snapshot rig repo issue branch session worktree status created
+  local created_epoch now_epoch grace_secs age_secs
+
+  [[ -f "$pfile" ]] || return 1
+  pname="$(basename "$pfile")"
+  if [[ -n "$rig_filter" && "$pname" != "${rig_filter}-"* ]]; then
+    return 1
+  fi
+
+  snapshot="$(
+    (
+      source "$pfile"
+      printf '%s|%s|%s|%s|%s|%s|%s|%s\n' \
+        "${RIG:-}" "${REPO:-}" "${ISSUE:-}" "${BRANCH:-}" "${SESSION:-}" "${WORKTREE:-}" "${STATUS:-}" "${CREATED:-}"
+    ) 2>/dev/null
+  )"
+  IFS='|' read -r rig repo issue branch session worktree status created <<< "$snapshot"
+
+  if [[ -n "$rig_filter" && -n "$rig" && "$rig" != "$rig_filter" ]]; then
+    return 1
+  fi
+
+  if [[ -n "$session" ]] && tmux has-session -t "$session" 2>/dev/null; then
+    return 0
+  fi
+
+  if [[ "$status" == "running" && -n "$worktree" && -d "$worktree" ]]; then
+    grace_secs="$(_polecat_start_grace_secs)"
+    created_epoch="$(date -d "$created" +%s 2>/dev/null || true)"
+    now_epoch="$(date +%s)"
+    if [[ "$created_epoch" =~ ^[0-9]+$ && "$now_epoch" =~ ^[0-9]+$ ]]; then
+      age_secs=$((now_epoch - created_epoch))
+      if (( age_secs >= 0 && age_secs <= grace_secs )); then
+        return 0
+      fi
+    fi
+  fi
+
+  if [[ -n "$worktree" && ! -d "$worktree" ]]; then
+    rm -f "$pfile" 2>/dev/null || true
+    log_event "POLECAT_COUNT_AUTO_PRUNE polecat=$pname reason_code=dead-session-missing-worktree rig=${rig:-unknown} issue=#${issue:-unknown} branch=\"$(_escape_quotes "$branch")\""
+  fi
+
+  return 1
 }
 
 _mayor_wake_dedupe_ttl_secs() {
@@ -2401,12 +2486,11 @@ _active_polecat_count() {
     return 0
   }
 
-  local pf pname
+  local pf
   for pf in "$SGT_POLECATS"/*; do
     [[ -f "$pf" ]] || continue
-    pname="$(basename "$pf")"
-    if [[ -n "$rig" ]]; then
-      [[ "$pname" == "${rig}-"* ]] || continue
+    if ! _polecat_counts_as_active "$pf" "$rig"; then
+      continue
     fi
     count=$((count + 1))
   done
@@ -6894,8 +6978,20 @@ PSTATE
   local polecat_prompt
   polecat_prompt="$(_build_polecat_runtime_prompt "$rig" "$issue_number" "$task" "$branch" "$rpath")"
 
-  tmux new-session -d -s "$session_name" -c "$worktree" \
-    "$( _ai_session_cmd "$backend" "$polecat_prompt" "$worktree/.sgt-agent-output.log" ); rc=\$?; echo '[SGT] polecat exited'; sgt _wake-refinery '${rig}' 'polecat-done:${pname}:#${issue_number}' 2>/dev/null; exit \$rc"
+  local tmux_error dispatch_reason_code
+  if ! tmux_error="$(
+    tmux new-session -d -s "$session_name" -c "$worktree" \
+      "$( _ai_session_cmd "$backend" "$polecat_prompt" "$worktree/.sgt-agent-output.log" ); rc=\$?; echo '[SGT] polecat exited'; sgt _wake-refinery '${rig}' 'polecat-done:${pname}:#${issue_number}' 2>/dev/null; exit \$rc" \
+      2>&1
+  )"; then
+    dispatch_reason_code="tmux-new-session-failed"
+    if [[ "${tmux_error,,}" == *"command too long"* ]]; then
+      dispatch_reason_code="command-too-long"
+    fi
+    _cleanup_failed_polecat_dispatch "$SGT_POLECATS/$pname" "$pname" "$rig" "$branch" "$session_name" "$worktree"
+    log_event "SLING_SPAWN_FAILED polecat=$pname rig=$rig issue=#$issue_number branch=$branch reason_code=$dispatch_reason_code detail=\"$(_escape_quotes "${tmux_error:-tmux new-session returned non-zero exit status}")\""
+    die "failed to spawn polecat '$pname': ${tmux_error:-tmux new-session returned non-zero exit status}"
+  fi
 
   # Auto-accept Claude Code workspace trust dialog if it appears
   if [[ "$backend" == "claude" ]]; then
@@ -7885,12 +7981,15 @@ _sweep_try_resilient_cleanup() {
   fi
 
   issue_state="$(gh issue view "$issue" --repo "$canonical_repo" --json state --jq '.state // ""' 2>/dev/null || true)"
-  if [[ "$issue_state" != "CLOSED" ]]; then
-    log_event "SWEEP_RESILIENT_SKIP polecat=$pname issue=#${issue:-unknown} reason_code=issue-not-closed issue_state=${issue_state:-unknown}"
+  if [[ "$issue_state" == "CLOSED" ]]; then
+    cleanup_reason="sweep-pr-lookup-race-issue-closed"
+  elif [[ "$issue_state" == "OPEN" ]]; then
+    cleanup_reason="sweep-dead-no-pr-open-issue"
+  else
+    log_event "SWEEP_RESILIENT_SKIP polecat=$pname issue=#${issue:-unknown} reason_code=issue-not-actionable issue_state=${issue_state:-unknown}"
     return 1
   fi
 
-  cleanup_reason="sweep-pr-lookup-race-issue-closed"
   cleanup_line="$(_mayor_cleanup_stale_polecat "$pfile" "$pname" "$rig" "$repo" "$issue" "$branch" "$session" "$worktree" "$cleanup_reason" "$issue_state" "" "UNAVAILABLE" 2>/dev/null || true)"
   if [[ "$cleanup_line" == CLEANED\|* ]]; then
     owner_repo="$(_repo_owner_repo "$repo")"
@@ -8554,8 +8653,21 @@ PSTATE
 
   local polecat_prompt
   polecat_prompt="$(_build_polecat_runtime_prompt "$rig" "$issue_number" "$task" "$branch" "$rpath")"
-  tmux new-session -d -s "$session_name" -c "$worktree" \
-    "$( _ai_session_cmd "$backend" "$polecat_prompt" "$worktree/.sgt-agent-output.log" ); rc=\$?; echo '[SGT] polecat exited'; sgt _wake-refinery '${rig}' 'polecat-done:${pname}:#${issue_number}' 2>/dev/null; exit \$rc"
+  local tmux_error dispatch_reason_code
+  if ! tmux_error="$(
+    tmux new-session -d -s "$session_name" -c "$worktree" \
+      "$( _ai_session_cmd "$backend" "$polecat_prompt" "$worktree/.sgt-agent-output.log" ); rc=\$?; echo '[SGT] polecat exited'; sgt _wake-refinery '${rig}' 'polecat-done:${pname}:#${issue_number}' 2>/dev/null; exit \$rc" \
+      2>&1
+  )"; then
+    dispatch_reason_code="tmux-new-session-failed"
+    if [[ "${tmux_error,,}" == *"command too long"* ]]; then
+      dispatch_reason_code="command-too-long"
+    fi
+    _cleanup_failed_polecat_dispatch "$SGT_POLECATS/$pname" "$pname" "$rig" "$branch" "$session_name" "$worktree"
+    log_event "RESLING_SPAWN_FAILED polecat=$pname rig=$rig issue=#$issue_number branch=$branch source_event=$source_event source_event_key=\"$(_escape_quotes "$source_event_key")\" reason_code=$dispatch_reason_code detail=\"$(_escape_quotes "${tmux_error:-tmux new-session returned non-zero exit status}")\""
+    echo "[resling] dispatch failed ($source_event) for issue #$issue_number — ${tmux_error:-tmux new-session returned non-zero exit status}" >&2
+    return 1
+  fi
 
   # Auto-accept Claude Code workspace trust dialog if it appears
   if [[ "$backend" == "claude" ]]; then

--- a/test_mayor_live_polecat_count_regression.sh
+++ b/test_mayor_live_polecat_count_regression.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# test_mayor_live_polecat_count_regression.sh — dead stale polecat files must not count as live in mayor revalidation.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+extract_fn() {
+  local name="$1"
+  awk -v n="$name" '
+    $0 ~ "^" n "\\(\\) \\{" {in_fn=1}
+    in_fn {print}
+    in_fn && $0 == "}" {exit}
+  ' "$SGT_SCRIPT"
+}
+
+eval "$(extract_fn _one_line)"
+eval "$(extract_fn _escape_quotes)"
+eval "$(extract_fn _polecat_start_grace_secs)"
+eval "$(extract_fn _polecat_counts_as_active)"
+eval "$(extract_fn _active_polecat_count)"
+
+export SGT_ROOT="$TMP_ROOT/root"
+export SGT_CONFIG="$SGT_ROOT/.sgt"
+export SGT_POLECATS="$SGT_CONFIG/polecats"
+export SGT_LOG="$TMP_ROOT/sgt.log"
+mkdir -p "$SGT_POLECATS" "$SGT_ROOT/polecats"
+
+log_event() {
+  local line="${1:-}"
+  printf '%s\n' "$line" >> "$SGT_LOG"
+}
+
+tmux() {
+  if [[ "${1:-}" == "has-session" ]]; then
+    return 1
+  fi
+  echo "mock tmux unsupported: $*" >&2
+  return 1
+}
+
+stale_worktree="$SGT_ROOT/polecats/sgt-stale"
+mkdir -p "$stale_worktree"
+cat > "$SGT_POLECATS/sgt-stale" <<EOF
+RIG=sgt
+REPO=https://github.com/codejeet/sgt
+ISSUE=251
+BRANCH=sgt/sgt-stale
+SESSION=sgt-sgt-stale
+WORKTREE=$stale_worktree
+CREATED=2026-03-26T20:00:00+01:00
+STATUS=running
+EOF
+
+starting_worktree="$SGT_ROOT/polecats/sgt-starting"
+mkdir -p "$starting_worktree"
+cat > "$SGT_POLECATS/sgt-starting" <<EOF
+RIG=sgt
+REPO=https://github.com/codejeet/sgt
+ISSUE=252
+BRANCH=sgt/sgt-starting
+SESSION=sgt-sgt-starting
+WORKTREE=$starting_worktree
+CREATED=$(date -Iseconds)
+STATUS=running
+EOF
+
+if [[ "$(_active_polecat_count sgt)" != "1" ]]; then
+  echo "expected only the fresh starting polecat to count as active" >&2
+  exit 1
+fi
+
+rm -rf "$starting_worktree"
+if [[ "$(_active_polecat_count sgt)" != "0" ]]; then
+  echo "expected dead stale polecat files to stop counting as active once startup grace expires or worktree disappears" >&2
+  exit 1
+fi
+
+if [[ -f "$SGT_POLECATS/sgt-starting" ]]; then
+  echo "expected missing-worktree dead polecat state to be auto-pruned" >&2
+  exit 1
+fi
+
+if ! grep -q 'POLECAT_COUNT_AUTO_PRUNE polecat=sgt-starting reason_code=dead-session-missing-worktree' "$SGT_LOG"; then
+  echo "expected structured auto-prune telemetry for missing-worktree stale polecat state" >&2
+  exit 1
+fi
+
+echo "ALL TESTS PASSED"

--- a/test_mayor_stale_polecat_revalidation_fence.sh
+++ b/test_mayor_stale_polecat_revalidation_fence.sh
@@ -299,4 +299,42 @@ if [[ -f "$closed_polecat_file" ]]; then
   exit 1
 fi
 
+# Case 7: dead session + open issue + no PR => cleanup failed-dispatch residue.
+no_pr_polecat_file="$SGT_POLECATS/rig-one-cat-nopr"
+no_pr_worktree="$SGT_ROOT/worktree/rig-one-cat-nopr"
+mkdir -p "$no_pr_worktree"
+cat > "$no_pr_polecat_file" <<PSTATE
+RIG=rig-one
+REPO=https://github.com/acme/demo
+ISSUE=117
+BRANCH=sgt/rig-one-cat-nopr
+SESSION=sgt-rig-one-cat-nopr
+WORKTREE=$no_pr_worktree
+STATUS=running
+PSTATE
+GH_PR_NUMBER="0"
+GH_PR_STATE=""
+GH_ISSUE_STATE="OPEN"
+mapfile -t case7_lines < <(_mayor_reconcile_stale_polecats)
+if [[ "${#case7_lines[@]}" -ne 1 ]]; then
+  echo "expected exactly one dead-no-pr stale cleanup action" >&2
+  exit 1
+fi
+if [[ "${case7_lines[0]}" != CLEANED\|rig-one-cat-nopr\|stale-no-pr-dead-session\|* ]]; then
+  echo "unexpected dead-no-pr cleanup payload: ${case7_lines[0]}" >&2
+  exit 1
+fi
+if [[ -f "$no_pr_polecat_file" ]]; then
+  echo "expected dead-no-pr polecat state file to be removed" >&2
+  exit 1
+fi
+if [[ -d "$no_pr_worktree" ]]; then
+  echo "expected dead-no-pr polecat worktree to be removed" >&2
+  exit 1
+fi
+if [[ "$(grep -c 'MAYOR_POLECAT_CLEANUP reason_code=stale-no-pr-dead-session polecat=rig-one-cat-nopr' "$SGT_LOG" || true)" -ne 1 ]]; then
+  echo "expected dead-no-pr cleanup activity log entry" >&2
+  exit 1
+fi
+
 echo "ALL TESTS PASSED"

--- a/test_sling_spawn_failure_cleanup.sh
+++ b/test_sling_spawn_failure_cleanup.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# test_sling_spawn_failure_cleanup.sh — Spawn failures must not leave stale polecat bookkeeping behind.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+HOME_DIR="$TMP_ROOT/home"
+MOCK_BIN="$TMP_ROOT/mockbin"
+mkdir -p "$HOME_DIR/.local/bin" "$MOCK_BIN"
+cp "$SGT_SCRIPT" "$HOME_DIR/.local/bin/sgt"
+chmod +x "$HOME_DIR/.local/bin/sgt"
+
+BRANCH_DELETE_LOG="$TMP_ROOT/branch-delete.log"
+
+cat > "$MOCK_BIN/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "label" && "${2:-}" == "create" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
+  echo "https://github.com/acme/demo/issues/251"
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "edit" ]]; then
+  exit 0
+fi
+
+echo "mock gh unsupported: $*" >&2
+exit 1
+GH
+chmod +x "$MOCK_BIN/gh"
+
+cat > "$MOCK_BIN/git" <<'GIT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRANCH_DELETE_LOG="${SGT_TEST_BRANCH_DELETE_LOG:?missing branch delete log}"
+
+if [[ "${1:-}" == "-C" ]]; then
+  shift 2
+fi
+
+if [[ "${1:-}" == "fetch" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "symbolic-ref" ]]; then
+  echo "refs/remotes/origin/master"
+  exit 0
+fi
+
+if [[ "${1:-}" == "worktree" && "${2:-}" == "add" ]]; then
+  mkdir -p "${5:?missing worktree path}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "worktree" && "${2:-}" == "remove" ]]; then
+  rm -rf "${4:?missing worktree path}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "branch" && "${2:-}" == "-D" ]]; then
+  printf '%s\n' "${3:-}" >> "$BRANCH_DELETE_LOG"
+  exit 0
+fi
+
+echo "mock git unsupported: $*" >&2
+exit 1
+GIT
+chmod +x "$MOCK_BIN/git"
+
+cat > "$MOCK_BIN/tmux" <<'TMUX'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "has-session" ]]; then
+  exit 1
+fi
+
+if [[ "${1:-}" == "new-session" ]]; then
+  echo "command too long" >&2
+  exit 1
+fi
+
+echo "mock tmux unsupported: $*" >&2
+exit 1
+TMUX
+chmod +x "$MOCK_BIN/tmux"
+
+env -i \
+  HOME="$HOME_DIR" \
+  PATH="$MOCK_BIN:$HOME_DIR/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+  TERM="${TERM:-xterm}" \
+  SGT_ROOT="$HOME_DIR/sgt" \
+  SGT_TEST_BRANCH_DELETE_LOG="$BRANCH_DELETE_LOG" \
+  bash --noprofile --norc -c '
+set -euo pipefail
+
+sgt init >/dev/null
+mkdir -p "$SGT_ROOT/rigs/test"
+printf "https://github.com/acme/demo\n" > "$SGT_ROOT/.sgt/rigs/test"
+
+set +e
+sgt sling test "spawn failure cleanup regression" --label critical > "$SGT_ROOT/sling.out" 2> "$SGT_ROOT/sling.err"
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected sling to fail when tmux spawn returns command too long" >&2
+  exit 1
+fi
+
+if ! grep -q "failed to spawn polecat" "$SGT_ROOT/sling.err"; then
+  echo "expected explicit spawn failure error" >&2
+  cat "$SGT_ROOT/sling.err" >&2
+  exit 1
+fi
+
+if find "$SGT_ROOT/.sgt/polecats" -type f | grep -q .; then
+  echo "expected no polecat state files after failed spawn cleanup" >&2
+  find "$SGT_ROOT/.sgt/polecats" -type f >&2
+  exit 1
+fi
+
+worktree_path="$(find "$SGT_ROOT/polecats" -mindepth 1 -maxdepth 1 -type d | head -n1 || true)"
+if [[ -n "$worktree_path" ]]; then
+  echo "expected failed spawn cleanup to remove worktree residue" >&2
+  find "$SGT_ROOT/polecats" -mindepth 1 -maxdepth 1 -type d >&2
+  exit 1
+fi
+
+if ! grep -q "^sgt/" "'"$BRANCH_DELETE_LOG"'"; then
+  echo "expected failed spawn cleanup to delete the local branch" >&2
+  cat "'"$BRANCH_DELETE_LOG"'" >&2
+  exit 1
+fi
+
+if ! grep -q "SLING_SPAWN_FAILED .*reason_code=command-too-long" "$SGT_ROOT/sgt.log"; then
+  echo "expected structured spawn failure log entry" >&2
+  cat "$SGT_ROOT/sgt.log" >&2
+  exit 1
+fi
+'
+
+echo "ALL TESTS PASSED"

--- a/test_sweep_stability.sh
+++ b/test_sweep_stability.sh
@@ -42,6 +42,9 @@ if [[ "$args" == *" pr list "* ]]; then
     lookup_race)
       echo ""
       ;;
+    dead_no_pr_open)
+      echo ""
+      ;;
     *)
       echo "unknown gh mode: $mode" >&2
       exit 1
@@ -54,6 +57,9 @@ if [[ "$args" == *" issue view "* && "$args" == *" --json state "* ]]; then
   case "$mode" in
     lookup_race)
       echo "CLOSED"
+      ;;
+    dead_no_pr_open)
+      echo "OPEN"
       ;;
     *)
       echo "OPEN"
@@ -196,6 +202,60 @@ fi
 if ! grep -q "MAYOR POLECAT CLEANUP reason_code=sweep-pr-lookup-race-issue-closed polecat=test-race1111" "$SGT_ROOT/.sgt/mayor-decisions.log"; then
   echo "expected decision-log reason code for fallback cleanup path" >&2
   cat "$SGT_ROOT/.sgt/mayor-decisions.log" >&2
+  exit 1
+fi
+'
+
+"${ENV_PREFIX[@]}" bash --noprofile --norc -c '
+set -euo pipefail
+
+worktree="$SGT_ROOT/polecats/test-open-no-pr"
+mkdir -p "$worktree"
+cat > "$SGT_ROOT/.sgt/polecats/test-open-no-pr" <<STATE
+RIG=test
+REPO=https://github.com/acme/demo
+ISSUE=72
+BRANCH=sgt/test-open-no-pr
+WORKTREE=$worktree
+SESSION=sgt-test-open-no-pr
+DEFAULT_BRANCH=master
+STATE
+
+set +e
+SGT_TEST_GH_MODE=dead_no_pr_open sgt sweep > "$SGT_ROOT/sweep-open-no-pr.out" 2> "$SGT_ROOT/sweep-open-no-pr.err"
+sweep_rc=$?
+set -e
+
+if [[ "$sweep_rc" -ne 0 ]]; then
+  echo "expected sweep to clean dead no-PR residue and succeed, got exit $sweep_rc" >&2
+  exit 1
+fi
+
+if [[ -s "$SGT_ROOT/sweep-open-no-pr.err" ]]; then
+  echo "expected no stderr for dead no-PR cleanup path" >&2
+  cat "$SGT_ROOT/sweep-open-no-pr.err" >&2
+  exit 1
+fi
+
+if ! grep -q "completed (fallback: reason_code=sweep-dead-no-pr-open-issue) — cleaning up" "$SGT_ROOT/sweep-open-no-pr.out"; then
+  echo "expected explicit dead no-PR cleanup line in sweep output" >&2
+  cat "$SGT_ROOT/sweep-open-no-pr.out" >&2
+  exit 1
+fi
+
+if [[ -f "$SGT_ROOT/.sgt/polecats/test-open-no-pr" ]]; then
+  echo "expected dead no-PR cleanup to remove polecat state file" >&2
+  exit 1
+fi
+
+if [[ -d "$worktree" ]]; then
+  echo "expected dead no-PR cleanup to remove polecat worktree" >&2
+  exit 1
+fi
+
+if ! grep -q "SWEEP_RESILIENT_CLEANUP reason_code=sweep-dead-no-pr-open-issue polecat=test-open-no-pr" "$SGT_ROOT/sgt.log"; then
+  echo "expected dead no-PR resilient cleanup activity log entry" >&2
+  cat "$SGT_ROOT/sgt.log" >&2
   exit 1
 fi
 '


### PR DESCRIPTION
## Summary
- clean up polecat state/worktree/branch when sling or resling fails before tmux session startup
- stop counting dead startup residue as active polecats after the short startup grace window
- let stale no-PR dead-session leftovers be reconciled/pruned instead of wedging mayor consistency checks

## Tests
- ./test_mayor_live_polecat_count_regression.sh
- ./test_sling_spawn_failure_cleanup.sh
- ./test_mayor_stale_polecat_revalidation_fence.sh
- ./test_sweep_stability.sh
- ./test_mayor_cross_source_consistency.sh

Closes #251.
