### PR TITLE
Add live multi-pane Mayor and polecat monitors

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -38,7 +38,7 @@ Environment variables:
 ## Features
 
 - **Dense cockpit shell** — Single-page JARVIS-style HUD with command pulse, alert center, worker roster, rig matrix, topology radar, and dispatch console
-- **Live tmux monitoring** — Mayor plus active worker panes subscribe on demand over WebSocket; focus mode and snapshot `peek` remain available
+- **Live tmux monitoring** — Mayor gets a dedicated live monitor, while all active polecats can stay open simultaneously in a filtered multi-pane wall with per-pane tail/focus/peek controls
 - **Acceptance blocker center** — Open blockers stay prominent with rig ownership, evidence snippets, and timestamps
 - **Realtime WS** — Normalized `snapshot` pushes plus tmux stream events and live `sgt.log` updates; reconnect/backoff and stale states remain visible
 - **Topology radar** — Canvas relationship view driven from normalized `topology` nodes/edges, with a clean fallback when WebGL is absent
@@ -124,6 +124,13 @@ Client-to-server:
 - `{"type":"snapshot/request"}` — request an immediate normalized snapshot
 - `{"type":"stream/subscribe","target":"mayor"}` — start a live tmux stream for `mayor`, `mayor/<rig>`, `witness/<rig>`, `refinery/<rig>`, `crew/<name>`, `dog/<name>`, or a polecat name
 - `{"type":"stream/unsubscribe","target":"mayor"}` — stop a live tmux stream
+
+The stream section defaults to a polecat-focused monitor wall:
+
+- rig and role filters narrow the active live panes without leaving the page
+- `Match` filters by worker name, rig, issue, or branch text
+- `Tail All` toggles auto-follow across every subscribed pane
+- each pane still supports `Tail`, `Focus`, and `Peek`
 
 Server-to-client additions:
 

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -9,6 +9,8 @@ const appState = {
   lastSnapshotAt: 0,
   lastLogAt: 0,
   focusTarget: "mayor",
+  streamFilters: { rig: "all", role: "polecat", query: "" },
+  streamFollowAll: true,
   desiredTargets: new Set(),
   streams: new Map(),
   sections: ["overview", "streams", "topology", "dispatch", "logs"],
@@ -33,8 +35,14 @@ const refs = {
   overviewHero: document.getElementById("overviewHero"),
   queueBoard: document.getElementById("queueBoard"),
   streamSummary: document.getElementById("streamSummary"),
+  streamRigFilter: document.getElementById("streamRigFilter"),
+  streamRoleFilter: document.getElementById("streamRoleFilter"),
+  streamQuery: document.getElementById("streamQuery"),
+  followAllBtn: document.getElementById("followAllBtn"),
+  monitorWallSummary: document.getElementById("monitorWallSummary"),
   focusStream: document.getElementById("focusStream"),
-  streamGrid: document.getElementById("streamGrid"),
+  mayorMonitor: document.getElementById("mayorMonitor"),
+  monitorWall: document.getElementById("monitorWall"),
   serverTimeLabel: document.getElementById("serverTimeLabel"),
   topologyMode: document.getElementById("topologyMode"),
   topologyCanvas: document.getElementById("topologyCanvas"),
@@ -72,6 +80,10 @@ function bindEvents() {
   refs.refreshSnapshotBtn.addEventListener("click", requestSnapshot);
   refs.refreshLogsBtn.addEventListener("click", loadLogs);
   refs.peekCloseBtn.addEventListener("click", closePeek);
+  refs.streamRigFilter.addEventListener("change", handleStreamFilterChange);
+  refs.streamRoleFilter.addEventListener("change", handleStreamFilterChange);
+  refs.streamQuery.addEventListener("input", handleStreamFilterChange);
+  refs.followAllBtn.addEventListener("click", toggleFollowAll);
   refs.peekModal.addEventListener("click", (event) => {
     if (event.target === refs.peekModal) closePeek();
   });
@@ -236,7 +248,7 @@ function handleStreamEvent(message) {
     target,
     content: "",
     state: "opening",
-    follow: true,
+    follow: appState.streamFollowAll,
     lastEventAt: 0,
     session: "",
   };
@@ -265,18 +277,16 @@ function handleStreamEvent(message) {
 }
 
 function preferredFocusTarget() {
-  const liveWorker = appState.cockpit.workers.find((worker) => worker.stream && worker.stream.available);
+  const liveWorker = monitorWorkers()[0];
   return liveWorker ? liveWorker.stream.target : "mayor";
 }
 
 function syncStreamTargets() {
   const desired = new Set(["mayor"]);
-  const workers = [...appState.cockpit.workers]
-    .filter((worker) => worker.stream && worker.stream.available)
-    .sort((left, right) => workerPriority(right) - workerPriority(left));
+  const workers = monitorWorkers().filter(matchesStreamFilters);
 
   if (appState.focusTarget) desired.add(appState.focusTarget);
-  for (const worker of workers.slice(0, 4)) desired.add(worker.stream.target);
+  for (const worker of workers) desired.add(worker.stream.target);
 
   const previous = appState.desiredTargets;
   appState.desiredTargets = desired;
@@ -460,30 +470,39 @@ function renderQueue() {
 }
 
 function renderStreamDeck() {
+  renderStreamFilters();
   const orderedTargets = Array.from(appState.desiredTargets);
   refs.streamSummary.textContent = `${orderedTargets.length} subscriptions`;
-  refs.overviewHero.innerHTML = renderHeroStream(appState.focusTarget || "mayor");
+  refs.overviewHero.innerHTML = renderHeroStream("mayor");
   refs.focusStream.innerHTML = renderHeroStream(appState.focusTarget || "mayor");
+  refs.mayorMonitor.innerHTML = renderMonitorStream("mayor", { focusable: false });
 
-  const others = orderedTargets.filter((target) => target !== appState.focusTarget);
-  refs.streamGrid.innerHTML = others.map((target) => renderMiniStream(target)).join("");
+  const visibleWorkers = monitorWorkers().filter(matchesStreamFilters);
+  refs.monitorWallSummary.textContent = `${visibleWorkers.length} panes visible`;
+  refs.monitorWall.innerHTML = visibleWorkers.length > 0
+    ? visibleWorkers.map((worker) => renderMonitorStream(worker.stream.target, { focusable: true })).join("")
+    : `<div class="empty-state">No worker streams match the current monitor filters.</div>`;
 
   bindStreamActions(refs.focusStream);
-  bindStreamActions(refs.streamGrid);
   bindStreamActions(refs.overviewHero);
+  bindStreamActions(refs.mayorMonitor);
+  bindStreamActions(refs.monitorWall);
 }
 
 function renderHeroStream(target) {
   const stream = streamFor(target);
+  const details = streamDetail(target);
   return `
     <article class="hero-card">
       <div class="stream-head">
         <div class="stream-title">
           <div class="stream-target">${esc(target)}</div>
+          <div class="stream-meta">${esc(details)}</div>
           <div class="stream-meta">${esc(streamCaption(stream))}</div>
         </div>
         <div class="stream-actions">
           <span class="state-pill ${streamStateClass(stream)}">${esc(stream.state)}</span>
+          <button class="btn tiny ghost" data-follow-toggle="${escAttr(target)}">${stream.follow ? "Tail On" : "Tail Off"}</button>
           <button class="btn tiny ghost" data-peek-target="${escAttr(target)}">Peek</button>
         </div>
       </div>
@@ -492,18 +511,22 @@ function renderHeroStream(target) {
   `;
 }
 
-function renderMiniStream(target) {
+function renderMonitorStream(target, options = {}) {
   const stream = streamFor(target);
+  const details = streamDetail(target);
   return `
     <article class="stream-card">
       <div class="stream-head">
         <div class="stream-title">
           <div class="stream-target">${esc(target)}</div>
+          <div class="stream-meta">${esc(details)}</div>
           <div class="stream-meta">${esc(streamCaption(stream))}</div>
         </div>
         <div class="stream-actions">
           <span class="state-pill ${streamStateClass(stream)}">${esc(stream.state)}</span>
-          <button class="btn tiny ghost" data-focus-target="${escAttr(target)}">Focus</button>
+          <button class="btn tiny ghost" data-follow-toggle="${escAttr(target)}">${stream.follow ? "Tail On" : "Tail Off"}</button>
+          ${options.focusable ? `<button class="btn tiny ghost" data-focus-target="${escAttr(target)}">Focus</button>` : ""}
+          <button class="btn tiny ghost" data-peek-target="${escAttr(target)}">Peek</button>
         </div>
       </div>
       <div class="stream-body" data-stream-target="${escAttr(target)}">${esc(stream.content || "Waiting for tmux stream data...")}</div>
@@ -521,6 +544,14 @@ function bindStreamActions(root) {
   });
   root.querySelectorAll("[data-peek-target]").forEach((button) => {
     button.addEventListener("click", () => peek(button.dataset.peekTarget));
+  });
+  root.querySelectorAll("[data-follow-toggle]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const stream = streamFor(button.dataset.followToggle);
+      stream.follow = !stream.follow;
+      appState.streams.set(stream.target, stream);
+      renderStreamDeck();
+    });
   });
   root.querySelectorAll("[data-stream-target]").forEach((el) => {
     const stream = appState.streams.get(el.dataset.streamTarget);
@@ -541,10 +572,40 @@ function streamFor(target) {
     target,
     content: "",
     state: "opening",
-    follow: true,
+    follow: appState.streamFollowAll,
     lastEventAt: 0,
     session: "",
   };
+}
+
+function handleStreamFilterChange() {
+  appState.streamFilters = {
+    rig: refs.streamRigFilter.value || "all",
+    role: refs.streamRoleFilter.value || "polecat",
+    query: refs.streamQuery.value.trim().toLowerCase(),
+  };
+  syncStreamTargets();
+  renderStreamDeck();
+}
+
+function toggleFollowAll() {
+  appState.streamFollowAll = !appState.streamFollowAll;
+  for (const stream of appState.streams.values()) {
+    stream.follow = appState.streamFollowAll;
+  }
+  renderStreamDeck();
+}
+
+function renderStreamFilters() {
+  const rigs = ["all", ...appState.cockpit.rigs.map((rig) => rig.name)];
+  refs.streamRigFilter.innerHTML = rigs
+    .map((rig) => `<option value="${escAttr(rig)}">${esc(rig === "all" ? "All rigs" : rig)}</option>`)
+    .join("");
+  if (!rigs.includes(appState.streamFilters.rig)) appState.streamFilters.rig = "all";
+  refs.streamRigFilter.value = appState.streamFilters.rig;
+  refs.streamRoleFilter.value = appState.streamFilters.role;
+  refs.streamQuery.value = appState.streamFilters.query;
+  refs.followAllBtn.textContent = appState.streamFollowAll ? "Tail All: On" : "Tail All: Off";
 }
 
 function renderLogs() {
@@ -746,6 +807,30 @@ function topologyColor(type, state) {
 
 function workerPriority(worker) {
   return (worker.status === "alive" ? 20 : 0) + (worker.role === "polecat" ? 8 : 0) + (worker.issue ? 4 : 0);
+}
+
+function monitorWorkers() {
+  return [...appState.cockpit.workers]
+    .filter((worker) => worker.stream && worker.stream.available)
+    .sort((left, right) => workerPriority(right) - workerPriority(left));
+}
+
+function matchesStreamFilters(worker) {
+  if (appState.streamFilters.role !== "all" && worker.role !== appState.streamFilters.role) return false;
+  if (appState.streamFilters.rig !== "all" && worker.rig !== appState.streamFilters.rig) return false;
+  if (!appState.streamFilters.query) return true;
+  const haystack = [worker.name, worker.rig, worker.role, worker.issue, worker.branch].join(" ").toLowerCase();
+  return haystack.includes(appState.streamFilters.query);
+}
+
+function streamDetail(target) {
+  if (target === "mayor") return "Mayor command loop";
+  const worker = appState.cockpit.workers.find((item) => item.stream && item.stream.target === target);
+  if (!worker) return "Live worker pane";
+  const detail = [worker.role];
+  if (worker.rig) detail.push(worker.rig);
+  if (worker.issue) detail.push(`#${worker.issue}`);
+  return detail.join(" • ");
 }
 
 function workerStateClass(worker) {

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -95,8 +95,47 @@
         <span>Live Streams</span>
         <span class="panel-meta" id="streamSummary">0 subscriptions</span>
       </div>
-      <div class="focus-stream" id="focusStream"></div>
-      <div class="stream-grid" id="streamGrid"></div>
+      <div class="stream-toolbar">
+        <div class="stream-filter-row">
+          <label class="stream-filter">
+            <span>Rig</span>
+            <select id="streamRigFilter">
+              <option value="all">All rigs</option>
+            </select>
+          </label>
+          <label class="stream-filter">
+            <span>Role</span>
+            <select id="streamRoleFilter">
+              <option value="polecat">Polecats</option>
+              <option value="all">All workers</option>
+              <option value="dog">Dogs</option>
+            </select>
+          </label>
+          <label class="stream-filter stream-filter-wide">
+            <span>Match</span>
+            <input type="text" id="streamQuery" placeholder="rig, worker, issue, branch">
+          </label>
+        </div>
+        <div class="stream-actions">
+          <button class="btn tiny ghost" id="followAllBtn">Tail All: On</button>
+          <span class="panel-meta" id="monitorWallSummary">0 panes visible</span>
+        </div>
+      </div>
+
+      <div class="monitor-layout">
+        <div class="monitor-column">
+          <div class="subpanel-title">Focused Pane</div>
+          <div class="focus-stream" id="focusStream"></div>
+
+          <div class="subpanel-title">Mayor Live Monitor</div>
+          <div id="mayorMonitor"></div>
+        </div>
+
+        <div class="monitor-column monitor-column-wide">
+          <div class="subpanel-title">Worker Monitor Wall</div>
+          <div class="stream-grid" id="monitorWall"></div>
+        </div>
+      </div>
     </section>
 
     <section class="panel section" id="section-topology">

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -456,6 +456,55 @@ a {
   margin-bottom: 16px;
 }
 
+.stream-toolbar,
+.stream-filter-row,
+.stream-filter {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.stream-toolbar {
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.stream-filter {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.stream-filter select,
+.stream-filter input {
+  min-width: 140px;
+  padding: 10px 12px;
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(3, 14, 22, 0.94);
+}
+
+.stream-filter-wide input {
+  min-width: 220px;
+}
+
+.monitor-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 0.95fr) minmax(0, 1.05fr);
+  gap: var(--gap);
+}
+
+.monitor-column {
+  min-width: 0;
+}
+
+.monitor-column-wide {
+  min-width: 0;
+}
+
 .hero-card,
 .stream-card {
   padding: 14px;
@@ -519,6 +568,17 @@ a {
 
 .hero-card .stream-body {
   height: 370px;
+}
+
+#mayorMonitor .stream-card {
+  min-height: 260px;
+  background:
+    linear-gradient(180deg, rgba(77, 214, 255, 0.08), rgba(8, 28, 41, 0.82)),
+    rgba(8, 28, 41, 0.78);
+}
+
+#mayorMonitor .stream-body {
+  height: 280px;
 }
 
 .stream-empty,
@@ -724,7 +784,8 @@ a {
 
   .dispatch-grid,
   .overview-grid,
-  .topology-wrap {
+  .topology-wrap,
+  .monitor-layout {
     grid-template-columns: 1fr;
   }
 }
@@ -745,5 +806,15 @@ a {
 
   .stream-grid {
     grid-template-columns: 1fr;
+  }
+
+  .stream-toolbar {
+    align-items: flex-start;
+  }
+
+  .stream-filter,
+  .stream-filter select,
+  .stream-filter input {
+    width: 100%;
   }
 }

--- a/web/test/operator-shell.test.js
+++ b/web/test/operator-shell.test.js
@@ -11,6 +11,10 @@ test("operator shell html includes cockpit sections and assets", () => {
   assert.match(html, /section-topology/);
   assert.match(html, /section-dispatch/);
   assert.match(html, /section-logs/);
+  assert.match(html, /id="streamRigFilter"/);
+  assert.match(html, /id="streamRoleFilter"/);
+  assert.match(html, /id="mayorMonitor"/);
+  assert.match(html, /id="monitorWall"/);
   assert.match(html, /id="blockerBoard"/);
   assert.match(html, /id="topologyCanvas"/);
   assert.match(html, /src="\/app\.js"/);
@@ -23,6 +27,10 @@ test("operator shell script consumes snapshot and tmux stream events", () => {
   assert.match(script, /message\.type === "stream\/open"/);
   assert.match(script, /message\.type === "stream\/data"/);
   assert.match(script, /message\.type === "stream\/stale"/);
+  assert.match(script, /streamFilters/);
+  assert.match(script, /Tail All: On/);
+  assert.match(script, /renderMonitorStream/);
+  assert.match(script, /matchesStreamFilters/);
   assert.match(script, /renderTopology/);
   assert.match(script, /renderStreamDeck/);
 });


### PR DESCRIPTION
Closes #268

## Summary
- add a dedicated Mayor monitor plus a filtered multi-pane worker wall in the repo-tracked web cockpit
- subscribe all filtered active polecat streams instead of capping live worker panes
- add rig/role/query filters and per-pane/global tail controls without regressing peek/focus workflows

## Verification
- cd web && npm test