### PR TITLE
Add mayor refresh handoff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ Optional per-rig Mayor architecture:
 - Set `SGT_MAYOR_ARCHITECTURE=per-rig` to run one Mayor tmux session per rig instead of one shared `sgt-mayor`.
 - In that mode, sessions/state/logs live under `~/.sgt/mayors/<rig>/`, deacon supervises each `sgt-mayor-<rig>` independently, and `sgt status` / `sgt status --json` expose entries like `mayor/pmkb` or `mayor/sgt`.
 - `sgt mayor start|stop` without a rig acts on all rig Mayors in per-rig mode; `sgt wake-mayor` routes rig-targeted wake reasons to the matching Mayor and otherwise broadcasts to all rig Mayors.
+- `sgt mayor refresh [rig]` captures a timestamped handoff under the scoped mayor directory, archives transient Mayor context there, restarts the Mayor, and prints the handoff markdown path after re-waking it.
 
 Mayor and boot both guard against stale deacon heartbeats:
 - Default stale threshold is `300` seconds (`5` minutes), configurable with:

--- a/SGT_CONTEXT.md
+++ b/SGT_CONTEXT.md
@@ -209,3 +209,37 @@ This is a feature request against the `sgt` repo / Mayor control-plane behavior.
 - 2026-03-26T09:45:58+01:00 — 2026-03-26: Manual rig hibernation is now authoritative until explicit : activity refresh preserves manual mode across mayor restarts, event-targeted mayor cycles no longer bypass manual hibernation, and dispatch fences now block sling, plan tick dispatch, sweep watchdog resling, witness stalled-worker resling, and direct resling helper dispatch while leaving passive status/logging intact. Regression coverage: test_mayor_rig_hibernation.sh, test_manual_hibernation_dispatch_fences.sh, test_witness_manual_hibernation_skip.sh.
 - 2026-03-26T09:46:05+01:00 — 2026-03-26: Manual rig hibernation is now authoritative until explicit sgt mayor unhibernate. Activity refresh preserves manual mode across mayor restarts, event-targeted mayor cycles no longer bypass manual hibernation, and dispatch fences now block sling, plan tick dispatch, sweep watchdog resling, witness stalled-worker resling, and direct resling helper dispatch while leaving passive status/logging intact. Regression coverage: test_mayor_rig_hibernation.sh, test_manual_hibernation_dispatch_fences.sh, test_witness_manual_hibernation_skip.sh.
 - 2026-03-26T20:18:42+01:00 — Observed PMKB canonical issue #679 enter a witness resling loop because Codex workers were hitting backend usage limits and exiting before opening a PR. Operator diagnosis: the underlying signature is the first Codex output containing 'You've hit your usage limit'. Current SGT behavior misclassifies this as generic WITNESS_STALLED dead/no-PR and immediately re-slings again, creating issue-comment spam and repeated dead polecats. Desired fix: detect codex usage-limit text from first message/output, classify as explicit backend/quota-limited blocker (for example reason_code=codex_usage_limit or backend_usage_limit), suppress immediate resling loops, and surface one operator-readable blocked state/comment instead of repeated stalled comments.
+- 2026-03-26T20:27:09+01:00 — Codex polecat sessions now persist terminal output to .sgt-agent-output.log so witness can detect first-output quota failures. When the first captured Codex output contains 'You've hit your usage limit', witness classifies the death as reason_code=codex_usage_limit, labels the issue backend-limited + codex-usage-limit, records an acceptance blocker, and sweep/resling paths skip further auto-resling for that issue.
+- 2026-03-26T22:37:24+01:00 — 2026-03-26 live controller bug: after PMKB dead-polecat cleanup, watchdog reslings for #693/#691 can die with 'command too long', and Mayor consistency revalidation can stay wedged on mismatch_categories=polecat-liveness even when sgt status shows no tracked polecats. snapshot open_polecats stayed > live open_polecats after nuke/sweep/manual dispatch retries, blocking fresh dispatch for #679/#693. Need self-healing stale polecat accounting after failed spawn / cleanup and clean handling for oversized command assembly.
+- 2026-03-26T22:55:43+01:00 — Acceptance blocker sgt-acceptance-1774562143-94f532df reported by witness: Replacement work required after stalled polecat for issue #251
+
+### Acceptance Blocker sgt-acceptance-1774562143-94f532df
+
+- Reported at: 2026-03-26T22:55:43+01:00
+- Reported by: witness
+- Title: Replacement work required after stalled polecat for issue #251
+
+```markdown
+Replacement work required after stalled polecat for issue #251
+
+Stalled polecat recovery did not produce replacement work.
+
+- Rig: sgt
+- Repo: codejeet/sgt
+- Issue: #251
+- Issue URL: https://github.com/codejeet/sgt/issues/251
+- Issue title: Fix stale polecat-liveness mismatch after failed dispatch cleanup
+- Polecat: sgt-c093b3ac
+- Failure reason: witness-stalled-resling-failed
+
+Required follow-up:
+- create replacement work (new PR or re-dispatched polecat) before closing the incident
+- re-investigate why the worker exited without producing a PR
+
+```
+- 2026-03-26T22:57:25+01:00 — 2026-03-26 post-#251 deploy blocker: stale polecat bookkeeping now recovers correctly, but real PMKB redispatches for #696/#693/#679 still fail at launch with RESLING_SPAWN_FAILED reason_code=command-too-long. Need to stop embedding oversized polecat launch payloads directly into tmux command strings; use file/stdin/wrapper launch instead and add regression coverage.
+- 2026-03-26T23:16:30+01:00 — 2026-03-26 issue #254: polecat sling/resling launches now write the runtime worker prompt to .sgt-polecat-prompt.md in the worktree and start tmux with a short file-based backend command, preventing command-too-long redispatch failures while leaving failed-spawn cleanup bookkeeping unchanged. Regression coverage: test_oversized_dispatch_payload_prompt_file.sh plus updated worker prompt runtime assertions.
+- 2026-03-26T23:29:54+01:00 — Acceptance blocker sgt-acceptance-1774562143-94f532df resolved.
+
+## 2026-03-30
+- 2026-03-30T01:58:00+02:00 — 2026-03-30 operator requested a first-class 'sgt mayor refresh' command: soft-reset Mayor transient context/workspace automatically, generate a durable handoff markdown/doc from current Mayor context before reset, preserve durable board state, and print the handoff artifact path on success. Manual production baseline came from the 2026-03-30 ~01:49 CET soft reset flow (stop, archive transient Mayor files, start, wake).

--- a/sgt
+++ b/sgt
@@ -641,6 +641,126 @@ _mayor_start_log_tail() {
   fi
 }
 
+_mayor_refresh_handoffs_dir() {
+  echo "$(_mayor_scope_dir)/handoffs"
+}
+
+_mayor_refresh_token() {
+  local now
+  now="$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || date '+%Y%m%dT%H%M%S')"
+  printf 'mayor-refresh-%s-%s\n' "$now" "$$"
+}
+
+_mayor_refresh_archive_transients() {
+  local handoff_dir="${1:-}"
+  local scope_dir src name
+  [[ -n "$handoff_dir" ]] || return 1
+
+  scope_dir="$(_mayor_scope_dir)"
+  mkdir -p "$handoff_dir"
+
+  for name in \
+    "mayor-briefing.md" \
+    "mayor-dispatch-snapshot.tsv" \
+    "mayor-ai-cycle.state" \
+    "mayor-start.receipt" \
+    "mayor-start.log" \
+    "mayor-start-failure.state"; do
+    src="$scope_dir/$name"
+    if [[ -e "$src" ]]; then
+      mv "$src" "$handoff_dir/$name"
+      printf '%s\n' "$name"
+    fi
+  done
+
+  src="$scope_dir/mayor-workspace"
+  if [[ -d "$src" ]]; then
+    mv "$src" "$handoff_dir/mayor-workspace"
+    printf '%s\n' "mayor-workspace/"
+  fi
+}
+
+_mayor_refresh_write_handoff() {
+  local handoff_file="${1:-}" handoff_token="${2:-}" was_running="${3:-false}" status_snapshot="${4:-}"
+  local scope_label scope_dir architecture generated_at event_log_path briefing_archive decisions_log
+  local start_fail_ts start_fail_reason start_fail_attempt start_fail_log start_fail_detail
+  local exit_ts exit_reason exit_code exit_signal exit_unexpected exit_pid exit_trigger exit_cycle_at exit_cycle_status
+  local cycle_ts cycle_completed_at cycle_trigger cycle_status
+  local hb_age hb_ts hb_state hb_pid hb_phase hb_cycle hb_trigger
+
+  [[ -n "$handoff_file" ]] || return 1
+  scope_label="$(_mayor_scope_display_text)"
+  scope_dir="$(_mayor_scope_dir)"
+  architecture="$(_mayor_architecture)"
+  generated_at="$(date -Iseconds)"
+  event_log_path="$SGT_LOG"
+  briefing_archive="$(dirname "$handoff_file")/mayor-briefing.md"
+  decisions_log="$scope_dir/mayor-decisions.log"
+
+  IFS='|' read -r start_fail_ts start_fail_reason start_fail_attempt start_fail_log start_fail_detail <<< "$(_mayor_start_failure_state_read)"
+  IFS='|' read -r exit_ts exit_reason exit_code exit_signal exit_unexpected exit_pid exit_trigger exit_cycle_at exit_cycle_status <<< "$(_mayor_exit_state_read)"
+  IFS='|' read -r cycle_ts cycle_completed_at cycle_trigger cycle_status <<< "$(_mayor_last_cycle_state_read)"
+  IFS='|' read -r hb_age hb_ts hb_state hb_pid hb_phase hb_cycle hb_trigger <<< "$(_mayor_heartbeat_snapshot)"
+
+  cat > "$handoff_file" <<EOF
+# Mayor Refresh Handoff
+
+- generated_at: $generated_at
+- handoff_token: $handoff_token
+- scope: $scope_label
+- architecture: $architecture
+- scope_dir: $scope_dir
+- mayor_was_running: $was_running
+- preserved_decision_log: $decisions_log
+- event_log: $event_log_path
+
+## Runtime Snapshot Before Refresh
+- heartbeat: age=${hb_age:-unknown}s timestamp=${hb_ts:-unknown} state=${hb_state:-unknown} pid=${hb_pid:-unknown} phase=${hb_phase:-unknown} cycle=${hb_cycle:-unknown} trigger=${hb_trigger:-unknown}
+- last_cycle: completed_at=${cycle_completed_at:-unknown} trigger=${cycle_trigger:-unknown} status=${cycle_status:-unknown}
+- last_exit: timestamp=${exit_ts:-unknown} reason=${exit_reason:-unknown} signal=${exit_signal:-unknown} code=${exit_code:-unknown} unexpected=${exit_unexpected:-unknown} pid=${exit_pid:-unknown} last_cycle_trigger=${exit_trigger:-unknown} last_cycle_at=${exit_cycle_at:-unknown} last_cycle_status=${exit_cycle_status:-unknown}
+- startup_warning: timestamp=${start_fail_ts:-none} reason=${start_fail_reason:-none} attempt=${start_fail_attempt:-none} log=${start_fail_log:-none} detail=${start_fail_detail:-none}
+
+## Archived Transient Files
+EOF
+
+  if find "$(dirname "$handoff_file")" -mindepth 1 -maxdepth 2 ! -name 'handoff.md' | read -r _; then
+    (
+      cd "$(dirname "$handoff_file")"
+      find . -mindepth 1 -maxdepth 2 ! -name 'handoff.md' | sed 's#^\./#- #'
+    ) >> "$handoff_file"
+  else
+    echo "- none" >> "$handoff_file"
+  fi
+
+  cat >> "$handoff_file" <<EOF
+
+## Status Snapshot
+\`\`\`
+${status_snapshot:-status unavailable}
+\`\`\`
+EOF
+
+  if [[ -f "$briefing_archive" ]]; then
+    cat >> "$handoff_file" <<EOF
+
+## Archived Briefing
+\`\`\`markdown
+$(cat "$briefing_archive")
+\`\`\`
+EOF
+  fi
+
+  if [[ -f "$decisions_log" ]]; then
+    cat >> "$handoff_file" <<EOF
+
+## Recent Durable Decisions
+\`\`\`
+$(tail -20 "$decisions_log" 2>/dev/null)
+\`\`\`
+EOF
+  fi
+}
+
 _mayor_wait_for_start() {
   local session="${1:-sgt-mayor}" attempt="${2:-}" timeout_secs="${3:-$(_mayor_start_validation_timeout_secs)}"
   local waited=0
@@ -6430,7 +6550,9 @@ _wake_mayor() {
     for rig in $(_mayor_target_rigs_for_reason "$reason"); do
       _mayor_scope_apply "$rig"
       if [[ -p "$SGT_MAYOR_FIFO" ]]; then
-        echo "$reason" > "$SGT_MAYOR_FIFO" &
+        (
+          printf '%s\n' "$reason" > "$SGT_MAYOR_FIFO"
+        ) </dev/null >/dev/null 2>&1 &
         disown 2>/dev/null
         sent=1
       fi
@@ -6439,7 +6561,9 @@ _wake_mayor() {
     return 0
   fi
   if [[ -p "$SGT_MAYOR_FIFO" ]]; then
-    echo "$reason" > "$SGT_MAYOR_FIFO" &
+    (
+      printf '%s\n' "$reason" > "$SGT_MAYOR_FIFO"
+    ) </dev/null >/dev/null 2>&1 &
     disown 2>/dev/null
   fi
 }
@@ -6450,7 +6574,9 @@ _wake_refinery() {
   local reason="${2:-unknown}"
   local fifo="$SGT_CONFIG/refinery-${rig}.fifo"
   if [[ -p "$fifo" ]]; then
-    echo "$reason" > "$fifo" &
+    (
+      printf '%s\n' "$reason" > "$fifo"
+    ) </dev/null >/dev/null 2>&1 &
     disown 2>/dev/null
   fi
 }
@@ -11836,6 +11962,7 @@ Usage: sgt mayor <command> [args]
 Commands:
   start [rig]             Start mayor (AI coordinator); in per-rig mode, starts all rig mayors unless a rig is given
   stop [rig]              Stop mayor; in per-rig mode, stops all rig mayors unless a rig is given
+  refresh [rig]           Archive transient mayor context into a handoff snapshot, then restart and wake mayor
   notify "<message>"      Send mayor notification to configured channels
   hibernate <rig> [reason]
                           Mark a rig hibernated until explicit manual unhibernate
@@ -11959,6 +12086,7 @@ _cmd_mayor_stop_one() {
   fi
   # Clean up FIFO
   [[ -p "$SGT_MAYOR_FIFO" ]] && rm -f "$SGT_MAYOR_FIFO"
+  return 0
 }
 
 cmd_mayor_stop() {
@@ -11976,6 +12104,58 @@ cmd_mayor_stop() {
     return 0
   fi
   _cmd_mayor_stop_one ""
+}
+
+_cmd_mayor_refresh_one() {
+  local scope_rig="${1:-}"
+  local was_running="false" handoff_token handoff_dir handoff_file status_snapshot refresh_reason
+  ensure_init
+  _mayor_scope_apply "$scope_rig"
+
+  handoff_token="$(_mayor_refresh_token)"
+  handoff_dir="$(_mayor_refresh_handoffs_dir)/$handoff_token"
+  handoff_file="$handoff_dir/handoff.md"
+  mkdir -p "$handoff_dir"
+
+  status_snapshot="$(cmd_status 2>&1 || true)"
+  _mayor_scope_apply "$scope_rig"
+  if tmux has-session -t "$(_mayor_scope_session_name "$scope_rig")" 2>/dev/null; then
+    was_running="true"
+  fi
+
+  _cmd_mayor_stop_one "$scope_rig"
+  _mayor_dispatch_snapshot_file "$(_mayor_scope_dir)/mayor-dispatch-snapshot.tsv" || true
+  _mayor_build_briefing >/dev/null || true
+  _mayor_scope_apply "$scope_rig"
+  _mayor_refresh_archive_transients "$handoff_dir" >/dev/null || true
+  _mayor_refresh_write_handoff "$handoff_file" "$handoff_token" "$was_running" "$status_snapshot"
+  log_event "MAYOR_REFRESH scope=${scope_rig:-shared} running_before=$was_running handoff=\"$(_escape_quotes "$handoff_file")\""
+
+  _cmd_mayor_start_one "$scope_rig"
+  if [[ -n "$scope_rig" ]]; then
+    refresh_reason="manual-refresh|rig=$scope_rig|handoff=$handoff_token"
+  else
+    refresh_reason="manual-refresh|handoff=$handoff_token"
+  fi
+  cmd_wake_mayor "$refresh_reason"
+  echo "$handoff_file"
+}
+
+cmd_mayor_refresh() {
+  local scope_rig="${1:-}"
+  if _mayor_architecture_per_rig; then
+    if [[ -n "$scope_rig" ]]; then
+      _cmd_mayor_refresh_one "$scope_rig"
+      return $?
+    fi
+    local rig
+    for rig in $(_mayor_all_rigs); do
+      _cmd_mayor_refresh_one "$rig"
+    done
+    _mayor_scope_apply ""
+    return 0
+  fi
+  _cmd_mayor_refresh_one ""
 }
 
 # Public command: wake the mayor on demand
@@ -13021,7 +13201,7 @@ Agent Commands:
   deacon start|stop             Control the health monitor
   witness start|stop <rig>      Control per-rig polecat monitor
   refinery start|stop <rig>     Control per-rig merge queue
-  mayor [help|start|stop|notify|hibernate|unhibernate|rig-status|request|merge]
+  mayor [help|start|stop|refresh|notify|hibernate|unhibernate|rig-status|request|merge]
                                 Control the AI coordinator
   wake-mayor [reason]           Wake the mayor on demand (event-driven)
   nudge <target> <message>      Send message to agent's tmux session
@@ -13225,6 +13405,7 @@ main() {
         ""|help|--help|-h) cmd_mayor_help ;;
         start)   cmd_mayor_start "$@" ;;
         stop)    cmd_mayor_stop "$@" ;;
+        refresh) cmd_mayor_refresh "$@" ;;
         notify)  cmd_mayor_notify "$@" ;;
         hibernate) cmd_mayor_hibernate "$@" ;;
         unhibernate) cmd_mayor_unhibernate "$@" ;;
@@ -13240,7 +13421,7 @@ main() {
           esac
           ;;
         merge)   cmd_mayor_merge "$@" ;;
-        *)       die "unknown mayor command: $sub (try: help, start, stop, notify, hibernate, unhibernate, rig-status, request, merge)" ;;
+        *)       die "unknown mayor command: $sub (try: help, start, stop, refresh, notify, hibernate, unhibernate, rig-status, request, merge)" ;;
       esac
       ;;
     plan)

--- a/test_mayor_help_compat.sh
+++ b/test_mayor_help_compat.sh
@@ -104,10 +104,11 @@ fi
 check_file_contains "mayor usage includes command synopsis" "$BASE_OUT" '^Usage: sgt mayor <command> \[args\]$'
 check_file_contains "unknown mayor subcommand exits 1" "$BAD_RC" '^1$'
 check_equals "unknown mayor subcommand writes no stdout" "$(wc -c <"$BAD_OUT" | tr -d ' ')" "0"
-check_file_contains "unknown mayor subcommand error is explicit" "$BAD_ERR" '^sgt: unknown mayor command: nope \(try: help, start, stop, notify, hibernate, unhibernate, rig-status, request, merge\)$'
+check_file_contains "unknown mayor subcommand error is explicit" "$BAD_ERR" '^sgt: unknown mayor command: nope \(try: help, start, stop, refresh, notify, hibernate, unhibernate, rig-status, request, merge\)$'
 
 check_file_contains "mayor command keeps start subcommand" "$SGT_SCRIPT" 'start\)[[:space:]]+cmd_mayor_start'
 check_file_contains "mayor command keeps stop subcommand" "$SGT_SCRIPT" 'stop\)[[:space:]]+cmd_mayor_stop'
+check_file_contains "mayor command keeps refresh subcommand" "$SGT_SCRIPT" 'refresh\)[[:space:]]+cmd_mayor_refresh'
 check_file_contains "mayor command keeps notify subcommand" "$SGT_SCRIPT" 'notify\)[[:space:]]+cmd_mayor_notify'
 check_file_contains "mayor command keeps request subcommand" "$SGT_SCRIPT" 'request\)'
 check_file_contains "mayor command keeps merge subcommand" "$SGT_SCRIPT" 'merge\)[[:space:]]+cmd_mayor_merge'

--- a/test_mayor_refresh.sh
+++ b/test_mayor_refresh.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# test_mayor_refresh.sh — Verify mayor refresh archives transient state into a handoff and restarts scoped mayor sessions.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+make_mock_bin() {
+  local mock_bin="$1"
+  local sessions_file="$2"
+  mkdir -p "$mock_bin"
+
+  cat > "$mock_bin/tmux" <<'TMUX'
+#!/usr/bin/env bash
+set -euo pipefail
+sessions_file="${SGT_TEST_TMUX_SESSIONS_FILE:?missing SGT_TEST_TMUX_SESSIONS_FILE}"
+cmd="${1:-}"
+case "$cmd" in
+  has-session)
+    [[ "${2:-}" == "-t" ]] || exit 1
+    grep -qx "${3:-}" "$sessions_file" 2>/dev/null
+    ;;
+  kill-session)
+    [[ "${2:-}" == "-t" ]] || exit 1
+    tmp="${sessions_file}.tmp.$$"
+    grep -vx "${3:-}" "$sessions_file" > "$tmp" 2>/dev/null || true
+    mv "$tmp" "$sessions_file"
+    ;;
+  new-session)
+    session=""
+    command_str=""
+    while [[ $# -gt 0 ]]; do
+      case "${1:-}" in
+        -s)
+          session="${2:-}"
+          shift 2
+          ;;
+        *)
+          command_str="${1:-}"
+          shift
+          ;;
+      esac
+    done
+    [[ -n "$session" ]] || exit 1
+    printf '%s\n' "$session" >> "$sessions_file"
+    start_token="$(printf '%s' "$command_str" | sed -n 's/.*SGT_MAYOR_START_TOKEN=\([^ ]*\).*/\1/p')"
+    scope_rig="$(printf '%s' "$command_str" | sed -n 's/.*SGT_MAYOR_SCOPE_RIG=\([^ ]*\).*/\1/p')"
+    start_token="${start_token%\'}"
+    start_token="${start_token#\'}"
+    scope_rig="${scope_rig%\'}"
+    scope_rig="${scope_rig#\'}"
+    if [[ -n "$scope_rig" && "$scope_rig" != "''" ]]; then
+      receipt_dir="$HOME/sgt/.sgt/mayors/$scope_rig"
+      fifo_path="$receipt_dir/mayor.fifo"
+    else
+      receipt_dir="$HOME/sgt/.sgt"
+      fifo_path="$receipt_dir/mayor.fifo"
+    fi
+    mkdir -p "$receipt_dir"
+    cat > "$receipt_dir/mayor-start.receipt" <<EOF
+ATTEMPT=$start_token
+PID=999
+STARTED_AT=2026-03-30T00:00:00Z
+STARTED_EPOCH=1774828800
+EOF
+    if [[ -p "$fifo_path" ]]; then
+      ( timeout 10 cat "$fifo_path" >/dev/null 2>&1 || true ) &
+    fi
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+TMUX
+  chmod +x "$mock_bin/tmux"
+
+  cat > "$mock_bin/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+GH
+  chmod +x "$mock_bin/gh"
+}
+
+run_env() {
+  local home_dir="$1"
+  local sessions_file="$2"
+  shift 2
+  env -i \
+    HOME="$home_dir" \
+    PATH="$home_dir/.local/bin:$TMP_ROOT/mockbin:/usr/local/bin:/usr/bin:/bin" \
+    TERM=dumb \
+    SGT_ROOT="$home_dir/sgt" \
+    SGT_TEST_TMUX_SESSIONS_FILE="$sessions_file" \
+    "$@"
+}
+
+assert_file() {
+  local path="$1"
+  [[ -f "$path" ]] || {
+    echo "expected file: $path" >&2
+    exit 1
+  }
+}
+
+assert_dir_missing() {
+  local path="$1"
+  [[ ! -d "$path" ]] || {
+    echo "expected directory to be removed: $path" >&2
+    exit 1
+  }
+}
+
+assert_file_missing() {
+  local path="$1"
+  [[ ! -f "$path" ]] || {
+    echo "expected file to be removed: $path" >&2
+    exit 1
+  }
+}
+
+mkdir -p "$TMP_ROOT/mockbin"
+
+echo "=== shared mayor refresh ==="
+SHARED_HOME="$TMP_ROOT/shared-home"
+SHARED_SESSIONS="$TMP_ROOT/shared-sessions"
+mkdir -p "$SHARED_HOME/.local/bin"
+cp "$SGT_SCRIPT" "$SHARED_HOME/.local/bin/sgt"
+chmod +x "$SHARED_HOME/.local/bin/sgt"
+printf 'sgt-mayor\n' > "$SHARED_SESSIONS"
+make_mock_bin "$TMP_ROOT/mockbin" "$SHARED_SESSIONS"
+
+run_env "$SHARED_HOME" "$SHARED_SESSIONS" bash --noprofile --norc -c '
+set -euo pipefail
+sgt init >/dev/null
+mkdir -p "$SGT_ROOT/.sgt/mayor-workspace"
+printf "briefing\n" > "$SGT_ROOT/.sgt/mayor-briefing.md"
+printf "snapshot\n" > "$SGT_ROOT/.sgt/mayor-dispatch-snapshot.tsv"
+printf "status=running\n" > "$SGT_ROOT/.sgt/mayor-ai-cycle.state"
+printf "ATTEMPT=abc\n" > "$SGT_ROOT/.sgt/mayor-start.receipt"
+printf "spawn log\n" > "$SGT_ROOT/.sgt/mayor-start.log"
+printf "1|startup-failed|attempt|log|detail\n" > "$SGT_ROOT/.sgt/mayor-start-failure.state"
+printf "decision\n" > "$SGT_ROOT/.sgt/mayor-decisions.log"
+printf "notes\n" > "$SGT_ROOT/.sgt/mayor-workspace/CLAUDE.md"
+'
+
+SHARED_OUT="$TMP_ROOT/shared-refresh.out"
+run_env "$SHARED_HOME" "$SHARED_SESSIONS" bash --noprofile --norc -c 'set -euo pipefail; timeout 15 sgt mayor refresh' > "$SHARED_OUT"
+shared_handoff="$(tail -n 1 "$SHARED_OUT")"
+assert_file "$shared_handoff"
+assert_file "$(dirname "$shared_handoff")/mayor-briefing.md"
+assert_file "$(dirname "$shared_handoff")/mayor-dispatch-snapshot.tsv"
+assert_file "$(dirname "$shared_handoff")/mayor-ai-cycle.state"
+assert_file "$(dirname "$shared_handoff")/mayor-start.receipt"
+assert_file "$(dirname "$shared_handoff")/mayor-start.log"
+assert_file "$(dirname "$shared_handoff")/mayor-start-failure.state"
+assert_file "$(dirname "$shared_handoff")/mayor-workspace/CLAUDE.md"
+assert_file "$SHARED_HOME/sgt/.sgt/mayor-decisions.log"
+assert_file_missing "$SHARED_HOME/sgt/.sgt/mayor-briefing.md"
+assert_dir_missing "$SHARED_HOME/sgt/.sgt/mayor-workspace"
+grep -qx 'sgt-mayor' "$SHARED_SESSIONS" || {
+  echo "expected shared mayor session to be restarted" >&2
+  exit 1
+}
+grep -q '^# Mayor Refresh Handoff$' "$shared_handoff" || {
+  echo "expected handoff title in shared handoff" >&2
+  exit 1
+}
+grep -q 'mayor_was_running: true' "$shared_handoff" || {
+  echo "expected shared handoff to note running mayor" >&2
+  exit 1
+}
+
+echo "=== per-rig mayor refresh ==="
+RIG_HOME="$TMP_ROOT/per-rig-home"
+RIG_SESSIONS="$TMP_ROOT/per-rig-sessions"
+mkdir -p "$RIG_HOME/.local/bin"
+cp "$SGT_SCRIPT" "$RIG_HOME/.local/bin/sgt"
+chmod +x "$RIG_HOME/.local/bin/sgt"
+printf 'sgt-mayor-alpha\nsgt-mayor-beta\n' > "$RIG_SESSIONS"
+
+run_env "$RIG_HOME" "$RIG_SESSIONS" bash --noprofile --norc -c '
+set -euo pipefail
+sgt init >/dev/null
+mkdir -p "$SGT_ROOT/.sgt/rigs" "$SGT_ROOT/rigs/alpha" "$SGT_ROOT/rigs/beta"
+printf "https://github.com/acme/alpha\n" > "$SGT_ROOT/.sgt/rigs/alpha"
+printf "https://github.com/acme/beta\n" > "$SGT_ROOT/.sgt/rigs/beta"
+mkdir -p "$SGT_ROOT/.sgt/mayors/alpha/mayor-workspace" "$SGT_ROOT/.sgt/mayors/beta/mayor-workspace"
+printf "alpha briefing\n" > "$SGT_ROOT/.sgt/mayors/alpha/mayor-briefing.md"
+printf "beta briefing\n" > "$SGT_ROOT/.sgt/mayors/beta/mayor-briefing.md"
+printf "alpha notes\n" > "$SGT_ROOT/.sgt/mayors/alpha/mayor-workspace/CLAUDE.md"
+printf "beta notes\n" > "$SGT_ROOT/.sgt/mayors/beta/mayor-workspace/CLAUDE.md"
+printf "alpha decision\n" > "$SGT_ROOT/.sgt/mayors/alpha/mayor-decisions.log"
+printf "beta decision\n" > "$SGT_ROOT/.sgt/mayors/beta/mayor-decisions.log"
+'
+
+RIG_OUT="$TMP_ROOT/per-rig-refresh.out"
+run_env "$RIG_HOME" "$RIG_SESSIONS" SGT_MAYOR_ARCHITECTURE=per-rig bash --noprofile --norc -c 'set -euo pipefail; timeout 15 sgt mayor refresh alpha' > "$RIG_OUT"
+rig_handoff="$(tail -n 1 "$RIG_OUT")"
+assert_file "$rig_handoff"
+assert_file "$(dirname "$rig_handoff")/mayor-briefing.md"
+assert_file "$(dirname "$rig_handoff")/mayor-workspace/CLAUDE.md"
+assert_file "$RIG_HOME/sgt/.sgt/mayors/alpha/mayor-decisions.log"
+assert_file "$RIG_HOME/sgt/.sgt/mayors/beta/mayor-briefing.md"
+assert_file "$RIG_HOME/sgt/.sgt/mayors/beta/mayor-workspace/CLAUDE.md"
+assert_file_missing "$RIG_HOME/sgt/.sgt/mayors/alpha/mayor-briefing.md"
+assert_dir_missing "$RIG_HOME/sgt/.sgt/mayors/alpha/mayor-workspace"
+grep -qx 'sgt-mayor-alpha' "$RIG_SESSIONS" || {
+  echo "expected alpha mayor session to be restarted" >&2
+  exit 1
+}
+grep -qx 'sgt-mayor-beta' "$RIG_SESSIONS" || {
+  echo "expected beta mayor session to remain running" >&2
+  exit 1
+}
+case "$rig_handoff" in
+  *"/mayors/alpha/handoffs/"*) ;;
+  *)
+    echo "expected per-rig handoff path to stay under alpha scope" >&2
+    exit 1
+    ;;
+esac
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Closes #256

Adds `sgt mayor refresh [rig]` to snapshot and archive transient Mayor context into a handoff, restart the scoped Mayor, and wake it again. Includes regression coverage for shared and per-rig refresh flows plus mayor help compatibility updates.