### PR TITLE
Redesign the web UI into an operator shell

### DIFF
--- a/SGT_CONTEXT.md
+++ b/SGT_CONTEXT.md
@@ -245,3 +245,177 @@ Required follow-up:
 - 2026-03-30T01:58:00+02:00 — 2026-03-30 operator requested a first-class 'sgt mayor refresh' command: soft-reset Mayor transient context/workspace automatically, generate a durable handoff markdown/doc from current Mayor context before reset, preserve durable board state, and print the handoff artifact path on success. Manual production baseline came from the 2026-03-30 ~01:49 CET soft reset flow (stop, archive transient Mayor files, start, wake).
 - 2026-03-30T02:11:53+02:00 — 2026-03-30 — Added 'sgt mayor refresh [rig]' to archive transient Mayor context into ~/.sgt[/mayors/<rig>]/handoffs/<token>/, write a handoff.md snapshot, restart+wake Mayor, and print the handoff path. Refresh had to reapply per-rig scope after cmd_status/_mayor_build_briefing because those helpers mutate mayor scope, and _cmd_mayor_stop_one now returns 0 even when no FIFO exists so refresh/stop do not fail spuriously.
 - 2026-03-30T04:29:18+02:00 — 2026-03-30 operator diagnosis: _find_recent_duplicate_issue currently matches recently closed issues too, so fresh sling dispatches can be suppressed against closed work (example: PMKB capture regression suppressed against closed #865). Separate live symptom: PMKB was left active with open issue #872 but zero active polecats/open PRs while Mayor stayed healthy and kept cycling, so SGT needs a stronger invariant against actionable rigs idling with zero workers.
+- 2026-03-30T04:31:10+02:00 — 2026-03-30: sling duplicate cooldown now ignores closed issues entirely; _find_recent_duplicate_issue checks only open issues, so freshly closed work no longer suppresses replacement dispatches for the same symptom.
+- 2026-03-30T04:36:10+02:00 — 2026-03-30: Mayor now enforces bounded stranded-rig recovery for non-hibernated rigs with open sgt-authorized issues but zero open PRs, zero active polecats, and zero merge-queue items; it attempts one replacement dispatch per cycle and logs MAYOR_STRANDED_RIG_RECOVERY_DISPATCH/BLOCKED telemetry with explicit reason_code values.
+- 2026-03-30T05:59:21+02:00 — Plan request sgt-1774843161-c615ad59 submitted by OpenClaw agent gastown. Full spec appended below.
+
+### Plan Request sgt-1774843161-c615ad59
+
+- Requested at: 2026-03-30T05:59:21+02:00
+- Requesting OpenClaw agent: gastown
+
+```markdown
+# SGT Plan Request — JARVIS-style real-time operations cockpit for SGT Web UI
+
+## Goal
+
+Turn the existing SGT Web UI into a real-time operator cockpit for SGT, with:
+
+1. **Live monitoring of the Mayor and all active polecats**
+   - real-time tmux-backed views of their output/logs
+   - fast switching + multi-pane monitoring
+   - stale/disconnected indicators
+2. **An Iron Man / JARVIS-style interface**
+   - visually striking HUD-style operator UI
+   - but still dense, practical, and readable for real work
+3. **Optional ElevenLabs TTS for acceptance blockers**
+   - announce newly created acceptance blockers / critical blocker transitions
+   - fully optional and gracefully disabled if not configured
+4. **A WebGL live visualization**
+   - real-time view of rigs / Mayor / polecats / PRs / blockers / queue relationships
+   - useful, not just decorative
+
+## Current baseline / source of truth
+
+- Existing SGT Web UI already exists under the **repo-tracked** path: `web/` in `codejeet/sgt`
+- There is also a running/deployed copy at `/root/sgt/web`
+- Current running copy and repo `web/` are presently identical, but future work should treat the **repo copy** as canonical source-of-truth
+- Current app is a small Node/Express + WebSocket dashboard with status/logs/dispatch functionality
+- Current live URL is served from the Tailscale host on port `4747`
+
+## Product intent
+
+This should feel like a serious operations console — not a toy dashboard.
+
+Desired vibe:
+- dark HUD / JARVIS-inspired visual language
+- strong live-state awareness
+- clear alerting
+- low cognitive load under pressure
+- compact operator ergonomics
+
+Important: do **not** let the visual theme make it less useful. Dense and practical beats flashy-but-useless.
+
+## Requested outcome
+
+### A. Live tmux monitoring
+
+Add live browser views for:
+- Mayor
+- all active polecats
+- ideally extensible to witness/refinery/dogs/crew later via same mechanism
+
+Requirements:
+- real-time or near-real-time streaming, not static snapshots
+- multiple simultaneous panes/cards
+- easy switching/filtering by rig / issue / worker / role
+- clear stale/disconnected/reconnecting state
+- support tail/follow behavior for active logs
+- support quick peek / expand / focus mode
+
+### B. JARVIS-style UI shell
+
+Redesign the UI into a cohesive ops cockpit.
+
+Expected qualities:
+- HUD-style layout
+- strong information hierarchy
+- visibly distinct states for healthy / active / blocked / stale / critical
+- keyboard-friendly operator flow where sensible
+- preserve existing useful controls (dispatch, logs, status) if still valuable
+
+### C. Acceptance blocker alerting + optional ElevenLabs TTS
+
+When new acceptance blockers are created:
+- surface them prominently in the UI
+- make them visually obvious
+- optionally announce them via ElevenLabs TTS
+
+Requirements:
+- fully optional: if ElevenLabs config is absent, feature should silently degrade to visual-only
+- must not require secrets committed to repo
+- add env/config-driven enablement
+- include mute/disable control and dedupe/rate-limiting so it does not spam
+- blocker announcements should focus on meaningful new blocker events, not noisy repeats
+
+### D. WebGL visualization
+
+Add a live visual layer showing relationships between:
+- Mayor
+- rigs
+- active polecats
+- open PRs
+- open issues
+- acceptance blockers / blocked state
+- maybe merge queue / wake events if it helps
+
+Requirements:
+- live-updating from the same backend state/event stream
+- genuinely useful for orientation / status, not just eye candy
+- degrade gracefully if browser/GPU support is weak
+- should not make the app laggy or unusable on normal operator hardware
+
+## Strong constraints
+
+1. **Canonical code lives in repo `web/`**
+   - do not create yet another divergent standalone web UI tree
+   - if deployment still uses `/root/sgt/web`, include an explicit sync/deploy path after merge
+2. **Do not break the current useful dashboard behavior**
+   - existing status/log/dispatch functionality should remain available or be cleanly superseded
+3. **Do not require ElevenLabs to use the UI**
+   - TTS is optional enhancement, not a hard dependency
+4. **Avoid gimmicks that reduce usability**
+   - keep the operator workflow primary
+5. **Tailnet-first ops**
+   - assume this is primarily used over Tailscale / trusted operator access, not as a public internet app
+
+## Suggested plan shape
+
+The Mayor should decompose this into a real multi-step plan rather than one giant sling. Likely shape:
+
+1. **Audit / architecture pass**
+   - inspect current `web/` implementation
+   - decide backend/frontend shape for live tmux streaming and live event model
+   - decide how to keep repo `web/` canonical while updating deployed copy cleanly
+2. **Backend streaming foundation**
+   - real-time tmux/log/event streaming API / WS model
+   - live data model for mayor, polecats, blockers, PRs, rigs
+3. **UI shell / JARVIS redesign**
+   - new layout system + operator panels + state presentation
+4. **Live tmux monitor views**
+   - Mayor + active polecats first
+   - multi-pane / focus / stale states
+5. **Acceptance blocker alerting + optional TTS**
+   - visual alert center + optional ElevenLabs announcements
+6. **WebGL visualization**
+   - live relationship graph / spatial view / systems model
+7. **Docs + deploy + polish**
+   - setup docs, config docs, deployment/sync path, screenshots, operator instructions
+
+## Completion condition
+
+This plan is complete when an operator can open the SGT Web UI and:
+- watch the Mayor and all active polecats live in-browser,
+- see actionable blocker/rig/PR state in real time,
+- receive optional acceptance-blocker TTS alerts when configured,
+- use a WebGL live visualization that meaningfully reflects current system state,
+- and do so from the repo-tracked `web/` implementation with a clear deployment path.
+
+## Acceptance criteria
+
+1. **Live monitor**: Mayor + active polecats can be watched live in browser with fresh updates and visible stale/reconnect state.
+2. **Operator usability**: UI is materially improved into a coherent JARVIS-style ops console without losing core utility.
+3. **Blocker alerts**: new acceptance blockers are prominently surfaced in UI.
+4. **Optional TTS**: when ElevenLabs config is provided, new acceptance blockers can be voiced; when not provided, UI still works normally.
+5. **WebGL**: a live WebGL visualization exists and reflects current SGT state in a meaningful way.
+6. **Canonical source**: repo `web/` is the maintained source of truth; deployment/update story is documented.
+7. **Docs**: README/setup/config docs explain local run, env vars, optional ElevenLabs setup, and deployment/sync path.
+8. **Graceful degradation**: weak browsers / missing TTS / missing WebGL support do not break the app.
+
+## Operator preference / direction
+
+Be bold about improving the interface. This is explicitly meant to become a serious real-time ops cockpit, not just a lightly polished log page.
+```
+- 2026-03-30T06:02:29+02:00 — Plan request clarification for sgt-1774843161-c615ad59: for ElevenLabs/TTS in the SGT WebUI JARVIS cockpit, the operator mainly wants voice notifications when blockers are cleared/resolved or major milestones are met. New blocker creation/escalation should stay visible in the UI, but TTS for new blockers is lower-priority and should be optional/configurable to avoid noisy negative chatter. The updated spec file at /home/aj/.openclaw/agents/gastown/workspace/notes/sgt-webui-jarvis-plan-2026-03-30.md reflects this preference and should be treated as the latest source text for the pending request.
+- 2026-03-30T06:08:58+02:00 — Issue #262 audit locked the SGT Web cockpit to the existing repo-tracked web/ app: keep a single Node/Express + vanilla JS process, grow it around a normalized snapshot/event model with backend-mediated on-demand tmux streams, treat acceptance blockers as first-class cockpit events, and deploy the canonical repo copy to /root/sgt/web via web/scripts/sync-live-copy.sh.
+- 2026-03-30T06:18:13+02:00 — 2026-03-30 issue #264 added the first normalized web cockpit backend in repo web/: /api/cockpit now emits meta/agents/rigs/workers/queue/blockers/logs/topology from sgt status --json plus blocker files, and the WebSocket now supports demand-driven tmux stream subscribe/unsubscribe with stream/open,data,stale,close events while preserving legacy status/log pushes for the existing UI.

--- a/web/README.md
+++ b/web/README.md
@@ -1,6 +1,6 @@
-# SGT Web UI (Control Panel)
+# SGT Web UI (Operator Shell)
 
-SGT Web UI is a small, dependency-light **real-time dashboard** for SGT (Simple GitHub Gastown): monitor agents/polecats, tail logs, and dispatch new work.
+SGT Web UI is a small, dependency-light **real-time operator shell** for SGT (Simple GitHub Gastown): monitor Mayor and workers live, surface blockers and queue state, tail logs, inspect topology relationships, and dispatch new work.
 
 For the locked follow-on cockpit architecture and deployment path, see [`web/docs/live-cockpit-architecture.md`](docs/live-cockpit-architecture.md).
 
@@ -37,22 +37,20 @@ Environment variables:
 
 ## Features
 
-- **Dashboard** — Live agent status (incl. mayor), polecat overview, merge queue summary
-- **Polecats** — Active polecats with rig/issue/branch/PR; click to peek tmux output
-- **Logs** — Tail `sgt.log` (auto-scroll + realtime updates)
-- **Realtime WS** — Status push (poll every 3s) + log stream; reconnect/backoff + heartbeat + stale indicators
-- **Cockpit snapshot backend** — Normalized `meta/agents/rigs/workers/queue/blockers/logs/topology` document for live cockpit consumers
-- **Demand-driven tmux streams** — WebSocket `stream/subscribe` / `stream/unsubscribe` for Mayor and worker panes, with `stream/open`, `stream/data`, `stream/stale`, and `stream/close` lifecycle events
-- **High density** — Compact mode toggle (`c`), multi-column rows, collapsible cards (persisted)
-- **Keyboard shortcuts** — `1..7` switch panels, `c` toggles compact, `Esc` closes peek modal
-- **Dispatch** — Sling polecats / dogs from the UI
+- **Dense cockpit shell** — Single-page JARVIS-style HUD with command pulse, alert center, worker roster, rig matrix, topology radar, and dispatch console
+- **Live tmux monitoring** — Mayor plus active worker panes subscribe on demand over WebSocket; focus mode and snapshot `peek` remain available
+- **Acceptance blocker center** — Open blockers stay prominent with rig ownership, evidence snippets, and timestamps
+- **Realtime WS** — Normalized `snapshot` pushes plus tmux stream events and live `sgt.log` updates; reconnect/backoff and stale states remain visible
+- **Topology radar** — Canvas relationship view driven from normalized `topology` nodes/edges, with a clean fallback when WebGL is absent
+- **Keyboard shortcuts** — `1..5` jump between shell sections, `c` toggles compact mode, `Esc` closes peek modal
+- **Dispatch** — Sling polecats and dogs without leaving the shell
 
 ## Theme
 
-The UI uses a **dark triadic “modern color wheel” theme** with accents used sparingly:
-- `--accentA` (Cyan) `#22D3EE`
-- `--accentB` (Amber) `#F59E0B`
-- `--accentC` (Lime) `#84CC16`
+The UI uses a dense **dark HUD / JARVIS-inspired** shell:
+- display typography via Orbitron for cockpit headers
+- IBM Plex Sans / Mono for readable dense operational content
+- cyan, amber, lime, and red accents reserved for live state and alert severity
 
 ## Screenshots
 
@@ -97,7 +95,7 @@ The goal is higher reliability, a simpler mental model, and easier ops.
 ## Architecture
 
 - **Backend**: Node.js + Express. Shells out to `sgt` CLI for actions; tails `~/sgt/sgt.log`.
-- **Frontend**: Single HTML page with vanilla JS.
+- **Frontend**: Static vanilla HTML/CSS/JS served by the same process.
 - **Real-time**: WebSocket pushes status and log deltas; includes heartbeat + reconnect/backoff.
 - **Canonical source**: repo `web/` is the source of truth; `/root/sgt/web` is a deployment target.
 

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -1,0 +1,836 @@
+const COMPACT_KEY = "sgt_web_compact";
+
+const appState = {
+  ws: null,
+  wsAttempts: 0,
+  wsReconnectTimer: null,
+  cockpit: emptyCockpit(),
+  rigs: [],
+  lastSnapshotAt: 0,
+  lastLogAt: 0,
+  focusTarget: "mayor",
+  desiredTargets: new Set(),
+  streams: new Map(),
+  sections: ["overview", "streams", "topology", "dispatch", "logs"],
+};
+
+const refs = {
+  wsHealth: document.getElementById("wsHealth"),
+  connLabel: document.getElementById("connLabel"),
+  lastUpdated: document.getElementById("lastUpdated"),
+  lastLog: document.getElementById("lastLog"),
+  compactBtn: document.getElementById("compactBtn"),
+  refreshSnapshotBtn: document.getElementById("refreshSnapshotBtn"),
+  navButtons: Array.from(document.querySelectorAll(".nav-btn")),
+  sections: new Map(Array.from(document.querySelectorAll(".section")).map((el) => [el.id.replace("section-", ""), el])),
+  commandMetrics: document.getElementById("commandMetrics"),
+  workerRoster: document.getElementById("workerRoster"),
+  workerCountLabel: document.getElementById("workerCountLabel"),
+  rigCountLabel: document.getElementById("rigCountLabel"),
+  rigMatrix: document.getElementById("rigMatrix"),
+  blockerSummary: document.getElementById("blockerSummary"),
+  blockerBoard: document.getElementById("blockerBoard"),
+  overviewHero: document.getElementById("overviewHero"),
+  queueBoard: document.getElementById("queueBoard"),
+  streamSummary: document.getElementById("streamSummary"),
+  focusStream: document.getElementById("focusStream"),
+  streamGrid: document.getElementById("streamGrid"),
+  serverTimeLabel: document.getElementById("serverTimeLabel"),
+  topologyMode: document.getElementById("topologyMode"),
+  topologyCanvas: document.getElementById("topologyCanvas"),
+  topologyList: document.getElementById("topologyList"),
+  logSummary: document.getElementById("logSummary"),
+  logViewer: document.getElementById("logViewer"),
+  refreshLogsBtn: document.getElementById("refreshLogsBtn"),
+  slingForm: document.getElementById("slingForm"),
+  dogForm: document.getElementById("dogForm"),
+  slingRig: document.getElementById("slingRig"),
+  dogRig: document.getElementById("dogRig"),
+  slingBtn: document.getElementById("slingBtn"),
+  dogBtn: document.getElementById("dogBtn"),
+  peekModal: document.getElementById("peekModal"),
+  peekTitle: document.getElementById("peekTitle"),
+  peekOutput: document.getElementById("peekOutput"),
+  peekCloseBtn: document.getElementById("peekCloseBtn"),
+  toasts: document.getElementById("toasts"),
+};
+
+initialize();
+
+function initialize() {
+  setCompact(localStorage.getItem(COMPACT_KEY) === "1");
+  bindEvents();
+  detectTopologyMode();
+  loadRigs();
+  loadLogs();
+  connectWs();
+  setInterval(updateClocks, 1000);
+}
+
+function bindEvents() {
+  refs.compactBtn.addEventListener("click", () => setCompact(!document.body.classList.contains("compact")));
+  refs.refreshSnapshotBtn.addEventListener("click", requestSnapshot);
+  refs.refreshLogsBtn.addEventListener("click", loadLogs);
+  refs.peekCloseBtn.addEventListener("click", closePeek);
+  refs.peekModal.addEventListener("click", (event) => {
+    if (event.target === refs.peekModal) closePeek();
+  });
+
+  refs.navButtons.forEach((button) => {
+    button.addEventListener("click", () => activateSection(button.dataset.section));
+  });
+
+  refs.slingForm.addEventListener("submit", handleSlingSubmit);
+  refs.dogForm.addEventListener("submit", handleDogSubmit);
+
+  document.addEventListener("keydown", (event) => {
+    const target = event.target;
+    if (target && ["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName)) return;
+
+    const shortcutMap = {
+      "1": "overview",
+      "2": "streams",
+      "3": "topology",
+      "4": "dispatch",
+      "5": "logs",
+    };
+
+    if (shortcutMap[event.key]) {
+      activateSection(shortcutMap[event.key]);
+      return;
+    }
+
+    if (event.key === "c" || event.key === "C") {
+      setCompact(!document.body.classList.contains("compact"));
+      return;
+    }
+
+    if (event.key === "Escape") {
+      closePeek();
+    }
+  });
+
+  window.addEventListener("resize", renderTopology);
+}
+
+function emptyCockpit() {
+  return {
+    meta: { serverTime: "", featureFlags: {} },
+    agents: [],
+    rigs: [],
+    workers: [],
+    queue: { items: [], summary: { total: 0 } },
+    blockers: [],
+    logs: { lines: [], total: 0 },
+    topology: { nodes: [], edges: [] },
+  };
+}
+
+function setCompact(on) {
+  document.body.classList.toggle("compact", Boolean(on));
+  localStorage.setItem(COMPACT_KEY, on ? "1" : "0");
+}
+
+function activateSection(name) {
+  refs.navButtons.forEach((button) => button.classList.toggle("active", button.dataset.section === name));
+  refs.sections.forEach((section, key) => section.classList.toggle("active", key === name));
+  const active = refs.sections.get(name);
+  if (active) active.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+function wsUrl() {
+  const proto = location.protocol === "https:" ? "wss:" : "ws:";
+  return `${proto}//${location.host}`;
+}
+
+function connectWs() {
+  clearTimeout(appState.wsReconnectTimer);
+
+  try {
+    appState.ws = new WebSocket(wsUrl());
+  } catch {
+    scheduleReconnect();
+    return;
+  }
+
+  appState.ws.onopen = () => {
+    appState.wsAttempts = 0;
+    setConnectionState(true);
+    requestSnapshot();
+  };
+
+  appState.ws.onclose = () => {
+    setConnectionState(false);
+    scheduleReconnect();
+  };
+
+  appState.ws.onerror = () => {
+    try {
+      appState.ws.close();
+    } catch {}
+  };
+
+  appState.ws.onmessage = (event) => {
+    const message = JSON.parse(event.data);
+    handleWsMessage(message);
+  };
+}
+
+function scheduleReconnect() {
+  appState.wsAttempts += 1;
+  const base = Math.min(30000, 600 * Math.pow(2, Math.min(appState.wsAttempts, 8)));
+  const jitter = 0.55 + Math.random() * 0.7;
+  appState.wsReconnectTimer = setTimeout(connectWs, Math.round(base * jitter));
+}
+
+function setConnectionState(connected) {
+  refs.wsHealth.classList.toggle("connected", connected);
+  refs.connLabel.textContent = connected ? "Connected" : "Disconnected";
+}
+
+function requestSnapshot() {
+  if (!appState.ws || appState.ws.readyState !== WebSocket.OPEN) return;
+  appState.ws.send(JSON.stringify({ type: "snapshot/request" }));
+}
+
+function handleWsMessage(message) {
+  if (message.type === "snapshot" && message.snapshot) {
+    appState.cockpit = message.snapshot;
+    appState.lastSnapshotAt = Date.now();
+    if (!appState.focusTarget || !hasTarget(appState.focusTarget)) {
+      appState.focusTarget = preferredFocusTarget();
+    }
+    syncStreamTargets();
+    renderAll();
+    return;
+  }
+
+  if (message.type === "log" && Array.isArray(message.lines)) {
+    appState.lastLogAt = Date.now();
+    const lines = message.lines.filter(Boolean);
+    if (lines.length > 0) {
+      appState.cockpit.logs.lines = [...appState.cockpit.logs.lines, ...lines].slice(-400);
+      appState.cockpit.logs.total = appState.cockpit.logs.lines.length;
+      appendLogLines(lines);
+      refs.logSummary.textContent = `${appState.cockpit.logs.total} lines buffered`;
+    }
+    return;
+  }
+
+  if (message.type === "log_reset") {
+    appState.cockpit.logs.lines = [];
+    refs.logViewer.innerHTML = "";
+    loadLogs();
+    return;
+  }
+
+  if (message.type && message.type.startsWith("stream/")) {
+    handleStreamEvent(message);
+  }
+}
+
+function handleStreamEvent(message) {
+  const target = message.target;
+  if (!target) return;
+  const existing = appState.streams.get(target) || {
+    target,
+    content: "",
+    state: "opening",
+    follow: true,
+    lastEventAt: 0,
+    session: "",
+  };
+
+  if (message.type === "stream/open") {
+    existing.state = "live";
+    existing.session = message.session || "";
+    existing.lastEventAt = Date.now();
+  } else if (message.type === "stream/data") {
+    existing.state = "live";
+    existing.session = message.session || existing.session;
+    existing.lastEventAt = Date.now();
+    existing.content = message.reset ? message.chunk : `${existing.content}${message.chunk}`;
+  } else if (message.type === "stream/stale") {
+    existing.state = "stale";
+    existing.reason = message.reason || "session-unavailable";
+    existing.lastEventAt = Date.now();
+  } else if (message.type === "stream/close") {
+    existing.state = "closed";
+    existing.reason = message.reason || "unsubscribed";
+    existing.lastEventAt = Date.now();
+  }
+
+  appState.streams.set(target, existing);
+  renderStreamDeck();
+}
+
+function preferredFocusTarget() {
+  const liveWorker = appState.cockpit.workers.find((worker) => worker.stream && worker.stream.available);
+  return liveWorker ? liveWorker.stream.target : "mayor";
+}
+
+function syncStreamTargets() {
+  const desired = new Set(["mayor"]);
+  const workers = [...appState.cockpit.workers]
+    .filter((worker) => worker.stream && worker.stream.available)
+    .sort((left, right) => workerPriority(right) - workerPriority(left));
+
+  if (appState.focusTarget) desired.add(appState.focusTarget);
+  for (const worker of workers.slice(0, 4)) desired.add(worker.stream.target);
+
+  const previous = appState.desiredTargets;
+  appState.desiredTargets = desired;
+
+  for (const target of desired) {
+    if (!previous.has(target)) sendWs({ type: "stream/subscribe", target });
+  }
+  for (const target of previous) {
+    if (!desired.has(target)) sendWs({ type: "stream/unsubscribe", target });
+  }
+}
+
+function sendWs(payload) {
+  if (!appState.ws || appState.ws.readyState !== WebSocket.OPEN) return;
+  appState.ws.send(JSON.stringify(payload));
+}
+
+function hasTarget(target) {
+  if (target === "mayor") return true;
+  return appState.cockpit.workers.some((worker) => worker.stream && worker.stream.target === target);
+}
+
+function renderAll() {
+  refs.lastUpdated.textContent = timeLabel(appState.lastSnapshotAt);
+  refs.lastLog.textContent = timeLabel(appState.lastLogAt);
+  refs.serverTimeLabel.textContent = appState.cockpit.meta.serverTime ? formatIso(appState.cockpit.meta.serverTime) : "waiting";
+  renderMetrics();
+  renderRoster();
+  renderRigs();
+  renderBlockers();
+  renderQueue();
+  renderStreamDeck();
+  renderLogs();
+  renderTopology();
+}
+
+function renderMetrics() {
+  const agentsOnline = appState.cockpit.agents.filter((agent) => String(agent.status).startsWith("on")).length;
+  const liveWorkers = appState.cockpit.workers.filter((worker) => worker.status === "alive").length;
+  const blockedRigs = appState.cockpit.rigs.filter((rig) => rig.blockers > 0).length;
+  const staleStreams = Array.from(appState.streams.values()).filter((stream) => stream.state === "stale").length;
+
+  const metrics = [
+    {
+      label: "Agents Online",
+      value: `${agentsOnline}/${appState.cockpit.agents.length || 0}`,
+      detail: "Daemon, Mayor, witness, refinery, and support process health.",
+    },
+    {
+      label: "Live Workers",
+      value: `${liveWorkers}`,
+      detail: `${appState.cockpit.workers.length} tracked workers with issue and branch context.`,
+    },
+    {
+      label: "Open Blockers",
+      value: `${appState.cockpit.blockers.length}`,
+      detail: blockedRigs ? `${blockedRigs} rigs are acceptance-blocked.` : "No rigs are blocked right now.",
+    },
+    {
+      label: "Queue Pressure",
+      value: `${appState.cockpit.queue.summary.total || 0}`,
+      detail: staleStreams ? `${staleStreams} subscribed streams are stale.` : "All subscribed streams are fresh.",
+    },
+  ];
+
+  refs.commandMetrics.innerHTML = metrics.map((metric) => `
+    <div class="metric-card">
+      <div class="eyebrow">${esc(metric.label)}</div>
+      <strong>${esc(metric.value)}</strong>
+      <div class="metric-detail">${esc(metric.detail)}</div>
+    </div>
+  `).join("");
+}
+
+function renderRoster() {
+  refs.workerCountLabel.textContent = `${appState.cockpit.workers.length} tracked`;
+
+  if (appState.cockpit.workers.length === 0) {
+    refs.workerRoster.innerHTML = "";
+    return;
+  }
+
+  const workers = [...appState.cockpit.workers].sort((left, right) => workerPriority(right) - workerPriority(left));
+  refs.workerRoster.innerHTML = workers.map((worker) => {
+    const target = worker.stream ? worker.stream.target : worker.name;
+    const stateClass = workerStateClass(worker);
+    const focusLabel = appState.focusTarget === target ? "Focused" : "Focus";
+    return `
+      <article class="roster-item">
+        <div class="roster-head">
+          <div class="roster-title">${esc(worker.name)}</div>
+          <span class="state-pill ${stateClass}">${esc(worker.status || "unknown")}</span>
+        </div>
+        <div class="roster-meta">
+          <span>${esc(worker.role)}</span>
+          ${worker.rig ? `<span>${esc(worker.rig)}</span>` : ""}
+          ${worker.issue ? `<span>#${esc(worker.issue)}</span>` : ""}
+          ${worker.branch ? `<span>${esc(worker.branch)}</span>` : ""}
+        </div>
+        <div class="roster-actions">
+          <button class="btn tiny ghost" data-focus-target="${escAttr(target)}">${focusLabel}</button>
+          <button class="btn tiny ghost" data-peek-target="${escAttr(target)}">Peek</button>
+        </div>
+      </article>
+    `;
+  }).join("");
+
+  refs.workerRoster.querySelectorAll("[data-focus-target]").forEach((button) => {
+    button.addEventListener("click", () => {
+      appState.focusTarget = button.dataset.focusTarget;
+      syncStreamTargets();
+      renderStreamDeck();
+      activateSection("streams");
+    });
+  });
+
+  refs.workerRoster.querySelectorAll("[data-peek-target]").forEach((button) => {
+    button.addEventListener("click", () => peek(button.dataset.peekTarget));
+  });
+}
+
+function renderRigs() {
+  refs.rigCountLabel.textContent = `${appState.cockpit.rigs.length} rigs`;
+  refs.rigMatrix.innerHTML = appState.cockpit.rigs.map((rig) => `
+    <article class="rig-item">
+      <div class="rig-head">
+        <div class="rig-name">${esc(rig.name)}</div>
+        <span class="state-pill ${rigStateClass(rig)}">${esc(rig.state || "unknown")}</span>
+      </div>
+      <div class="rig-meta">
+        <span>${rig.activeWorkers || 0} workers</span>
+        <span>${rig.blockers || 0} blockers</span>
+        <span>${rig.mergeQueue || 0} queue</span>
+      </div>
+      <div class="subtle">${esc(rig.reason || "No mayor detail available.")}</div>
+    </article>
+  `).join("");
+}
+
+function renderBlockers() {
+  refs.blockerSummary.textContent = `${appState.cockpit.blockers.length} open blockers`;
+  if (appState.cockpit.blockers.length === 0) {
+    refs.blockerBoard.innerHTML = `<div class="empty-state">Acceptance blockers will surface here with evidence and rig ownership.</div>`;
+    return;
+  }
+
+  refs.blockerBoard.innerHTML = appState.cockpit.blockers.map((blocker) => `
+    <article class="blocker-card">
+      <div class="queue-head">
+        <div class="blocker-title">${esc(blocker.title)}</div>
+        <span class="state-pill state-blocked">${esc(blocker.status)}</span>
+      </div>
+      <div class="blocker-meta">
+        <span>${esc(blocker.rig || "unknown rig")}</span>
+        <span>${esc(blocker.requester || "unknown reporter")}</span>
+        <span>${esc(formatIso(blocker.createdAt))}</span>
+      </div>
+      <p>${esc(snippet(blocker.evidence || "No evidence body recorded.", 240))}</p>
+    </article>
+  `).join("");
+}
+
+function renderQueue() {
+  const items = appState.cockpit.queue.items || [];
+  if (items.length === 0) {
+    refs.queueBoard.innerHTML = `<div class="empty-state">Merge queue is clear.</div>`;
+    return;
+  }
+
+  refs.queueBoard.innerHTML = items.map((item) => `
+    <article class="queue-item">
+      <div class="queue-head">
+        <div class="queue-name">${esc(item.name || "queue-item")}</div>
+        <span class="state-pill state-active">queued</span>
+      </div>
+      <div class="queue-meta">
+        <span>${esc(item.detail || "No detail")}</span>
+      </div>
+    </article>
+  `).join("");
+}
+
+function renderStreamDeck() {
+  const orderedTargets = Array.from(appState.desiredTargets);
+  refs.streamSummary.textContent = `${orderedTargets.length} subscriptions`;
+  refs.overviewHero.innerHTML = renderHeroStream(appState.focusTarget || "mayor");
+  refs.focusStream.innerHTML = renderHeroStream(appState.focusTarget || "mayor");
+
+  const others = orderedTargets.filter((target) => target !== appState.focusTarget);
+  refs.streamGrid.innerHTML = others.map((target) => renderMiniStream(target)).join("");
+
+  bindStreamActions(refs.focusStream);
+  bindStreamActions(refs.streamGrid);
+  bindStreamActions(refs.overviewHero);
+}
+
+function renderHeroStream(target) {
+  const stream = streamFor(target);
+  return `
+    <article class="hero-card">
+      <div class="stream-head">
+        <div class="stream-title">
+          <div class="stream-target">${esc(target)}</div>
+          <div class="stream-meta">${esc(streamCaption(stream))}</div>
+        </div>
+        <div class="stream-actions">
+          <span class="state-pill ${streamStateClass(stream)}">${esc(stream.state)}</span>
+          <button class="btn tiny ghost" data-peek-target="${escAttr(target)}">Peek</button>
+        </div>
+      </div>
+      <div class="stream-body" data-stream-target="${escAttr(target)}">${esc(stream.content || "Waiting for tmux stream data...")}</div>
+    </article>
+  `;
+}
+
+function renderMiniStream(target) {
+  const stream = streamFor(target);
+  return `
+    <article class="stream-card">
+      <div class="stream-head">
+        <div class="stream-title">
+          <div class="stream-target">${esc(target)}</div>
+          <div class="stream-meta">${esc(streamCaption(stream))}</div>
+        </div>
+        <div class="stream-actions">
+          <span class="state-pill ${streamStateClass(stream)}">${esc(stream.state)}</span>
+          <button class="btn tiny ghost" data-focus-target="${escAttr(target)}">Focus</button>
+        </div>
+      </div>
+      <div class="stream-body" data-stream-target="${escAttr(target)}">${esc(stream.content || "Waiting for tmux stream data...")}</div>
+    </article>
+  `;
+}
+
+function bindStreamActions(root) {
+  root.querySelectorAll("[data-focus-target]").forEach((button) => {
+    button.addEventListener("click", () => {
+      appState.focusTarget = button.dataset.focusTarget;
+      syncStreamTargets();
+      renderStreamDeck();
+    });
+  });
+  root.querySelectorAll("[data-peek-target]").forEach((button) => {
+    button.addEventListener("click", () => peek(button.dataset.peekTarget));
+  });
+  root.querySelectorAll("[data-stream-target]").forEach((el) => {
+    const stream = appState.streams.get(el.dataset.streamTarget);
+    if (!stream) return;
+    const wasNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+    if (stream.follow || wasNearBottom) {
+      el.scrollTop = el.scrollHeight;
+      stream.follow = true;
+    }
+    el.addEventListener("scroll", () => {
+      stream.follow = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+    });
+  });
+}
+
+function streamFor(target) {
+  return appState.streams.get(target) || {
+    target,
+    content: "",
+    state: "opening",
+    follow: true,
+    lastEventAt: 0,
+    session: "",
+  };
+}
+
+function renderLogs() {
+  refs.logSummary.textContent = `${appState.cockpit.logs.total || appState.cockpit.logs.lines.length} lines buffered`;
+  const nearTail = refs.logViewer.scrollHeight - refs.logViewer.scrollTop - refs.logViewer.clientHeight < 40;
+  refs.logViewer.innerHTML = (appState.cockpit.logs.lines || []).map(formatLogLine).join("");
+  if (nearTail || !refs.logViewer.dataset.rendered) {
+    refs.logViewer.scrollTop = refs.logViewer.scrollHeight;
+  }
+  refs.logViewer.dataset.rendered = "1";
+}
+
+function appendLogLines(lines) {
+  const viewer = refs.logViewer;
+  const nearTail = viewer.scrollHeight - viewer.scrollTop - viewer.clientHeight < 40;
+  viewer.innerHTML += lines.map(formatLogLine).join("");
+  if (nearTail) viewer.scrollTop = viewer.scrollHeight;
+}
+
+async function loadRigs() {
+  try {
+    const response = await fetch("/api/rigs");
+    appState.rigs = await response.json();
+    populateRigSelects();
+  } catch {}
+}
+
+function populateRigSelects() {
+  const options = appState.rigs.map((rig) => `<option value="${escAttr(rig.name)}">${esc(rig.name)}</option>`).join("");
+  const placeholder = `<option value="">Select a rig...</option>`;
+  refs.slingRig.innerHTML = placeholder + options;
+  refs.dogRig.innerHTML = placeholder + options;
+}
+
+async function handleSlingSubmit(event) {
+  event.preventDefault();
+  refs.slingBtn.disabled = true;
+  refs.slingBtn.textContent = "Dispatching...";
+  try {
+    const labels = document.getElementById("slingLabels").value.split(",").map((label) => label.trim()).filter(Boolean);
+    const response = await fetch("/api/sling", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        rig: refs.slingRig.value,
+        task: document.getElementById("slingTask").value,
+        labels,
+        convoy: document.getElementById("slingConvoy").value || undefined,
+      }),
+    });
+    const payload = await response.json();
+    if (!response.ok) throw new Error(payload.error || "Dispatch failed");
+    toast("Polecat dispatched.", "success");
+    refs.slingForm.reset();
+  } catch (error) {
+    toast(error.message, "error");
+  } finally {
+    refs.slingBtn.disabled = false;
+    refs.slingBtn.textContent = "Dispatch Polecat";
+    populateRigSelects();
+  }
+}
+
+async function handleDogSubmit(event) {
+  event.preventDefault();
+  refs.dogBtn.disabled = true;
+  refs.dogBtn.textContent = "Dispatching...";
+  try {
+    const response = await fetch("/api/sling-dog", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        rig: refs.dogRig.value,
+        issue: document.getElementById("dogIssue").value.replace("#", ""),
+      }),
+    });
+    const payload = await response.json();
+    if (!response.ok) throw new Error(payload.error || "Dispatch failed");
+    toast("Dog dispatched.", "success");
+    refs.dogForm.reset();
+  } catch (error) {
+    toast(error.message, "error");
+  } finally {
+    refs.dogBtn.disabled = false;
+    refs.dogBtn.textContent = "Dispatch Dog";
+    populateRigSelects();
+  }
+}
+
+async function loadLogs() {
+  try {
+    const response = await fetch("/api/logs?lines=250");
+    const payload = await response.json();
+    appState.cockpit.logs.lines = payload.lines || [];
+    appState.cockpit.logs.total = appState.cockpit.logs.lines.length;
+    appState.lastLogAt = Date.now();
+    refs.logViewer.dataset.rendered = "";
+    renderLogs();
+  } catch {}
+}
+
+async function peek(target) {
+  refs.peekModal.classList.add("active");
+  refs.peekTitle.textContent = `Peek: ${target}`;
+  refs.peekOutput.textContent = "Loading...";
+  try {
+    const response = await fetch(`/api/peek/${encodeURIComponent(target)}`);
+    const payload = await response.json();
+    refs.peekOutput.textContent = payload.output || payload.error || "No output.";
+  } catch (error) {
+    refs.peekOutput.textContent = `Error: ${error.message}`;
+  }
+}
+
+function closePeek() {
+  refs.peekModal.classList.remove("active");
+}
+
+function renderTopology() {
+  const topology = appState.cockpit.topology || { nodes: [], edges: [] };
+  refs.topologyList.innerHTML = (topology.edges || []).slice(0, 16).map((edge) => `
+    <div class="topology-item">${esc(edge.from)} -> ${esc(edge.to)} (${esc(edge.type)})</div>
+  `).join("");
+
+  const canvas = refs.topologyCanvas;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  const width = canvas.clientWidth || canvas.width;
+  const height = canvas.clientHeight || canvas.height;
+  canvas.width = width * devicePixelRatio;
+  canvas.height = height * devicePixelRatio;
+  ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+  ctx.clearRect(0, 0, width, height);
+
+  const nodes = topology.nodes || [];
+  const edges = topology.edges || [];
+  if (nodes.length === 0) {
+    ctx.fillStyle = "#7fa9bc";
+    ctx.font = "14px IBM Plex Sans";
+    ctx.fillText("Topology data will appear when the cockpit snapshot contains nodes.", 20, 34);
+    return;
+  }
+
+  const positions = new Map();
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const radius = Math.max(120, Math.min(width, height) / 2.8);
+
+  nodes.forEach((node, index) => {
+    const angle = (Math.PI * 2 * index) / Math.max(nodes.length, 1) - Math.PI / 2;
+    positions.set(node.id, {
+      x: centerX + Math.cos(angle) * radius,
+      y: centerY + Math.sin(angle) * radius,
+      color: topologyColor(node.type, node.state),
+    });
+  });
+
+  ctx.lineWidth = 1.2;
+  edges.forEach((edge) => {
+    const from = positions.get(edge.from);
+    const to = positions.get(edge.to);
+    if (!from || !to) return;
+    ctx.strokeStyle = "rgba(77, 214, 255, 0.28)";
+    ctx.beginPath();
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
+    ctx.stroke();
+  });
+
+  nodes.forEach((node) => {
+    const pos = positions.get(node.id);
+    if (!pos) return;
+    ctx.fillStyle = pos.color;
+    ctx.shadowBlur = 18;
+    ctx.shadowColor = pos.color;
+    ctx.beginPath();
+    ctx.arc(pos.x, pos.y, 8, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.shadowBlur = 0;
+    ctx.fillStyle = "#d9f4ff";
+    ctx.font = "12px IBM Plex Sans";
+    ctx.fillText(node.label || node.id, pos.x + 12, pos.y + 4);
+  });
+}
+
+function detectTopologyMode() {
+  const hasWebGl = Boolean(window.WebGLRenderingContext && document.createElement("canvas").getContext("webgl"));
+  refs.topologyMode.textContent = hasWebGl ? "WebGL-ready browser, canvas radar active" : "Canvas fallback";
+}
+
+function topologyColor(type, state) {
+  if (type === "blocker" || state === "blocked") return "#ff6b6b";
+  if (type === "rig") return "#8bf0ff";
+  if (type === "queue") return "#f8b84a";
+  if (state === "alive" || state === "active") return "#9df77d";
+  return "#7da8ff";
+}
+
+function workerPriority(worker) {
+  return (worker.status === "alive" ? 20 : 0) + (worker.role === "polecat" ? 8 : 0) + (worker.issue ? 4 : 0);
+}
+
+function workerStateClass(worker) {
+  if (worker.status === "alive") return "state-live";
+  if (worker.warning) return "state-warn";
+  return "state-bad";
+}
+
+function rigStateClass(rig) {
+  if (rig.blockers > 0) return "state-blocked";
+  if (String(rig.state).includes("hibernat")) return "state-warn";
+  if (rig.activeWorkers > 0) return "state-active";
+  return "state-good";
+}
+
+function streamStateClass(stream) {
+  if (stream.state === "live") return "state-live";
+  if (stream.state === "stale") return "state-stale";
+  if (stream.state === "closed") return "state-bad";
+  return "state-active";
+}
+
+function streamCaption(stream) {
+  if (stream.state === "live") {
+    return stream.session ? `Live tmux stream from ${stream.session}` : "Live tmux stream";
+  }
+  if (stream.state === "stale") {
+    return `Stale stream${stream.reason ? `: ${stream.reason}` : ""}`;
+  }
+  if (stream.state === "closed") {
+    return `Closed${stream.reason ? `: ${stream.reason}` : ""}`;
+  }
+  return "Waiting for stream open";
+}
+
+function updateClocks() {
+  refs.lastUpdated.textContent = timeLabel(appState.lastSnapshotAt);
+  refs.lastLog.textContent = timeLabel(appState.lastLogAt);
+}
+
+function timeLabel(timestamp) {
+  if (!timestamp) return "--";
+  return new Date(timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+function formatIso(iso) {
+  if (!iso) return "unknown";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString([], {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function snippet(value, maxLength) {
+  if (!value) return "";
+  return value.length > maxLength ? `${value.slice(0, maxLength - 1)}...` : value;
+}
+
+function formatLogLine(line) {
+  const match = line.match(/^\[([^\]]+)\]\s+(\S+)\s*(.*)/);
+  if (match) {
+    return `<div class="log-line"><span class="timestamp">[${esc(match[1])}]</span> <span class="log-event">${esc(match[2])}</span> ${esc(match[3])}</div>`;
+  }
+  return `<div class="log-line">${esc(line)}</div>`;
+}
+
+function toast(message, type) {
+  const node = document.createElement("div");
+  node.className = `toast ${type || ""}`;
+  node.textContent = message;
+  refs.toasts.appendChild(node);
+  setTimeout(() => node.remove(), 4000);
+}
+
+function esc(value) {
+  if (value == null) return "";
+  const div = document.createElement("div");
+  div.textContent = String(value);
+  return div.innerHTML;
+}
+
+function escAttr(value) {
+  return esc(value).replace(/"/g, "&quot;");
+}

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -3,729 +3,168 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>SGT Control Panel</title>
-<style>
-  :root {
-    /* =============================
-       Theme: modern color wheel (triadic)
-       - dark UI, crisp separators
-       - accents sparingly
-       ============================= */
-
-    --bg: #0B0F14;            /* page */
-    --panel: #0F1520;         /* cards, modals */
-    --panel-2: #0C121B;       /* subtle alternate */
-    --border: #1F2A37;        /* crisp separators */
-    --border-2: #243244;
-
-    --text: #E5E7EB;
-    --muted: #9CA3AF;
-
-    --accentA: #22D3EE;       /* cyan */
-    --accentB: #F59E0B;       /* amber */
-    --accentC: #84CC16;       /* lime */
-
-    --danger: #EF4444;
-    --ok: var(--accentC);
-    --warn: var(--accentB);
-
-    /* subtle rounding only */
-    --radius: 3px;
-
-    /* density controls */
-    --pad-page: 28px;
-    --pad-card-h: 16px;
-    --pad-card-v: 16px;
-    --pad-item: 12px;
-    --font: 14px;
-    --line: 1.45;
-  }
-
-  body.compact {
-    --pad-page: 18px;
-    --pad-card-h: 12px;
-    --pad-card-v: 12px;
-    --pad-item: 10px;
-    --font: 13px;
-    --line: 1.35;
-  }
-
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body {
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    background: var(--bg);
-    color: var(--text);
-    font-size: var(--font);
-    line-height: var(--line);
-    -webkit-font-smoothing: antialiased;
-  }
-  a { color: var(--text); text-decoration: underline; text-decoration-color: rgba(229,231,235,0.35); }
-  a:hover { color: var(--accentA); text-decoration-color: rgba(34,211,238,0.65); }
-
-  /* Header */
-  .header {
-    border-bottom: 1px solid var(--border);
-    padding: 18px 28px;
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 12px;
-    background: var(--bg);
-  }
-  body.compact .header { padding: 14px 18px; }
-
-  .header h1 {
-    font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 0.2em;
-    text-transform: uppercase;
-    color: var(--text);
-  }
-  .header h1 span {
-    color: var(--accentA);
-    font-size: 22px;
-    letter-spacing: 0.05em;
-    display: block;
-    text-transform: none;
-    margin-bottom: 2px;
-  }
-
-  .header-right {
-    display: flex;
-    align-items: center;
-    gap: 14px;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-  }
-
-  .mini {
-    font-size: 11px;
-    font-weight: 500;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    color: var(--muted);
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .conn-dot {
-    width: 10px; height: 10px;
-    border-radius: 50%;
-    background: var(--red);
-    flex-shrink: 0;
-  }
-  .conn-dot.connected { background: var(--ok); }
-
-  .stale {
-    color: var(--warn);
-    font-weight: 700;
-  }
-
-  /* Navigation */
-  .nav {
-    border-bottom: 1px solid var(--border);
-    display: flex;
-    gap: 0;
-    overflow-x: auto;
-    padding: 0 28px;
-    background: var(--bg);
-  }
-  body.compact .nav { padding: 0 18px; }
-
-  .nav button {
-    background: none;
-    border: none;
-    color: var(--muted);
-    padding: 10px 0;
-    margin-right: 22px;
-    font-family: inherit;
-    font-size: 11px;
-    font-weight: 500;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    cursor: pointer;
-    border-bottom: 2px solid transparent;
-    white-space: nowrap;
-    transition: color 0.15s;
-  }
-  .nav button:hover { color: var(--text); }
-  .nav button.active {
-    color: var(--text);
-    border-bottom-color: var(--accentA);
-  }
-
-  /* Main content */
-  .main {
-    padding: var(--pad-page);
-    max-width: 1320px;
-    background: var(--bg);
-  }
-  body.compact .main { max-width: 1600px; }
-
-  .panel { display: none; }
-  .panel.active { display: block; }
-
-  /* Cards */
-  .card {
-    background: var(--panel);
-    border: 1px solid var(--border);
-    margin-bottom: 18px;
-    overflow: hidden;
-    border-radius: var(--radius);
-  }
-  .card-header {
-    padding: var(--pad-card-v) var(--pad-card-h);
-    font-size: 10px;
-    font-weight: 700;
-    color: var(--text);
-    text-transform: uppercase;
-    letter-spacing: 0.15em;
-    border-bottom: 1px solid var(--border);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    background: rgba(255,255,255,0.02);
-  }
-  .card-header .right {
-    display: inline-flex;
-    align-items: center;
-    gap: 10px;
-  }
-
-  .card-header.collapsible { cursor: pointer; user-select: none; }
-  .card-header .chev { font-size: 12px; color: var(--muted); }
-  .card-body { padding: var(--pad-card-v) var(--pad-card-h); }
-
-  .card.collapsed .card-body { display: none; }
-  .card.collapsed .card-header { border-bottom: none; }
-
-  /* Status indicators */
-  .status-dot {
-    display: inline-block;
-    width: 8px; height: 8px;
-    border-radius: 50%;
-    margin-right: 8px;
-    flex-shrink: 0;
-  }
-  .status-on { background: var(--ok); }
-  .status-off { background: var(--border); }
-  .status-alive { background: var(--ok); }
-  .status-dead { background: var(--border); }
-
-  /* Agent grid */
-  .agent-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: 10px;
-  }
-  body.compact .agent-grid {
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-    gap: 8px;
-  }
-
-  .agent-item {
-    border: 1px solid var(--border);
-    padding: 12px;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    border-radius: var(--radius);
-    background: rgba(255,255,255,0.01);
-  }
-  body.compact .agent-item { padding: 10px; }
-
-  .agent-item .name {
-    font-weight: 600;
-    font-size: 13px;
-    flex: 1;
-  }
-  .agent-item .meta {
-    color: var(--muted);
-    font-size: 11px;
-    text-align: right;
-  }
-
-  /* Worker lists */
-  .worker-list { display: flex; flex-direction: column; gap: 0; }
-  .worker-item {
-    padding: var(--pad-item) var(--pad-card-h);
-    cursor: pointer;
-    border-bottom: 1px solid var(--border);
-    transition: background 0.1s;
-  }
-  .worker-item:last-child { border-bottom: none; }
-  .worker-item:hover { background: rgba(34,211,238,0.05); }
-  .worker-item .worker-header {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 4px;
-  }
-  .worker-item .worker-name {
-    font-weight: 600;
-    font-size: 13px;
-    font-family: 'SF Mono', 'Consolas', 'Liberation Mono', monospace;
-    letter-spacing: -0.01em;
-  }
-  .worker-item .worker-meta {
-    color: var(--muted);
-    font-size: 12px;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 2px 16px;
-    padding-left: 16px;
-  }
-  .worker-item .worker-meta span { display: block; }
-
-  .badge {
-    font-size: 9px;
-    padding: 2px 8px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    border-radius: var(--radius);
-  }
-  .badge-alive { background: rgba(132,204,22,0.18); color: var(--accentC); border: 1px solid rgba(132,204,22,0.35); }
-  .badge-dead { background: rgba(156,163,175,0.08); color: var(--muted); border: 1px solid rgba(156,163,175,0.22); }
-  .badge-running { background: rgba(34,211,238,0.14); color: var(--accentA); border: 1px solid rgba(34,211,238,0.35); }
-
-  /* Rig cards */
-  .rig-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: 12px;
-  }
-  .rig-card {
-    border: 1px solid var(--border);
-    padding: 14px;
-    border-radius: var(--radius);
-    background: rgba(255,255,255,0.01);
-  }
-  .rig-card .rig-name {
-    font-weight: 700;
-    font-size: 15px;
-    margin-bottom: 3px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .rig-card .rig-repo {
-    color: var(--muted);
-    font-size: 12px;
-    margin-bottom: 12px;
-    word-break: break-all;
-  }
-  .rig-card .rig-stats {
-    display: flex;
-    gap: 16px;
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    flex-wrap: wrap;
-  }
-  .rig-card .rig-stats span { color: var(--muted); }
-  .rig-card .rig-stats .val { color: var(--text); font-weight: 700; }
-
-  /* Sling form */
-  .sling-form {
-    display: flex;
-    flex-direction: column;
-    gap: 14px;
-    max-width: 680px;
-  }
-  .form-group { display: flex; flex-direction: column; gap: 6px; }
-  .form-group label {
-    font-size: 10px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    color: var(--text);
-  }
-  .form-group select,
-  .form-group input,
-  .form-group textarea {
-    background: var(--panel-2);
-    border: 1px solid var(--border);
-    color: var(--text);
-    padding: 8px 10px;
-    font-family: inherit;
-    font-size: var(--font);
-    transition: border-color 0.15s, box-shadow 0.15s;
-    border-radius: var(--radius);
-  }
-  .form-group textarea { min-height: 92px; resize: vertical; }
-  .form-group select:focus,
-  .form-group input:focus,
-  .form-group textarea:focus {
-    outline: none;
-    border-color: rgba(34,211,238,0.65);
-    box-shadow: 0 0 0 3px rgba(34,211,238,0.18);
-  }
-  .form-row { display: flex; gap: 12px; }
-  .form-row .form-group { flex: 1; }
-
-  .btn {
-    background: rgba(34,211,238,0.14);
-    color: var(--accentA);
-    border: 1px solid rgba(34,211,238,0.35);
-    padding: 8px 14px;
-    font-family: inherit;
-    font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    cursor: pointer;
-    align-self: flex-start;
-    transition: background 0.15s, border-color 0.15s, color 0.15s;
-    border-radius: var(--radius);
-  }
-  .btn:hover {
-    background: rgba(34,211,238,0.20);
-    border-color: rgba(34,211,238,0.55);
-  }
-  .btn:disabled { opacity: 0.3; cursor: not-allowed; }
-  .btn-secondary {
-    background: transparent;
-    border: 1px solid var(--border);
-    color: var(--text);
-  }
-  .btn-secondary:hover {
-    border-color: rgba(245,158,11,0.55);
-    background: rgba(245,158,11,0.08);
-  }
-
-  /* Log viewer */
-  .log-viewer {
-    background: var(--panel-2);
-    border: 1px solid var(--border);
-    height: 520px;
-    overflow-y: auto;
-    padding: 12px;
-    font-family: 'SF Mono', 'Consolas', 'Liberation Mono', monospace;
-    font-size: 12px;
-    line-height: 1.55;
-    border-radius: var(--radius);
-  }
-  body.compact .log-viewer { height: 620px; }
-
-  .log-line { white-space: pre-wrap; word-break: break-word; }
-  .log-line .timestamp { color: var(--muted); }
-  .log-line .event { color: var(--accentB); font-weight: 700; }
-
-  /* Merge queue */
-  .mq-list { display: flex; flex-direction: column; gap: 0; }
-  .mq-item {
-    padding: var(--pad-item) var(--pad-card-h);
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    border-bottom: 1px solid var(--border);
-  }
-  .mq-item:last-child { border-bottom: none; }
-  .mq-item .mq-pr { font-weight: 700; font-size: 13px; }
-  .mq-item .mq-meta { color: var(--muted); font-size: 12px; flex: 1; }
-
-  /* Peek modal */
-  .modal-overlay {
-    display: none;
-    position: fixed;
-    inset: 0;
-    background: rgba(0,0,0,0.4);
-    z-index: 100;
-    align-items: center;
-    justify-content: center;
-  }
-  .modal-overlay.active { display: flex; }
-  .modal {
-    background: var(--panel);
-    border: 2px solid var(--border-2);
-    width: 92%;
-    max-width: 940px;
-    max-height: 84vh;
-    display: flex;
-    flex-direction: column;
-    border-radius: calc(var(--radius) + 1px);
-    overflow: hidden;
-  }
-  .modal-header {
-    padding: 12px 16px;
-    border-bottom: 1px solid var(--border);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    font-weight: 700;
-    font-size: 11px;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-  }
-  .modal-header button {
-    background: none;
-    border: none;
-    color: var(--text);
-    font-size: 22px;
-    cursor: pointer;
-    line-height: 1;
-  }
-  .modal-header button:hover { color: var(--accentA); }
-  .modal-body {
-    padding: 16px;
-    overflow-y: auto;
-    flex: 1;
-  }
-  .modal-body pre {
-    white-space: pre-wrap;
-    word-break: break-word;
-    font-family: 'SF Mono', 'Consolas', 'Liberation Mono', monospace;
-    font-size: 12px;
-    line-height: 1.55;
-  }
-
-  /* Empty state */
-  .empty {
-    color: var(--muted);
-    text-align: center;
-    padding: 26px 18px;
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-  }
-
-  /* Toast notifications */
-  .toast-container {
-    position: fixed;
-    bottom: 18px;
-    right: 18px;
-    z-index: 200;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-  .toast {
-    background: var(--panel);
-    color: var(--text);
-    border: 1px solid var(--border);
-    padding: 10px 14px;
-    font-size: 12px;
-    font-weight: 500;
-    max-width: 420px;
-    animation: slideIn 0.2s ease-out;
-    border-radius: var(--radius);
-  }
-  .toast.error { border-color: rgba(239,68,68,0.55); color: #fecaca; }
-  .toast.success { border-color: rgba(132,204,22,0.55); color: #d9f99d; }
-  @keyframes slideIn {
-    from { opacity: 0; transform: translateY(8px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
-
-  /* Section titles */
-  .section-title {
-    font-size: 10px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.15em;
-    margin-bottom: 14px;
-    padding-bottom: 10px;
-    border-bottom: 1px solid var(--border);
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    color: var(--muted);
-  }
-  .count {
-    background: rgba(34,211,238,0.14);
-    color: var(--accentA);
-    border: 1px solid rgba(34,211,238,0.35);
-    padding: 2px 8px;
-    font-size: 10px;
-    font-weight: 700;
-    border-radius: var(--radius);
-  }
-
-  /* Keyboard hint */
-  .kbd {
-    border: 1px solid var(--border);
-    font-family: 'SF Mono', 'Consolas', 'Liberation Mono', monospace;
-    font-size: 10px;
-    padding: 1px 6px;
-    border-radius: var(--radius);
-    color: var(--muted);
-    background: rgba(255,255,255,0.03);
-    text-transform: none;
-    letter-spacing: 0;
-  }
-</style>
+<title>SGT Operator Shell</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700;800&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/styles.css">
 </head>
 <body>
-
-<div class="header">
-  <h1><span>SGT</span> Control Panel</h1>
-  <div class="header-right">
-    <div class="mini" title="WebSocket connection">
-      <div class="conn-dot" id="connDot"></div>
-      <span id="connLabel">Disconnected</span>
+<div class="shell-grid">
+  <header class="topbar panel">
+    <div>
+      <div class="eyebrow">SGT Operator Shell</div>
+      <h1>JARVIS Cockpit</h1>
+      <p class="lead">Dense live control surface for Mayor, active workers, blockers, queue state, and dispatch.</p>
     </div>
-
-    <div class="mini" title="Last successful status update">
-      <span>Updated</span>
-      <span id="lastUpdated" class="stale">—</span>
+    <div class="topbar-controls">
+      <div class="status-chip" id="wsHealth">
+        <span class="pill-dot"></span>
+        <span>Link</span>
+        <strong id="connLabel">Disconnected</strong>
+      </div>
+      <div class="status-chip">
+        <span>Snapshot</span>
+        <strong id="lastUpdated">--</strong>
+      </div>
+      <div class="status-chip">
+        <span>Log Feed</span>
+        <strong id="lastLog">--</strong>
+      </div>
+      <button class="btn ghost" id="compactBtn">Compact</button>
+      <button class="btn ghost" id="refreshSnapshotBtn">Refresh</button>
     </div>
+  </header>
 
-    <button class="btn btn-secondary" id="compactBtn" title="Toggle compact mode (c)">
-      Compact <span class="kbd">c</span>
-    </button>
-  </div>
-</div>
+  <nav class="section-nav panel">
+    <button data-section="overview" class="nav-btn active">Overview <span class="kbd">1</span></button>
+    <button data-section="streams" class="nav-btn">Streams <span class="kbd">2</span></button>
+    <button data-section="topology" class="nav-btn">Topology <span class="kbd">3</span></button>
+    <button data-section="dispatch" class="nav-btn">Dispatch <span class="kbd">4</span></button>
+    <button data-section="logs" class="nav-btn">Logs <span class="kbd">5</span></button>
+  </nav>
 
-<nav class="nav" id="nav">
-  <button class="active" data-panel="dashboard">Dashboard <span class="kbd">1</span></button>
-  <button data-panel="polecats">Polecats <span class="kbd">2</span></button>
-  <button data-panel="dogs">Dogs <span class="kbd">3</span></button>
-  <button data-panel="rigs">Rigs <span class="kbd">4</span></button>
-  <button data-panel="sling">Sling <span class="kbd">5</span></button>
-  <button data-panel="logs">Logs <span class="kbd">6</span></button>
-  <button data-panel="merge-queue">Merge Queue <span class="kbd">7</span></button>
-</nav>
-
-<div class="main">
-  <!-- Dashboard -->
-  <div class="panel active" id="panel-dashboard">
-    <div class="card" data-collapse-key="agents">
-      <div class="card-header collapsible" data-collapse>
-        <span>Agents</span>
-        <span class="right"><span class="chev" aria-hidden="true">▾</span></span>
+  <aside class="sidebar">
+    <section class="panel command-panel">
+      <div class="panel-title">
+        <span>Command Pulse</span>
+        <span class="panel-meta" id="serverTimeLabel">waiting</span>
       </div>
-      <div class="card-body">
-        <div class="agent-grid" id="agentGrid"></div>
-      </div>
-    </div>
+      <div class="metric-stack" id="commandMetrics"></div>
+    </section>
 
-    <div class="card" data-collapse-key="dash_polecats">
-      <div class="card-header collapsible" data-collapse>
-        <span>Polecats</span>
-        <span class="right"><span class="count" id="polecatCount">0</span><span class="chev" aria-hidden="true">▾</span></span>
+    <section class="panel roster-panel">
+      <div class="panel-title">
+        <span>Worker Roster</span>
+        <span class="panel-meta" id="workerCountLabel">0 tracked</span>
       </div>
-      <div class="card-body" style="padding:0;">
-        <div class="worker-list" id="dashPolecats"></div>
+      <div class="roster-list" id="workerRoster"></div>
+    </section>
+
+    <section class="panel roster-panel">
+      <div class="panel-title">
+        <span>Rig Matrix</span>
+        <span class="panel-meta" id="rigCountLabel">0 rigs</span>
       </div>
-    </div>
+      <div class="rig-list" id="rigMatrix"></div>
+    </section>
+  </aside>
 
-    <div class="card" data-collapse-key="dash_merge_queue">
-      <div class="card-header collapsible" data-collapse>
-        <span>Merge Queue</span>
-        <span class="right"><span class="count" id="mqCount">0</span><span class="chev" aria-hidden="true">▾</span></span>
+  <main class="main-column">
+    <section class="panel section active" id="section-overview">
+      <div class="panel-title">
+        <span>Alert Center</span>
+        <span class="panel-meta" id="blockerSummary">0 open blockers</span>
       </div>
-      <div class="card-body" style="padding:0;">
-        <div class="mq-list" id="dashMergeQueue"></div>
+      <div class="blocker-board" id="blockerBoard"></div>
+
+      <div class="overview-grid">
+        <div class="subpanel">
+          <div class="subpanel-title">Mayor Focus</div>
+          <div class="stream-hero" id="overviewHero"></div>
+        </div>
+        <div class="subpanel">
+          <div class="subpanel-title">Queue + Issues</div>
+          <div class="queue-list" id="queueBoard"></div>
+        </div>
       </div>
-    </div>
-  </div>
+    </section>
 
-  <!-- Polecats -->
-  <div class="panel" id="panel-polecats">
-    <div class="section-title">Active Polecats <span class="count" id="polecatCount2">0</span></div>
-    <div class="worker-list" id="polecatList"></div>
-  </div>
-
-  <!-- Dogs -->
-  <div class="panel" id="panel-dogs">
-    <div class="section-title">Active Dogs <span class="count" id="dogCount">0</span></div>
-    <div class="worker-list" id="dogList"></div>
-  </div>
-
-  <!-- Rigs -->
-  <div class="panel" id="panel-rigs">
-    <div class="section-title">Registered Rigs <span class="count" id="rigCount">0</span></div>
-    <div class="rig-grid" id="rigGrid"></div>
-  </div>
-
-  <!-- Sling -->
-  <div class="panel" id="panel-sling">
-    <div class="card" data-collapse-key="sling_polecat">
-      <div class="card-header collapsible" data-collapse>
-        <span>Dispatch Polecat</span>
-        <span class="right"><span class="chev" aria-hidden="true">▾</span></span>
+    <section class="panel section" id="section-streams">
+      <div class="panel-title">
+        <span>Live Streams</span>
+        <span class="panel-meta" id="streamSummary">0 subscriptions</span>
       </div>
-      <div class="card-body">
-        <form class="sling-form" id="slingForm">
-          <div class="form-group">
-            <label>Rig</label>
-            <select id="slingRig" required></select>
+      <div class="focus-stream" id="focusStream"></div>
+      <div class="stream-grid" id="streamGrid"></div>
+    </section>
+
+    <section class="panel section" id="section-topology">
+      <div class="panel-title">
+        <span>Topology Radar</span>
+        <span class="panel-meta" id="topologyMode">Canvas fallback</span>
+      </div>
+      <div class="topology-wrap">
+        <canvas id="topologyCanvas" width="960" height="520"></canvas>
+        <div class="topology-sidebar">
+          <div class="subpanel-title">Relationship Feed</div>
+          <div class="topology-list" id="topologyList"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel section" id="section-dispatch">
+      <div class="panel-title">
+        <span>Dispatch Console</span>
+        <span class="panel-meta">Repo-tracked web/ remains canonical</span>
+      </div>
+      <div class="dispatch-grid">
+        <form class="dispatch-form" id="slingForm">
+          <div class="subpanel-title">Sling Polecat</div>
+          <label for="slingRig">Rig</label>
+          <select id="slingRig" required></select>
+          <label for="slingTask">Task</label>
+          <textarea id="slingTask" placeholder="Describe the operator task..." required></textarea>
+          <label for="slingLabels">Labels</label>
+          <input type="text" id="slingLabels" placeholder="enhancement, plan-SGT31">
+          <label for="slingConvoy">Convoy</label>
+          <input type="text" id="slingConvoy" placeholder="Optional convoy">
+          <button type="submit" class="btn" id="slingBtn">Dispatch Polecat</button>
+        </form>
+
+        <form class="dispatch-form" id="dogForm">
+          <div class="subpanel-title">Sling Dog</div>
+          <label for="dogRig">Rig</label>
+          <select id="dogRig" required></select>
+          <label for="dogIssue">Issue</label>
+          <input type="text" id="dogIssue" placeholder="#266" required>
+          <button type="submit" class="btn" id="dogBtn">Dispatch Dog</button>
+          <div class="dispatch-note">
+            Dog dispatch remains available from the operator shell so the redesign does not regress existing utility.
           </div>
-          <div class="form-group">
-            <label>Task Description</label>
-            <textarea id="slingTask" placeholder="Describe the task..." required></textarea>
-          </div>
-          <div class="form-row">
-            <div class="form-group">
-              <label>Labels (comma-separated)</label>
-              <input type="text" id="slingLabels" placeholder="enhancement, bug...">
-            </div>
-            <div class="form-group">
-              <label>Convoy (Milestone)</label>
-              <input type="text" id="slingConvoy" placeholder="Optional milestone name">
-            </div>
-          </div>
-          <button type="submit" class="btn" id="slingBtn">Sling Polecat</button>
         </form>
       </div>
-    </div>
+    </section>
 
-    <div class="card" data-collapse-key="sling_dog">
-      <div class="card-header collapsible" data-collapse>
-        <span>Dispatch Dog</span>
-        <span class="right"><span class="chev" aria-hidden="true">▾</span></span>
+    <section class="panel section" id="section-logs">
+      <div class="panel-title">
+        <span>Operator Log Feed</span>
+        <span class="panel-meta" id="logSummary">0 lines buffered</span>
       </div>
-      <div class="card-body">
-        <form class="sling-form" id="dogForm">
-          <div class="form-group">
-            <label>Rig</label>
-            <select id="dogRig" required></select>
-          </div>
-          <div class="form-group">
-            <label>Issue Number</label>
-            <input type="text" id="dogIssue" placeholder="#7 or 7" required>
-          </div>
-          <button type="submit" class="btn" id="dogBtn">Sling Dog</button>
-        </form>
+      <div class="log-toolbar">
+        <button class="btn ghost" id="refreshLogsBtn">Refresh Logs</button>
+        <span class="panel-meta">Auto-follows when the viewport stays near the tail.</span>
       </div>
-    </div>
-  </div>
-
-  <!-- Logs -->
-  <div class="panel" id="panel-logs">
-    <div class="card" data-collapse-key="logs">
-      <div class="card-header">
-        <span>sgt.log</span>
-        <span class="right">
-          <span class="mini" style="gap:6px;">
-            <span>Last log</span>
-            <span id="lastLog" class="stale">—</span>
-          </span>
-          <button class="btn btn-secondary" id="refreshLogsBtn" style="padding:4px 10px;font-size:10px;">Refresh</button>
-        </span>
-      </div>
-      <div class="card-body" style="padding:0;">
-        <div class="log-viewer" id="logViewer"></div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Merge Queue -->
-  <div class="panel" id="panel-merge-queue">
-    <div class="section-title">Refinery Merge Queue <span class="count" id="mqCount2">0</span></div>
-    <div class="mq-list" id="mergeQueueList"></div>
-  </div>
+      <div class="log-viewer" id="logViewer"></div>
+    </section>
+  </main>
 </div>
 
-<!-- Peek Modal -->
 <div class="modal-overlay" id="peekModal">
   <div class="modal">
     <div class="modal-header">
       <span id="peekTitle">Peek</span>
-      <button onclick="closePeek()" aria-label="Close">&times;</button>
+      <button id="peekCloseBtn" aria-label="Close">&times;</button>
     </div>
     <div class="modal-body">
       <pre id="peekOutput">Loading...</pre>
@@ -733,462 +172,8 @@
   </div>
 </div>
 
-<!-- Toast Container -->
 <div class="toast-container" id="toasts"></div>
 
-<script>
-// --- State ---
-let ws = null;
-let state = { agents: [], polecats: [], dogs: [], crew: [], mergeQueue: [] };
-let rigs = [];
-
-let lastStatusAt = 0;
-let lastLogAt = 0;
-let staleTimer = null;
-
-// --- Nav ---
-function activatePanel(name) {
-  document.querySelectorAll('.nav button').forEach(b => b.classList.toggle('active', b.dataset.panel === name));
-  document.querySelectorAll('.panel').forEach(p => p.classList.toggle('active', p.id === 'panel-' + name));
-  if (name === 'logs') loadLogs();
-  if (name === 'rigs') loadRigs();
-}
-
-document.getElementById('nav').addEventListener('click', (e) => {
-  if (e.target.tagName !== 'BUTTON') return;
-  activatePanel(e.target.dataset.panel);
-});
-
-// --- Compact mode ---
-const COMPACT_KEY = 'sgt_web_compact';
-function setCompact(on) {
-  document.body.classList.toggle('compact', !!on);
-  localStorage.setItem(COMPACT_KEY, on ? '1' : '0');
-}
-setCompact(localStorage.getItem(COMPACT_KEY) === '1');
-
-document.getElementById('compactBtn').addEventListener('click', () => {
-  setCompact(!document.body.classList.contains('compact'));
-});
-
-// --- Collapsible cards ---
-function initCollapsibles() {
-  document.querySelectorAll('.card[data-collapse-key]').forEach(card => {
-    const key = 'sgt_web_collapse_' + card.dataset.collapseKey;
-    const collapsed = localStorage.getItem(key) === '1';
-    card.classList.toggle('collapsed', collapsed);
-    const header = card.querySelector('[data-collapse]');
-    if (!header) return;
-    header.addEventListener('click', () => {
-      const now = !card.classList.contains('collapsed');
-      card.classList.toggle('collapsed', now);
-      localStorage.setItem(key, now ? '1' : '0');
-    });
-  });
-}
-initCollapsibles();
-
-// --- WebSocket (robust reconnect + stale indicators) ---
-let wsAttempts = 0;
-let wsReconnectTimer = null;
-
-function wsUrl() {
-  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-  return proto + '//' + location.host;
-}
-
-function connectWs() {
-  clearTimeout(wsReconnectTimer);
-
-  try {
-    ws = new WebSocket(wsUrl());
-  } catch {
-    scheduleReconnect();
-    return;
-  }
-
-  ws.onopen = () => {
-    wsAttempts = 0;
-    setConn(true);
-  };
-
-  ws.onclose = () => {
-    setConn(false);
-    scheduleReconnect();
-  };
-
-  ws.onerror = () => {
-    try { ws.close(); } catch {}
-  };
-
-  ws.onmessage = (e) => {
-    const msg = JSON.parse(e.data);
-
-    if (msg.type === 'status') {
-      state = msg.parsed;
-      lastStatusAt = Date.now();
-      updateLastUpdated();
-      renderDashboard();
-      renderPolecats();
-      renderDogs();
-      renderMergeQueue();
-
-    } else if (msg.type === 'log') {
-      lastLogAt = Date.now();
-      updateLastLog();
-      appendLogLines(msg.lines);
-
-    } else if (msg.type === 'log_reset') {
-      // log file rotated / truncated
-      const viewer = document.getElementById('logViewer');
-      viewer.innerHTML = '';
-      loadLogs();
-
-    } else if (msg.type === 'hello') {
-      // no-op (reserved for future)
-    }
-  };
-}
-
-function scheduleReconnect() {
-  wsAttempts += 1;
-  // exponential backoff w/ jitter (0.5x..1.2x)
-  const base = Math.min(30000, 500 * Math.pow(2, Math.min(wsAttempts, 8)));
-  const jitter = 0.5 + Math.random() * 0.7;
-  const delay = Math.round(base * jitter);
-  wsReconnectTimer = setTimeout(connectWs, delay);
-}
-
-function setConn(isConnected) {
-  const dot = document.getElementById('connDot');
-  dot.classList.toggle('connected', !!isConnected);
-  document.getElementById('connLabel').textContent = isConnected ? 'Connected' : 'Disconnected';
-}
-
-function fmtTime(ms) {
-  if (!ms) return '—';
-  const d = new Date(ms);
-  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-}
-
-function updateLastUpdated() {
-  const el = document.getElementById('lastUpdated');
-  el.textContent = fmtTime(lastStatusAt);
-}
-
-function updateLastLog() {
-  const el = document.getElementById('lastLog');
-  el.textContent = fmtTime(lastLogAt);
-}
-
-function updateStaleIndicators() {
-  const now = Date.now();
-  const statusAge = lastStatusAt ? (now - lastStatusAt) : Infinity;
-  const logAge = lastLogAt ? (now - lastLogAt) : Infinity;
-
-  document.getElementById('lastUpdated').classList.toggle('stale', statusAge > 12000);
-  document.getElementById('lastLog').classList.toggle('stale', logAge > 20000);
-}
-
-connectWs();
-staleTimer = setInterval(updateStaleIndicators, 1000);
-
-// --- Keyboard shortcuts ---
-document.addEventListener('keydown', (e) => {
-  if (e.target && (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT')) return;
-
-  if (e.key === 'c' || e.key === 'C') {
-    setCompact(!document.body.classList.contains('compact'));
-  }
-
-  const map = {
-    '1': 'dashboard',
-    '2': 'polecats',
-    '3': 'dogs',
-    '4': 'rigs',
-    '5': 'sling',
-    '6': 'logs',
-    '7': 'merge-queue',
-  };
-  if (map[e.key]) activatePanel(map[e.key]);
-
-  if (e.key === 'Escape') closePeek();
-});
-
-// --- Render: Dashboard ---
-function renderDashboard() {
-  // Agents
-  const grid = document.getElementById('agentGrid');
-  grid.innerHTML = state.agents.map(a => {
-    const isOn = a.status.startsWith('on');
-    return `<div class="agent-item">
-      <span class="status-dot ${isOn ? 'status-on' : 'status-off'}"></span>
-      <span class="name">${esc(a.name)}</span>
-      <span class="meta">${esc(a.status)}${a.heartbeat ? '<br>' + esc(a.heartbeat) : ''}</span>
-    </div>`;
-  }).join('');
-
-  // Polecats summary
-  document.getElementById('polecatCount').textContent = state.polecats.length;
-  const dashP = document.getElementById('dashPolecats');
-  if (state.polecats.length === 0) {
-    dashP.innerHTML = '<div class="empty">No active polecats</div>';
-  } else {
-    dashP.innerHTML = state.polecats.map(p => workerHtml(p)).join('');
-  }
-
-  // Merge queue summary
-  document.getElementById('mqCount').textContent = state.mergeQueue.length;
-  const dashMq = document.getElementById('dashMergeQueue');
-  if (state.mergeQueue.length === 0) {
-    dashMq.innerHTML = '<div class="empty">Merge queue empty</div>';
-  } else {
-    dashMq.innerHTML = state.mergeQueue.map(m =>
-      `<div class="mq-item">
-        <span class="mq-pr">${esc(m.name)}</span>
-        <span class="mq-meta">${esc(m.detail)}</span>
-      </div>`
-    ).join('');
-  }
-}
-
-function workerHtml(p) {
-  const isAlive = p.alive === 'alive';
-  return `<div class="worker-item" onclick="peek('${esc(p.name)}')">
-    <div class="worker-header">
-      <span class="status-dot ${isAlive ? 'status-alive' : 'status-dead'}"></span>
-      <span class="worker-name">${esc(p.name)}</span>
-      <span class="badge ${isAlive ? 'badge-alive' : 'badge-dead'}">${isAlive ? 'alive' : 'dead'}</span>
-    </div>
-    <div class="worker-meta">
-      ${p.rig ? '<span>rig: ' + esc(p.rig) + '</span>' : ''}
-      ${p.issue ? '<span>issue: ' + esc(p.issue) + '</span>' : ''}
-      ${p.branch ? '<span>branch: ' + esc(p.branch) + '</span>' : ''}
-      ${p.pr ? '<span>pr: ' + esc(p.pr) + '</span>' : ''}
-    </div>
-  </div>`;
-}
-
-// --- Render: Polecats ---
-function renderPolecats() {
-  document.getElementById('polecatCount2').textContent = state.polecats.length;
-  const list = document.getElementById('polecatList');
-  if (state.polecats.length === 0) {
-    list.innerHTML = '<div class="empty">No active polecats</div>';
-  } else {
-    list.innerHTML = state.polecats.map(p => workerHtml(p)).join('');
-  }
-}
-
-// --- Render: Dogs ---
-function renderDogs() {
-  document.getElementById('dogCount').textContent = state.dogs.length;
-  const list = document.getElementById('dogList');
-  if (state.dogs.length === 0) {
-    list.innerHTML = '<div class="empty">No active dogs</div>';
-  } else {
-    list.innerHTML = state.dogs.map(d =>
-      `<div class="worker-item">
-        <div class="worker-header">
-          <span class="status-dot ${d.alive === 'alive' ? 'status-alive' : 'status-dead'}"></span>
-          <span class="worker-name">${esc(d.name)}</span>
-          <span class="badge ${d.alive === 'alive' ? 'badge-alive' : 'badge-dead'}">${d.alive}</span>
-        </div>
-        <div class="worker-meta"><span>${esc(d.issue)}</span></div>
-      </div>`
-    ).join('');
-  }
-}
-
-// --- Render: Merge Queue ---
-function renderMergeQueue() {
-  document.getElementById('mqCount2').textContent = state.mergeQueue.length;
-  const list = document.getElementById('mergeQueueList');
-  if (state.mergeQueue.length === 0) {
-    list.innerHTML = '<div class="empty">Merge queue empty</div>';
-  } else {
-    list.innerHTML = state.mergeQueue.map(m =>
-      `<div class="mq-item">
-        <span class="mq-pr">${esc(m.name)}</span>
-        <span class="mq-meta">${esc(m.detail)}</span>
-      </div>`
-    ).join('');
-  }
-}
-
-// --- Rigs ---
-async function loadRigs() {
-  try {
-    const res = await fetch('/api/rigs');
-    rigs = await res.json();
-    renderRigs();
-    populateRigSelects();
-  } catch {}
-}
-
-function renderRigs() {
-  document.getElementById('rigCount').textContent = rigs.length;
-  const grid = document.getElementById('rigGrid');
-  if (rigs.length === 0) {
-    grid.innerHTML = '<div class="empty">No rigs registered</div>';
-    return;
-  }
-  grid.innerHTML = rigs.map(r =>
-    `<div class="rig-card">
-      <div class="rig-name">${esc(r.name)}</div>
-      <div class="rig-repo"><a href="${esc(r.repo)}" target="_blank">${esc(r.repo)}</a></div>
-      <div class="rig-stats">
-        <span>polecats: <span class="val">${r.polecats ?? '?'}</span></span>
-        <span>witness: <span class="val">${esc(r.witness ?? '?')}</span></span>
-        <span>refinery: <span class="val">${esc(r.refinery ?? '?')}</span></span>
-      </div>
-    </div>`
-  ).join('');
-}
-
-function populateRigSelects() {
-  const opts = rigs.map(r => `<option value="${esc(r.name)}">${esc(r.name)}</option>`).join('');
-  const placeholder = '<option value="">Select a rig...</option>';
-  document.getElementById('slingRig').innerHTML = placeholder + opts;
-  document.getElementById('dogRig').innerHTML = placeholder + opts;
-}
-
-// Load rigs on start
-loadRigs();
-
-// --- Sling Form ---
-document.getElementById('slingForm').addEventListener('submit', async (e) => {
-  e.preventDefault();
-  const btn = document.getElementById('slingBtn');
-  btn.disabled = true;
-  btn.textContent = 'Dispatching...';
-  try {
-    const labels = document.getElementById('slingLabels').value
-      .split(',').map(l => l.trim()).filter(Boolean);
-    const res = await fetch('/api/sling', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        rig: document.getElementById('slingRig').value,
-        task: document.getElementById('slingTask').value,
-        labels,
-        convoy: document.getElementById('slingConvoy').value || undefined,
-      }),
-    });
-    const data = await res.json();
-    if (res.ok) {
-      toast('Polecat dispatched!', 'success');
-      document.getElementById('slingTask').value = '';
-      document.getElementById('slingLabels').value = '';
-      document.getElementById('slingConvoy').value = '';
-    } else {
-      toast('Error: ' + data.error, 'error');
-    }
-  } catch (err) {
-    toast('Error: ' + err.message, 'error');
-  } finally {
-    btn.disabled = false;
-    btn.textContent = 'Sling Polecat';
-  }
-});
-
-document.getElementById('dogForm').addEventListener('submit', async (e) => {
-  e.preventDefault();
-  const btn = document.getElementById('dogBtn');
-  btn.disabled = true;
-  btn.textContent = 'Dispatching...';
-  try {
-    const issue = document.getElementById('dogIssue').value.replace('#', '');
-    const res = await fetch('/api/sling-dog', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        rig: document.getElementById('dogRig').value,
-        issue,
-      }),
-    });
-    const data = await res.json();
-    if (res.ok) {
-      toast('Dog dispatched!', 'success');
-      document.getElementById('dogIssue').value = '';
-    } else {
-      toast('Error: ' + data.error, 'error');
-    }
-  } catch (err) {
-    toast('Error: ' + err.message, 'error');
-  } finally {
-    btn.disabled = false;
-    btn.textContent = 'Sling Dog';
-  }
-});
-
-// --- Logs ---
-document.getElementById('refreshLogsBtn').addEventListener('click', loadLogs);
-
-async function loadLogs() {
-  try {
-    const res = await fetch('/api/logs?lines=250');
-    const data = await res.json();
-    const viewer = document.getElementById('logViewer');
-    viewer.innerHTML = data.lines.map(formatLogLine).join('');
-    viewer.scrollTop = viewer.scrollHeight;
-  } catch {}
-}
-
-function appendLogLines(lines) {
-  const viewer = document.getElementById('logViewer');
-  const wasAtBottom = viewer.scrollHeight - viewer.scrollTop - viewer.clientHeight < 50;
-  viewer.innerHTML += lines.map(formatLogLine).join('');
-  if (wasAtBottom) viewer.scrollTop = viewer.scrollHeight;
-}
-
-function formatLogLine(line) {
-  const m = line.match(/^\[([^\]]+)\]\s+(\S+)\s*(.*)/);
-  if (m) {
-    return `<div class="log-line"><span class="timestamp">[${esc(m[1])}]</span> <span class="event">${esc(m[2])}</span> ${esc(m[3])}</div>`;
-  }
-  return `<div class="log-line">${esc(line)}</div>`;
-}
-
-// --- Peek ---
-async function peek(target) {
-  document.getElementById('peekModal').classList.add('active');
-  document.getElementById('peekTitle').textContent = 'Peek: ' + target;
-  document.getElementById('peekOutput').textContent = 'Loading...';
-  try {
-    const res = await fetch('/api/peek/' + encodeURIComponent(target));
-    const data = await res.json();
-    document.getElementById('peekOutput').textContent = data.output || data.error || 'No output';
-  } catch (err) {
-    document.getElementById('peekOutput').textContent = 'Error: ' + err.message;
-  }
-}
-
-function closePeek() {
-  document.getElementById('peekModal').classList.remove('active');
-}
-
-document.getElementById('peekModal').addEventListener('click', (e) => {
-  if (e.target === e.currentTarget) closePeek();
-});
-
-// --- Toast ---
-function toast(msg, type) {
-  const container = document.getElementById('toasts');
-  const el = document.createElement('div');
-  el.className = 'toast ' + (type || '');
-  el.textContent = msg;
-  container.appendChild(el);
-  setTimeout(() => el.remove(), 4000);
-}
-
-// --- Util ---
-function esc(s) {
-  if (s == null) return '';
-  const d = document.createElement('div');
-  d.textContent = String(s);
-  return d.innerHTML;
-}
-</script>
+<script src="/app.js"></script>
 </body>
 </html>

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -1,0 +1,749 @@
+:root {
+  --bg: #04131b;
+  --bg-2: #061c28;
+  --panel: rgba(6, 28, 40, 0.9);
+  --panel-strong: rgba(5, 24, 35, 0.96);
+  --panel-glow: rgba(23, 188, 248, 0.08);
+  --line: rgba(80, 180, 211, 0.24);
+  --line-strong: rgba(80, 180, 211, 0.5);
+  --text: #d9f4ff;
+  --muted: #7fa9bc;
+  --cyan: #4dd6ff;
+  --cyan-strong: #8bf0ff;
+  --amber: #f8b84a;
+  --lime: #9df77d;
+  --red: #ff6b6b;
+  --violet: #7da8ff;
+  --shadow: 0 18px 40px rgba(0, 0, 0, 0.34);
+  --radius: 18px;
+  --mono: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+  --sans: "IBM Plex Sans", "Segoe UI", sans-serif;
+  --display: "Orbitron", "IBM Plex Sans", sans-serif;
+  --page-pad: 20px;
+  --panel-pad: 18px;
+  --gap: 18px;
+  --stream-height: 220px;
+}
+
+body.compact {
+  --page-pad: 14px;
+  --panel-pad: 14px;
+  --gap: 14px;
+  --stream-height: 180px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
+  font-family: var(--sans);
+  background:
+    radial-gradient(circle at top left, rgba(77, 214, 255, 0.12), transparent 32%),
+    radial-gradient(circle at top right, rgba(125, 168, 255, 0.12), transparent 28%),
+    linear-gradient(180deg, #041017 0%, #071822 52%, #04131b 100%);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(77, 214, 255, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(77, 214, 255, 0.035) 1px, transparent 1px);
+  background-size: 100% 40px, 40px 100%;
+  opacity: 0.42;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+a {
+  color: var(--cyan-strong);
+}
+
+.shell-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  grid-template-areas:
+    "topbar topbar"
+    "nav nav"
+    "sidebar main";
+  gap: var(--gap);
+  padding: var(--page-pad);
+}
+
+.panel {
+  border: 1px solid var(--line);
+  background:
+    linear-gradient(180deg, rgba(10, 37, 54, 0.93), rgba(4, 18, 28, 0.96)),
+    var(--panel);
+  box-shadow: var(--shadow);
+  border-radius: var(--radius);
+  backdrop-filter: blur(16px);
+}
+
+.topbar {
+  grid-area: topbar;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: var(--panel-pad);
+}
+
+.eyebrow,
+.panel-meta,
+.subtle,
+.kbd {
+  color: var(--muted);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 11px;
+}
+
+.topbar h1 {
+  margin: 6px 0 8px;
+  font-family: var(--display);
+  font-size: clamp(30px, 5vw, 48px);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.lead {
+  max-width: 760px;
+  margin: 0;
+  color: #a6cada;
+}
+
+.topbar-controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 280px;
+}
+
+.status-chip,
+.metric-card,
+.nav-btn,
+.roster-item,
+.rig-item,
+.blocker-card,
+.queue-item,
+.stream-card,
+.hero-card,
+.dispatch-note {
+  border: 1px solid var(--line);
+  background: rgba(8, 28, 41, 0.72);
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 999px;
+}
+
+.status-chip strong {
+  color: var(--cyan-strong);
+  font-family: var(--mono);
+  font-size: 13px;
+}
+
+.pill-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--red);
+  box-shadow: 0 0 18px rgba(255, 107, 107, 0.45);
+}
+
+.status-chip.connected .pill-dot {
+  background: var(--lime);
+  box-shadow: 0 0 20px rgba(157, 247, 125, 0.42);
+}
+
+.section-nav {
+  grid-area: nav;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 12px;
+}
+
+.nav-btn {
+  border-radius: 999px;
+  padding: 10px 14px;
+  color: var(--muted);
+  transition: border-color 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.nav-btn.active,
+.nav-btn:hover {
+  color: var(--text);
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
+}
+
+.sidebar {
+  grid-area: sidebar;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
+}
+
+.main-column {
+  grid-area: main;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
+}
+
+.command-panel,
+.roster-panel,
+.section {
+  padding: var(--panel-pad);
+}
+
+.panel-title {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+  margin-bottom: 16px;
+  font-family: var(--display);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 14px;
+}
+
+.metric-stack {
+  display: grid;
+  gap: 10px;
+}
+
+.metric-card {
+  padding: 12px;
+  border-radius: 16px;
+}
+
+.metric-card strong {
+  display: block;
+  margin-top: 6px;
+  font-family: var(--display);
+  font-size: 24px;
+  color: var(--cyan-strong);
+}
+
+.metric-card .metric-detail {
+  margin-top: 6px;
+  color: #afcfdb;
+  font-size: 13px;
+}
+
+.roster-list,
+.rig-list,
+.blocker-board,
+.queue-list,
+.topology-list {
+  display: grid;
+  gap: 10px;
+}
+
+.roster-item,
+.rig-item,
+.blocker-card,
+.queue-item,
+.hero-card,
+.stream-card {
+  border-radius: 16px;
+}
+
+.roster-item,
+.rig-item {
+  padding: 12px;
+}
+
+.roster-item {
+  display: grid;
+  gap: 8px;
+}
+
+.roster-head,
+.rig-head,
+.queue-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.mono {
+  font-family: var(--mono);
+}
+
+.roster-title,
+.rig-name,
+.blocker-title,
+.queue-name {
+  font-family: var(--mono);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.roster-meta,
+.rig-meta,
+.queue-meta,
+.blocker-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: #a6cada;
+  font-size: 12px;
+}
+
+.pill,
+.state-pill,
+.severity-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid var(--line);
+}
+
+.state-good,
+.state-live {
+  color: var(--lime);
+  border-color: rgba(157, 247, 125, 0.35);
+}
+
+.state-active {
+  color: var(--cyan-strong);
+  border-color: rgba(77, 214, 255, 0.35);
+}
+
+.state-warn,
+.state-stale {
+  color: var(--amber);
+  border-color: rgba(248, 184, 74, 0.35);
+}
+
+.state-bad,
+.state-blocked,
+.state-critical {
+  color: #ff9797;
+  border-color: rgba(255, 107, 107, 0.4);
+}
+
+.roster-actions,
+.stream-actions,
+.log-toolbar {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.btn {
+  border: 1px solid rgba(77, 214, 255, 0.45);
+  background: rgba(77, 214, 255, 0.12);
+  color: var(--cyan-strong);
+  padding: 10px 14px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 11px;
+}
+
+.btn:hover {
+  border-color: rgba(77, 214, 255, 0.7);
+}
+
+.btn.ghost {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+}
+
+.btn.tiny {
+  padding: 7px 10px;
+  font-size: 10px;
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.overview-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(280px, 0.85fr);
+  gap: var(--gap);
+  margin-top: 16px;
+}
+
+.subpanel {
+  min-width: 0;
+}
+
+.subpanel-title {
+  margin-bottom: 10px;
+  color: var(--muted);
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.blocker-board:empty::before,
+.queue-list:empty::before,
+.stream-grid:empty::before,
+.roster-list:empty::before,
+.rig-list:empty::before,
+.topology-list:empty::before {
+  content: "No live data";
+  display: block;
+  padding: 18px;
+  text-align: center;
+  color: var(--muted);
+  border: 1px dashed var(--line);
+  border-radius: 14px;
+}
+
+.blocker-card {
+  padding: 14px;
+  background:
+    linear-gradient(135deg, rgba(255, 107, 107, 0.14), transparent 60%),
+    rgba(8, 28, 41, 0.78);
+}
+
+.blocker-card p,
+.queue-item p,
+.dispatch-note {
+  margin: 0;
+  color: #c3dfea;
+  line-height: 1.5;
+}
+
+.queue-item {
+  padding: 12px;
+}
+
+.focus-stream {
+  margin-bottom: 16px;
+}
+
+.hero-card,
+.stream-card {
+  padding: 14px;
+  overflow: hidden;
+}
+
+.hero-card {
+  min-height: 320px;
+  background:
+    linear-gradient(180deg, rgba(77, 214, 255, 0.09), rgba(8, 28, 41, 0.88)),
+    rgba(8, 28, 41, 0.78);
+}
+
+.stream-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+}
+
+.stream-card {
+  min-height: var(--stream-height);
+}
+
+.stream-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.stream-title {
+  display: grid;
+  gap: 6px;
+}
+
+.stream-target {
+  font-family: var(--mono);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.stream-meta {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.stream-body {
+  border: 1px solid rgba(77, 214, 255, 0.18);
+  background: rgba(2, 10, 16, 0.94);
+  border-radius: 14px;
+  height: 230px;
+  overflow: auto;
+  padding: 14px;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.48;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.hero-card .stream-body {
+  height: 370px;
+}
+
+.stream-empty,
+.empty-state {
+  display: grid;
+  place-items: center;
+  min-height: 120px;
+  color: var(--muted);
+  border: 1px dashed var(--line);
+  border-radius: 14px;
+}
+
+.topology-wrap {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: var(--gap);
+}
+
+#topologyCanvas {
+  width: 100%;
+  min-height: 520px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at center, rgba(77, 214, 255, 0.08), transparent 45%),
+    rgba(3, 14, 22, 0.96);
+}
+
+.topology-item {
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(8, 28, 41, 0.64);
+  color: #b8d6e3;
+  font-size: 12px;
+}
+
+.dispatch-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--gap);
+}
+
+.dispatch-form {
+  display: grid;
+  gap: 10px;
+}
+
+.dispatch-form label {
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 11px;
+}
+
+.dispatch-form input,
+.dispatch-form textarea,
+.dispatch-form select {
+  width: 100%;
+  padding: 12px;
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(3, 14, 22, 0.94);
+}
+
+.dispatch-form textarea {
+  min-height: 160px;
+  resize: vertical;
+}
+
+.dispatch-form input:focus,
+.dispatch-form textarea:focus,
+.dispatch-form select:focus {
+  outline: none;
+  border-color: var(--line-strong);
+  box-shadow: 0 0 0 3px rgba(77, 214, 255, 0.15);
+}
+
+.log-toolbar {
+  margin-bottom: 12px;
+}
+
+.log-viewer {
+  min-height: 420px;
+  max-height: 520px;
+  overflow: auto;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(2, 10, 16, 0.94);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.log-line {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.timestamp {
+  color: var(--muted);
+}
+
+.log-event {
+  color: var(--amber);
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 10;
+}
+
+.modal-overlay.active {
+  display: flex;
+}
+
+.modal {
+  width: min(1000px, calc(100vw - 32px));
+  max-height: calc(100vh - 48px);
+  overflow: hidden;
+  border-radius: 18px;
+  border: 1px solid var(--line-strong);
+  background: rgba(3, 14, 22, 0.98);
+  box-shadow: var(--shadow);
+}
+
+.modal-header,
+.modal-body {
+  padding: 16px;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: var(--display);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.modal-header button {
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 28px;
+}
+
+.modal-body {
+  max-height: calc(100vh - 180px);
+  overflow: auto;
+}
+
+.modal-body pre {
+  margin: 0;
+  font-family: var(--mono);
+  white-space: pre-wrap;
+}
+
+.toast-container {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  display: grid;
+  gap: 10px;
+  z-index: 12;
+}
+
+.toast {
+  padding: 12px 14px;
+  min-width: 240px;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: rgba(6, 28, 40, 0.94);
+  box-shadow: var(--shadow);
+}
+
+.toast.success {
+  border-color: rgba(157, 247, 125, 0.35);
+  color: #d5ffca;
+}
+
+.toast.error {
+  border-color: rgba(255, 107, 107, 0.35);
+  color: #ffc2c2;
+}
+
+@media (max-width: 1200px) {
+  .shell-grid {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "topbar"
+      "nav"
+      "main"
+      "sidebar";
+  }
+
+  .dispatch-grid,
+  .overview-grid,
+  .topology-wrap {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .topbar {
+    flex-direction: column;
+  }
+
+  .topbar-controls {
+    justify-content: flex-start;
+  }
+
+  .section-nav {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+  }
+
+  .stream-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/test/operator-shell.test.js
+++ b/web/test/operator-shell.test.js
@@ -1,0 +1,28 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+test("operator shell html includes cockpit sections and assets", () => {
+  const html = fs.readFileSync(path.join(__dirname, "..", "public", "index.html"), "utf8");
+  assert.match(html, /JARVIS Cockpit/);
+  assert.match(html, /section-overview/);
+  assert.match(html, /section-streams/);
+  assert.match(html, /section-topology/);
+  assert.match(html, /section-dispatch/);
+  assert.match(html, /section-logs/);
+  assert.match(html, /id="blockerBoard"/);
+  assert.match(html, /id="topologyCanvas"/);
+  assert.match(html, /src="\/app\.js"/);
+  assert.match(html, /href="\/styles\.css"/);
+});
+
+test("operator shell script consumes snapshot and tmux stream events", () => {
+  const script = fs.readFileSync(path.join(__dirname, "..", "public", "app.js"), "utf8");
+  assert.match(script, /message\.type === "snapshot"/);
+  assert.match(script, /message\.type === "stream\/open"/);
+  assert.match(script, /message\.type === "stream\/data"/);
+  assert.match(script, /message\.type === "stream\/stale"/);
+  assert.match(script, /renderTopology/);
+  assert.match(script, /renderStreamDeck/);
+});


### PR DESCRIPTION
Closes #266

## Summary
- redesign the repo-tracked web UI into a dense single-page JARVIS-style operator shell
- drive the frontend from normalized cockpit snapshots and tmux stream events
- keep blockers, live stream focus, topology radar, logs, and dispatch workflows visible in one shell

## Verification
- cd web && npm test
- node --check public/app.js