### PR TITLE
Fix oversized polecat tmux launch payloads

### DIFF
--- a/sgt
+++ b/sgt
@@ -6516,6 +6516,35 @@ _ai_session_cmd() {
   printf '%s' "$backend_cmd"
 }
 
+_ai_session_cmd_from_file() {
+  # Print a command that runs the selected backend using a prompt file instead of
+  # embedding the full prompt text into the tmux command string.
+  # Usage: _ai_session_cmd_from_file <backend> <prompt_file> [output_log]
+  local backend="$1" prompt_file="$2" output_log="${3:-}"
+  local backend_cmd prompt_basename
+  prompt_basename="$(basename "$prompt_file")"
+  case "$backend" in
+    claude)
+      backend_cmd="$(printf 'unset CLAUDECODE; IS_SANDBOX=1 claude %q --dangerously-skip-permissions' "Read ${prompt_basename} and follow it exactly.")"
+      ;;
+    codex)
+      backend_cmd="$(printf 'OPENAI_BASE_URL= OPENAI_API_BASE= OPENAI_HOST= codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --color auto - < %q' "$prompt_file")"
+      ;;
+    *)
+      die "unknown backend: $backend"
+      ;;
+  esac
+  if [[ -n "$output_log" ]]; then
+    if command -v script >/dev/null 2>&1; then
+      printf 'rm -f %q; script -qefc %q %q' "$output_log" "$backend_cmd" "$output_log"
+      return 0
+    fi
+    printf 'rm -f %q; %s' "$output_log" "$backend_cmd"
+    return 0
+  fi
+  printf '%s' "$backend_cmd"
+}
+
 _ai_promptfile() {
   # Run a backend using a prompt read from a file; echoes agent output to stdout.
   # Usage: _ai_promptfile <backend> <workdir> <prompt_file>
@@ -6975,13 +7004,15 @@ PSTATE
   # ── 5. Spawn AI agent in tmux ──
   info "spawning polecat $pname in tmux session $session_name..."
 
-  local polecat_prompt
+  local polecat_prompt polecat_prompt_file
   polecat_prompt="$(_build_polecat_runtime_prompt "$rig" "$issue_number" "$task" "$branch" "$rpath")"
+  _write_polecat_runtime_prompt_file "$worktree" "$polecat_prompt"
+  polecat_prompt_file="./$(basename "$(_polecat_runtime_prompt_file "$worktree")")"
 
   local tmux_error dispatch_reason_code
   if ! tmux_error="$(
     tmux new-session -d -s "$session_name" -c "$worktree" \
-      "$( _ai_session_cmd "$backend" "$polecat_prompt" "$worktree/.sgt-agent-output.log" ); rc=\$?; echo '[SGT] polecat exited'; sgt _wake-refinery '${rig}' 'polecat-done:${pname}:#${issue_number}' 2>/dev/null; exit \$rc" \
+      "$( _ai_session_cmd_from_file "$backend" "$polecat_prompt_file" "./.sgt-agent-output.log" ); rc=\$?; echo '[SGT] polecat exited'; sgt _wake-refinery '${rig}' 'polecat-done:${pname}:#${issue_number}' 2>/dev/null; exit \$rc" \
       2>&1
   )"; then
     dispatch_reason_code="tmux-new-session-failed"
@@ -8651,12 +8682,14 @@ CREATED=$(date -Iseconds)
 STATUS=running
 PSTATE
 
-  local polecat_prompt
+  local polecat_prompt polecat_prompt_file
   polecat_prompt="$(_build_polecat_runtime_prompt "$rig" "$issue_number" "$task" "$branch" "$rpath")"
+  _write_polecat_runtime_prompt_file "$worktree" "$polecat_prompt"
+  polecat_prompt_file="./$(basename "$(_polecat_runtime_prompt_file "$worktree")")"
   local tmux_error dispatch_reason_code
   if ! tmux_error="$(
     tmux new-session -d -s "$session_name" -c "$worktree" \
-      "$( _ai_session_cmd "$backend" "$polecat_prompt" "$worktree/.sgt-agent-output.log" ); rc=\$?; echo '[SGT] polecat exited'; sgt _wake-refinery '${rig}' 'polecat-done:${pname}:#${issue_number}' 2>/dev/null; exit \$rc" \
+      "$( _ai_session_cmd_from_file "$backend" "$polecat_prompt_file" "./.sgt-agent-output.log" ); rc=\$?; echo '[SGT] polecat exited'; sgt _wake-refinery '${rig}' 'polecat-done:${pname}:#${issue_number}' 2>/dev/null; exit \$rc" \
       2>&1
   )"; then
     dispatch_reason_code="tmux-new-session-failed"
@@ -12885,6 +12918,19 @@ _build_polecat_runtime_prompt() {
   fi
   prompt+="$readme_prompt"
   printf '%s' "$prompt"
+}
+
+_polecat_runtime_prompt_file() {
+  local worktree="$1"
+  printf '%s/.sgt-polecat-prompt.md\n' "$worktree"
+}
+
+_write_polecat_runtime_prompt_file() {
+  local worktree="$1" prompt="$2"
+  local prompt_file
+  prompt_file="$(_polecat_runtime_prompt_file "$worktree")"
+  printf '%s' "$prompt" > "$prompt_file"
+  chmod 600 "$prompt_file" 2>/dev/null || true
 }
 
 _write_polecat_claude_md() {

--- a/test_oversized_dispatch_payload_prompt_file.sh
+++ b/test_oversized_dispatch_payload_prompt_file.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# test_oversized_dispatch_payload_prompt_file.sh — Oversized polecat prompts must live in files, not tmux command strings.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+TMP_HOME="$TMP_ROOT/home"
+mkdir -p "$TMP_HOME/mock-bin" "$TMP_HOME/.local/bin"
+
+cat > "$TMP_HOME/mock-bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+cmd="${1:-}:${2:-}"
+case "$cmd" in
+  label:create)
+    exit 0
+    ;;
+  issue:create)
+    echo "https://github.com/acme/demo/issues/251"
+    exit 0
+    ;;
+  issue:view)
+    if [[ " $* " == *" --json labels "* ]]; then
+      printf 'sgt-authorized\n'
+    elif [[ " $* " == *" --json title "* ]]; then
+      printf 'oversized payload regression\n'
+    else
+      printf 'OPEN\n'
+    fi
+    exit 0
+    ;;
+  issue:list|issue:edit|issue:comment|pr:view|pr:list|api:*)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+chmod +x "$TMP_HOME/mock-bin/gh"
+
+cat > "$TMP_HOME/mock-bin/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LOG_FILE="${TMUX_LOG_FILE:?missing TMUX_LOG_FILE}"
+case "${1:-}" in
+  has-session)
+    exit 1
+    ;;
+  new-session)
+    printf '%s\n' "$*" >> "$LOG_FILE"
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+chmod +x "$TMP_HOME/mock-bin/tmux"
+
+cat > "$TMP_HOME/mock-bin/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+chmod +x "$TMP_HOME/mock-bin/codex"
+
+LIB_SCRIPT="$TMP_HOME/sgt-lib.sh"
+sed '$d' "$SGT_SCRIPT" > "$LIB_SCRIPT"
+
+env -i \
+  HOME="$TMP_HOME" \
+  PATH="$TMP_HOME/mock-bin:/usr/local/bin:/usr/bin:/bin" \
+  TERM="${TERM:-xterm}" \
+  TMUX_LOG_FILE="$TMP_HOME/tmux.log" \
+  SGT_AI_BACKEND=codex \
+  SGT_REQUIRE_AUTH_LABEL=0 \
+  bash --noprofile --norc <<'BASH'
+set -euo pipefail
+
+source "$HOME/sgt-lib.sh"
+
+cmd_init >/dev/null
+mkdir -p "$HOME/sgt/.sgt/rigs" "$HOME/sgt/rigs/demo"
+printf '%s\n' 'https://github.com/acme/demo' > "$HOME/sgt/.sgt/rigs/demo"
+
+repo_dir="$HOME/sgt/rigs/demo"
+git -C "$repo_dir" init -b main >/dev/null
+git -C "$repo_dir" config user.name "SGT Test"
+git -C "$repo_dir" config user.email "sgt@example.com"
+cat > "$repo_dir/README.md" <<'EOF_README'
+# Demo
+EOF_README
+cat > "$repo_dir/CLAUDE.md" <<'EOF_CLAUDE'
+# Project Context
+EOF_CLAUDE
+cat > "$repo_dir/SGT_CONTEXT.md" <<'EOF_CONTEXT'
+# SGT Project Context
+EOF_CONTEXT
+git -C "$repo_dir" add README.md CLAUDE.md SGT_CONTEXT.md
+git -C "$repo_dir" commit -m "test fixture" >/dev/null
+
+huge_title="Oversized payload regression $(printf 'X%.0s' $(seq 1 25000))"
+
+cmd_sling "demo" "$huge_title" --backend codex >/dev/null
+first_polecat="${_SGT_LAST_SLING_POLECAT:?missing sling polecat}"
+first_prompt="$HOME/sgt/polecats/$first_polecat/.sgt-polecat-prompt.md"
+
+grep -q "$huge_title" "$first_prompt" || { echo "expected sling prompt file to contain oversized title" >&2; exit 1; }
+grep -q '\.sgt-polecat-prompt\.md' "$HOME/tmux.log" || { echo "expected sling tmux command to reference prompt file" >&2; exit 1; }
+if grep -q "$huge_title" "$HOME/tmux.log"; then
+  echo "expected sling tmux command to omit oversized title" >&2
+  exit 1
+fi
+if [[ "$(wc -c < "$HOME/tmux.log" | tr -d ' ')" -ge 6000 ]]; then
+  echo "expected sling tmux command log to stay small even for oversized payloads" >&2
+  exit 1
+fi
+
+rm -f "$HOME/sgt/.sgt/polecats/$first_polecat"
+rm -rf "$HOME/sgt/polecats/$first_polecat"
+rm -f "$HOME/tmux.log"
+
+_resling_existing_issue "demo" "251" "$huge_title" "https://github.com/acme/demo" "codex" "" "oversized-resling" "oversized-resling:issue-251"
+second_polecat="${_RESLING_LAST_POLECAT:?missing resling polecat}"
+second_prompt="$HOME/sgt/polecats/$second_polecat/.sgt-polecat-prompt.md"
+
+grep -q "$huge_title" "$second_prompt" || { echo "expected resling prompt file to contain oversized title" >&2; exit 1; }
+grep -q '\.sgt-polecat-prompt\.md' "$HOME/tmux.log" || { echo "expected resling tmux command to reference prompt file" >&2; exit 1; }
+if grep -q "$huge_title" "$HOME/tmux.log"; then
+  echo "expected resling tmux command to omit oversized title" >&2
+  exit 1
+fi
+if [[ "$(wc -c < "$HOME/tmux.log" | tr -d ' ')" -ge 6000 ]]; then
+  echo "expected resling tmux command log to stay small even for oversized payloads" >&2
+  exit 1
+fi
+
+echo "ALL TESTS PASSED"
+BASH

--- a/test_worker_prompt_completion_context.sh
+++ b/test_worker_prompt_completion_context.sh
@@ -198,6 +198,7 @@ _acceptance_blocker_write "demo" "Verified acceptance is still red after merge."
 cmd_sling "demo" "Inject completion context into worker prompts" --backend codex >/dev/null
 first_polecat="${_SGT_LAST_SLING_POLECAT:?missing first polecat}"
 first_claude="$HOME/sgt/polecats/$first_polecat/CLAUDE.md"
+first_prompt="$HOME/sgt/polecats/$first_polecat/.sgt-polecat-prompt.md"
 
 grep -q '## Rig Completion Context' "$first_claude" || { echo "missing rig completion context in sling CLAUDE" >&2; exit 1; }
 grep -q 'Run a fresh-state verification on latest main and confirm the workflow succeeds.' "$first_claude" || { echo "missing completion condition in sling CLAUDE" >&2; exit 1; }
@@ -207,10 +208,15 @@ grep -q '\*\*Acceptance details\*\*: Fresh-state verification is still required 
 grep -q '\*\*Unresolved acceptance blockers\*\*: yes (1 active)' "$first_claude" || { echo "missing acceptance blocker summary in sling CLAUDE" >&2; exit 1; }
 grep -q 'merged intermediate work is not rig completion' "$first_claude" || { echo "missing merged-work rule in sling CLAUDE" >&2; exit 1; }
 
-grep -q 'Rig Completion Context' "$HOME/tmux.log" || { echo "missing rig completion context in sling runtime prompt" >&2; exit 1; }
-grep -q 'Run a fresh-state verification on latest main and confirm the workflow succeeds.' "$HOME/tmux.log" || { echo "missing completion condition in sling runtime prompt" >&2; exit 1; }
-grep -q 'Acceptance rollup' "$HOME/tmux.log" || { echo "missing acceptance rollup in sling runtime prompt" >&2; exit 1; }
-grep -q 'Fresh-state verification is still required after merges.' "$HOME/tmux.log" || { echo "missing acceptance details in sling runtime prompt" >&2; exit 1; }
+grep -q 'Rig Completion Context' "$first_prompt" || { echo "missing rig completion context in sling runtime prompt file" >&2; exit 1; }
+grep -q 'Run a fresh-state verification on latest main and confirm the workflow succeeds.' "$first_prompt" || { echo "missing completion condition in sling runtime prompt file" >&2; exit 1; }
+grep -q 'Acceptance rollup' "$first_prompt" || { echo "missing acceptance rollup in sling runtime prompt file" >&2; exit 1; }
+grep -q 'Fresh-state verification is still required after merges.' "$first_prompt" || { echo "missing acceptance details in sling runtime prompt file" >&2; exit 1; }
+grep -q '\.sgt-polecat-prompt\.md' "$HOME/tmux.log" || { echo "expected tmux launch to reference prompt file for sling" >&2; exit 1; }
+if grep -q 'Run a fresh-state verification on latest main and confirm the workflow succeeds.' "$HOME/tmux.log"; then
+  echo "expected tmux launch to avoid embedding full sling runtime prompt" >&2
+  exit 1
+fi
 
 rm -f "$HOME/sgt/.sgt/polecats/$first_polecat"
 rm -rf "$HOME/sgt/polecats/$first_polecat"
@@ -219,6 +225,7 @@ rm -f "$HOME/tmux.log"
 _resling_existing_issue "demo" "1" "Inject completion context into worker prompts" "https://github.com/acme/demo" "codex" "" "test-resling" "test-resling:issue-1"
 second_polecat="${_RESLING_LAST_POLECAT:?missing reslung polecat}"
 second_claude="$HOME/sgt/polecats/$second_polecat/CLAUDE.md"
+second_prompt="$HOME/sgt/polecats/$second_polecat/.sgt-polecat-prompt.md"
 
 grep -q '## Rig Completion Context' "$second_claude" || { echo "missing rig completion context in resling CLAUDE" >&2; exit 1; }
 grep -q 'Run a fresh-state verification on latest main and confirm the workflow succeeds.' "$second_claude" || { echo "missing completion condition in resling CLAUDE" >&2; exit 1; }
@@ -227,10 +234,15 @@ grep -q '\*\*Acceptance rollup\*\*: pending' "$second_claude" || { echo "missing
 grep -q '\*\*Acceptance details\*\*: Fresh-state verification is still required after merges.' "$second_claude" || { echo "missing acceptance details in resling CLAUDE" >&2; exit 1; }
 grep -q '\*\*Unresolved acceptance blockers\*\*: yes (1 active)' "$second_claude" || { echo "missing acceptance blocker summary in resling CLAUDE" >&2; exit 1; }
 
-grep -q 'Rig Completion Context' "$HOME/tmux.log" || { echo "missing rig completion context in resling runtime prompt" >&2; exit 1; }
-grep -q 'Run a fresh-state verification on latest main and confirm the workflow succeeds.' "$HOME/tmux.log" || { echo "missing completion condition in resling runtime prompt" >&2; exit 1; }
-grep -q 'Acceptance rollup' "$HOME/tmux.log" || { echo "missing acceptance rollup in resling runtime prompt" >&2; exit 1; }
-grep -q 'Fresh-state verification is still required after merges.' "$HOME/tmux.log" || { echo "missing acceptance details in resling runtime prompt" >&2; exit 1; }
+grep -q 'Rig Completion Context' "$second_prompt" || { echo "missing rig completion context in resling runtime prompt file" >&2; exit 1; }
+grep -q 'Run a fresh-state verification on latest main and confirm the workflow succeeds.' "$second_prompt" || { echo "missing completion condition in resling runtime prompt file" >&2; exit 1; }
+grep -q 'Acceptance rollup' "$second_prompt" || { echo "missing acceptance rollup in resling runtime prompt file" >&2; exit 1; }
+grep -q 'Fresh-state verification is still required after merges.' "$second_prompt" || { echo "missing acceptance details in resling runtime prompt file" >&2; exit 1; }
+grep -q '\.sgt-polecat-prompt\.md' "$HOME/tmux.log" || { echo "expected tmux launch to reference prompt file for resling" >&2; exit 1; }
+if grep -q 'Run a fresh-state verification on latest main and confirm the workflow succeeds.' "$HOME/tmux.log"; then
+  echo "expected tmux launch to avoid embedding full resling runtime prompt" >&2
+  exit 1
+fi
 
 echo "ALL TESTS PASSED"
 BASH


### PR DESCRIPTION
Closes #254

## Summary
- move sling/resling polecat runtime prompts into per-worktree `.sgt-polecat-prompt.md` files
- launch tmux sessions with short file-based backend commands instead of embedding the full prompt in the tmux command string
- add regression coverage for oversized dispatch payload assembly and keep prompt/runtime assertions aligned with the new launch shape

## Testing
- bash test_worker_prompt_completion_context.sh
- bash test_sling_spawn_failure_cleanup.sh
- bash test_oversized_dispatch_payload_prompt_file.sh
- bash test_mayor_live_polecat_count_regression.sh