### PR TITLE
Surface blocker alerts and optional voice announcements

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -34,12 +34,19 @@ Environment variables:
 | `SGT_WEB_PORT` | `4747` | Server port |
 | `SGT_ROOT` | `~/sgt` | SGT workspace root |
 | `SGT_BIN` | `$SGT_ROOT/sgt` | Path to sgt binary |
+| `SGT_WEB_ELEVENLABS_API_KEY` | unset | Optional ElevenLabs API key for blocker voice announcements |
+| `SGT_WEB_ELEVENLABS_VOICE_ID` | unset | Optional ElevenLabs voice id used when voice is enabled |
+| `SGT_WEB_ELEVENLABS_MODEL_ID` | `eleven_turbo_v2_5` | Optional ElevenLabs model override |
+| `SGT_WEB_VOICE_EVENT_KINDS` | `blocker-resolved` | Comma-separated blocker alert kinds eligible for voice |
+| `SGT_WEB_VOICE_RATE_LIMIT_SECS` | `90` | Minimum seconds between eligible voice announcements |
 
 ## Features
 
 - **Dense cockpit shell** — Single-page JARVIS-style HUD with command pulse, alert center, worker roster, rig matrix, topology radar, and dispatch console
 - **Live tmux monitoring** — Mayor gets a dedicated live monitor, while all active polecats can stay open simultaneously in a filtered multi-pane wall with per-pane tail/focus/peek controls
 - **Acceptance blocker center** — Open blockers stay prominent with rig ownership, evidence snippets, and timestamps
+- **Recent alert rail** — New blocker openings, follow-up escalations, and resolutions surface as explicit alert cards instead of blending into the blocker list
+- **Optional ElevenLabs voice** — Env-gated blocker voice announcements with browser mute control plus backend dedupe and rate limiting
 - **Realtime WS** — Normalized `snapshot` pushes plus tmux stream events and live `sgt.log` updates; reconnect/backoff and stale states remain visible
 - **Topology radar** — Canvas relationship view driven from normalized `topology` nodes/edges, with a clean fallback when WebGL is absent
 - **Keyboard shortcuts** — `1..5` jump between shell sections, `c` toggles compact mode, `Esc` closes peek modal
@@ -79,6 +86,11 @@ Stored under `web/docs/screenshots/`:
 - **Permissions**
   - The server shells out to `sgt` and reads `~/sgt/sgt.log`. Ensure the user running the web server can access those files.
 
+- **Voice announcements are unavailable**
+  - Set both `SGT_WEB_ELEVENLABS_API_KEY` and `SGT_WEB_ELEVENLABS_VOICE_ID`.
+  - The UI stays fully usable without them; the Voice chip will show `Unavailable`.
+  - The browser mute toggle only affects local playback. Backend event gating and rate limiting still apply for eligible announcements.
+
 ## Reasoning behind the project
 
 SGT exists because the original **Gas Town** tooling became bloated and fragile:
@@ -110,6 +122,7 @@ The goal is higher reliability, a simpler mental model, and easier ops.
 | GET | `/api/dogs` | Dog state files |
 | GET | `/api/merge-queue` | Merge queue items |
 | GET | `/api/blockers` | Active acceptance blockers |
+| GET | `/api/announcements/:alertId/audio` | Optional ElevenLabs audio for an eligible blocker alert |
 | GET | `/api/peek/:target` | Peek at tmux pane output |
 | GET | `/api/logs?lines=N` | Tail sgt.log |
 | GET | `/api/plan-state/:rig` | Repo plan-state JSON for one rig |

--- a/web/lib/cockpit.js
+++ b/web/lib/cockpit.js
@@ -183,6 +183,163 @@ function readAcceptanceBlockers(configDir) {
     .sort((a, b) => String(b.createdAt).localeCompare(String(a.createdAt)));
 }
 
+function mapById(items = []) {
+  const mapped = new Map();
+  for (const item of items) {
+    if (!item || !item.id) continue;
+    mapped.set(item.id, item);
+  }
+  return mapped;
+}
+
+function blockerAlertMessage(kind, blocker, context = {}) {
+  const rig = blocker.rig || 'unknown rig';
+  if (kind === 'blocker-opened') {
+    return `${rig} blocker opened: ${blocker.title}`;
+  }
+  if (kind === 'blocker-followup') {
+    return `${rig} blocker needs follow-up: ${blocker.title}`;
+  }
+  if (kind === 'blocker-resolved') {
+    if (context.remainingRigBlockers === 0 && context.remainingTotalBlockers === 0) {
+      return `${rig} blocker resolved. All acceptance blockers are clear.`;
+    }
+    if (context.remainingRigBlockers === 0) {
+      return `${rig} blocker resolved. No open blockers remain on this rig.`;
+    }
+    return `${rig} blocker resolved: ${blocker.title}`;
+  }
+  return `${rig} blocker updated: ${blocker.title}`;
+}
+
+class BlockerAlertTracker {
+  constructor({
+    now = () => new Date().toISOString(),
+    historyLimit = 24,
+    voice = {},
+  } = {}) {
+    this.now = now;
+    this.historyLimit = historyLimit;
+    this.voice = {
+      enabled: Boolean(voice.enabled),
+      eventKinds: Array.isArray(voice.eventKinds) ? voice.eventKinds : [],
+      rateLimitMs: Number(voice.rateLimitMs) || 0,
+      ...voice,
+    };
+    this.previousBlockers = new Map();
+    this.events = [];
+    this.primed = false;
+    this.lastVoiceAtMs = 0;
+  }
+
+  observe(blockers = []) {
+    const nextBlockers = mapById(blockers);
+    if (!this.primed) {
+      this.previousBlockers = nextBlockers;
+      this.primed = true;
+      return this.listEvents();
+    }
+
+    const createdAt = this.now();
+    const createdMs = Date.parse(createdAt) || Date.now();
+    const rigCounts = new Map();
+    for (const blocker of blockers) {
+      const key = blocker.rig || '';
+      rigCounts.set(key, (rigCounts.get(key) || 0) + 1);
+    }
+
+    for (const [id, blocker] of nextBlockers.entries()) {
+      const previous = this.previousBlockers.get(id);
+      if (!previous) {
+        this.pushEvent({
+          id: `alert:${id}:opened:${createdAt}`,
+          blockerId: id,
+          kind: 'blocker-opened',
+          severity: 'critical',
+          createdAt,
+          blocker,
+          remainingRigBlockers: rigCounts.get(blocker.rig || '') || 0,
+          remainingTotalBlockers: blockers.length,
+        }, createdMs);
+        continue;
+      }
+      if (previous.status !== blocker.status) {
+        this.pushEvent({
+          id: `alert:${id}:status:${createdAt}`,
+          blockerId: id,
+          kind: blocker.status === 'needs-followup' ? 'blocker-followup' : 'blocker-opened',
+          severity: blocker.status === 'needs-followup' ? 'warning' : 'critical',
+          createdAt,
+          blocker,
+          remainingRigBlockers: rigCounts.get(blocker.rig || '') || 0,
+          remainingTotalBlockers: blockers.length,
+        }, createdMs);
+      }
+    }
+
+    for (const [id, blocker] of this.previousBlockers.entries()) {
+      if (nextBlockers.has(id)) continue;
+      this.pushEvent({
+        id: `alert:${id}:resolved:${createdAt}`,
+        blockerId: id,
+        kind: 'blocker-resolved',
+        severity: 'good',
+        createdAt,
+        blocker,
+        remainingRigBlockers: rigCounts.get(blocker.rig || '') || 0,
+        remainingTotalBlockers: blockers.length,
+      }, createdMs);
+    }
+
+    this.previousBlockers = nextBlockers;
+    this.events = this.events
+      .sort((left, right) => String(right.createdAt).localeCompare(String(left.createdAt)))
+      .slice(0, this.historyLimit);
+    return this.listEvents();
+  }
+
+  pushEvent(event, createdMs) {
+    const voice = this.computeVoice(event, createdMs);
+    this.events.unshift({
+      id: event.id,
+      blockerId: event.blockerId,
+      kind: event.kind,
+      severity: event.severity,
+      createdAt: event.createdAt,
+      rig: event.blocker.rig || '',
+      title: event.blocker.title || 'Verified acceptance blocker',
+      status: event.blocker.status || '',
+      requester: event.blocker.requester || 'unknown',
+      message: blockerAlertMessage(event.kind, event.blocker, event),
+      evidence: event.blocker.evidence || '',
+      voice,
+    });
+  }
+
+  computeVoice(event, createdMs) {
+    const text = blockerAlertMessage(event.kind, event.blocker, event);
+    if (!this.voice.enabled) {
+      return { enabled: false, eligible: false, reason: 'not-configured', text };
+    }
+    if (!this.voice.eventKinds.includes(event.kind)) {
+      return { enabled: true, eligible: false, reason: 'event-disabled', text };
+    }
+    if (this.voice.rateLimitMs > 0 && this.lastVoiceAtMs > 0 && createdMs - this.lastVoiceAtMs < this.voice.rateLimitMs) {
+      return { enabled: true, eligible: false, reason: 'rate-limited', text };
+    }
+    this.lastVoiceAtMs = createdMs;
+    return { enabled: true, eligible: true, reason: 'ready', text };
+  }
+
+  listEvents() {
+    return this.events.map((event) => ({ ...event }));
+  }
+
+  getEvent(alertId) {
+    return this.events.find((event) => event.id === alertId) || null;
+  }
+}
+
 function readRecentLogLines(logPath, maxLines) {
   try {
     const content = fs.readFileSync(logPath, 'utf8');
@@ -368,8 +525,10 @@ function buildCockpitSnapshot({
   statusRaw = '',
   rigs = [],
   blockers = [],
+  alerts = [],
   recentLogs = [],
   version = '1',
+  voice = {},
 }) {
   const fallbackParsed = parseStatus(statusRaw || '');
   const statusData = statusJson || {};
@@ -415,6 +574,13 @@ function buildCockpitSnapshot({
         blockers: true,
         tmuxStreaming: true,
         normalizedSnapshot: true,
+        voiceAnnouncements: Boolean(voice.enabled),
+      },
+      voice: {
+        enabled: Boolean(voice.enabled),
+        configured: Boolean(voice.configured),
+        eventKinds: Array.isArray(voice.eventKinds) ? voice.eventKinds : [],
+        rateLimitSeconds: Number(voice.rateLimitSeconds) || 0,
       },
     },
     agents,
@@ -427,6 +593,7 @@ function buildCockpitSnapshot({
       },
     },
     blockers,
+    alerts,
     logs: {
       lines: recentLogs,
       total: recentLogs.length,
@@ -590,6 +757,7 @@ class TmuxStreamManager {
 }
 
 module.exports = {
+  BlockerAlertTracker,
   TmuxStreamManager,
   buildCockpitSnapshot,
   computeStreamDelta,

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -1,4 +1,5 @@
 const COMPACT_KEY = "sgt_web_compact";
+const VOICE_MUTE_KEY = "sgt_web_voice_muted";
 
 const appState = {
   ws: null,
@@ -14,6 +15,10 @@ const appState = {
   desiredTargets: new Set(),
   streams: new Map(),
   sections: ["overview", "streams", "topology", "dispatch", "logs"],
+  voiceMuted: true,
+  alertIdsSeen: new Set(),
+  alertsBootstrapped: false,
+  activeAnnouncement: null,
 };
 
 const refs = {
@@ -21,6 +26,8 @@ const refs = {
   connLabel: document.getElementById("connLabel"),
   lastUpdated: document.getElementById("lastUpdated"),
   lastLog: document.getElementById("lastLog"),
+  voiceMuteBtn: document.getElementById("voiceMuteBtn"),
+  voiceStatus: document.getElementById("voiceStatus"),
   compactBtn: document.getElementById("compactBtn"),
   refreshSnapshotBtn: document.getElementById("refreshSnapshotBtn"),
   navButtons: Array.from(document.querySelectorAll(".nav-btn")),
@@ -31,6 +38,7 @@ const refs = {
   rigCountLabel: document.getElementById("rigCountLabel"),
   rigMatrix: document.getElementById("rigMatrix"),
   blockerSummary: document.getElementById("blockerSummary"),
+  alertRail: document.getElementById("alertRail"),
   blockerBoard: document.getElementById("blockerBoard"),
   overviewHero: document.getElementById("overviewHero"),
   queueBoard: document.getElementById("queueBoard"),
@@ -67,6 +75,7 @@ initialize();
 
 function initialize() {
   setCompact(localStorage.getItem(COMPACT_KEY) === "1");
+  setVoiceMuted(localStorage.getItem(VOICE_MUTE_KEY) !== "0");
   bindEvents();
   detectTopologyMode();
   loadRigs();
@@ -78,6 +87,7 @@ function initialize() {
 function bindEvents() {
   refs.compactBtn.addEventListener("click", () => setCompact(!document.body.classList.contains("compact")));
   refs.refreshSnapshotBtn.addEventListener("click", requestSnapshot);
+  refs.voiceMuteBtn.addEventListener("click", () => setVoiceMuted(!appState.voiceMuted));
   refs.refreshLogsBtn.addEventListener("click", loadLogs);
   refs.peekCloseBtn.addEventListener("click", closePeek);
   refs.streamRigFilter.addEventListener("change", handleStreamFilterChange);
@@ -127,12 +137,13 @@ function bindEvents() {
 
 function emptyCockpit() {
   return {
-    meta: { serverTime: "", featureFlags: {} },
+    meta: { serverTime: "", featureFlags: {}, voice: {} },
     agents: [],
     rigs: [],
     workers: [],
     queue: { items: [], summary: { total: 0 } },
     blockers: [],
+    alerts: [],
     logs: { lines: [], total: 0 },
     topology: { nodes: [], edges: [] },
   };
@@ -141,6 +152,14 @@ function emptyCockpit() {
 function setCompact(on) {
   document.body.classList.toggle("compact", Boolean(on));
   localStorage.setItem(COMPACT_KEY, on ? "1" : "0");
+}
+
+function setVoiceMuted(on) {
+  appState.voiceMuted = Boolean(on);
+  localStorage.setItem(VOICE_MUTE_KEY, appState.voiceMuted ? "1" : "0");
+  refs.voiceMuteBtn.setAttribute("aria-pressed", appState.voiceMuted ? "true" : "false");
+  refs.voiceMuteBtn.classList.toggle("active", !appState.voiceMuted);
+  updateVoiceStatus();
 }
 
 function activateSection(name) {
@@ -207,6 +226,7 @@ function requestSnapshot() {
 
 function handleWsMessage(message) {
   if (message.type === "snapshot" && message.snapshot) {
+    const newAlerts = diffNewAlerts(message.snapshot.alerts || []);
     appState.cockpit = message.snapshot;
     appState.lastSnapshotAt = Date.now();
     if (!appState.focusTarget || !hasTarget(appState.focusTarget)) {
@@ -214,6 +234,7 @@ function handleWsMessage(message) {
     }
     syncStreamTargets();
     renderAll();
+    maybePlayVoiceAnnouncement(newAlerts);
     return;
   }
 
@@ -316,11 +337,35 @@ function renderAll() {
   renderMetrics();
   renderRoster();
   renderRigs();
+  renderAlerts();
   renderBlockers();
   renderQueue();
   renderStreamDeck();
   renderLogs();
   renderTopology();
+}
+
+function renderAlerts() {
+  const alerts = appState.cockpit.alerts || [];
+  updateVoiceStatus();
+  if (alerts.length === 0) {
+    refs.alertRail.innerHTML = `<div class="empty-state">Recent blocker transitions and milestone alerts will appear here.</div>`;
+    return;
+  }
+
+  refs.alertRail.innerHTML = alerts.slice(0, 6).map((alert) => `
+    <article class="alert-card alert-${escAttr(alert.severity || "info")}">
+      <div class="queue-head">
+        <div class="blocker-title">${esc(alert.message || alert.title)}</div>
+        <span class="severity-pill ${alertSeverityClass(alert)}">${esc(alert.kind || "event")}</span>
+      </div>
+      <div class="blocker-meta">
+        <span>${esc(alert.rig || "unknown rig")}</span>
+        <span>${esc(formatIso(alert.createdAt))}</span>
+        <span>${esc(alertVoiceLabel(alert))}</span>
+      </div>
+    </article>
+  `).join("");
 }
 
 function renderMetrics() {
@@ -427,7 +472,8 @@ function renderRigs() {
 }
 
 function renderBlockers() {
-  refs.blockerSummary.textContent = `${appState.cockpit.blockers.length} open blockers`;
+  const totalAlerts = (appState.cockpit.alerts || []).length;
+  refs.blockerSummary.textContent = `${appState.cockpit.blockers.length} open blockers · ${totalAlerts} recent alerts`;
   if (appState.cockpit.blockers.length === 0) {
     refs.blockerBoard.innerHTML = `<div class="empty-state">Acceptance blockers will surface here with evidence and rig ownership.</div>`;
     return;
@@ -443,6 +489,7 @@ function renderBlockers() {
         <span>${esc(blocker.rig || "unknown rig")}</span>
         <span>${esc(blocker.requester || "unknown reporter")}</span>
         <span>${esc(formatIso(blocker.createdAt))}</span>
+        <span>${esc(snippet(blocker.id || "", 26))}</span>
       </div>
       <p>${esc(snippet(blocker.evidence || "No evidence body recorded.", 240))}</p>
     </article>
@@ -899,6 +946,87 @@ function formatLogLine(line) {
     return `<div class="log-line"><span class="timestamp">[${esc(match[1])}]</span> <span class="log-event">${esc(match[2])}</span> ${esc(match[3])}</div>`;
   }
   return `<div class="log-line">${esc(line)}</div>`;
+}
+
+function diffNewAlerts(alerts) {
+  const unseen = [];
+  for (const alert of alerts) {
+    if (!alert || !alert.id) continue;
+    if (!appState.alertIdsSeen.has(alert.id) && appState.alertsBootstrapped) {
+      unseen.push(alert);
+    }
+  }
+  appState.alertIdsSeen = new Set(alerts.map((alert) => alert.id).filter(Boolean));
+  if (!appState.alertsBootstrapped) {
+    appState.alertsBootstrapped = true;
+  }
+  return unseen;
+}
+
+function updateVoiceStatus() {
+  const voice = appState.cockpit.meta.voice || {};
+  let label = "Muted";
+  if (!voice.configured) {
+    label = "Unavailable";
+  } else if (appState.voiceMuted) {
+    label = "Muted";
+  } else if (appState.activeAnnouncement) {
+    label = "Playing";
+  } else {
+    label = "Armed";
+  }
+  refs.voiceStatus.textContent = label;
+}
+
+function alertSeverityClass(alert) {
+  if (alert.severity === "good") return "state-good";
+  if (alert.severity === "warning") return "state-warn";
+  if (alert.severity === "critical") return "state-critical";
+  return "state-active";
+}
+
+function alertVoiceLabel(alert) {
+  if (!alert.voice || !alert.voice.enabled) return "Visual only";
+  if (alert.voice.eligible) return "Voice ready";
+  if (alert.voice.reason === "event-disabled") return "Voice disabled for event";
+  if (alert.voice.reason === "rate-limited") return "Voice rate-limited";
+  return "Voice unavailable";
+}
+
+async function maybePlayVoiceAnnouncement(alerts) {
+  if (appState.voiceMuted || appState.activeAnnouncement) {
+    updateVoiceStatus();
+    return;
+  }
+  const next = alerts.find((alert) => alert && alert.voice && alert.voice.enabled && alert.voice.eligible);
+  if (!next) {
+    updateVoiceStatus();
+    return;
+  }
+
+  const audio = new Audio(`/api/announcements/${encodeURIComponent(next.id)}/audio`);
+  appState.activeAnnouncement = audio;
+  updateVoiceStatus();
+
+  const clear = () => {
+    if (appState.activeAnnouncement === audio) {
+      appState.activeAnnouncement = null;
+      updateVoiceStatus();
+    }
+  };
+
+  audio.addEventListener("ended", clear, { once: true });
+  audio.addEventListener("error", () => {
+    clear();
+    toast(`Voice announcement unavailable for ${next.rig || "rig"}.`, "error");
+  }, { once: true });
+
+  try {
+    await audio.play();
+  } catch (error) {
+    clear();
+    toast(`Voice playback blocked: ${error.message}`, "error");
+  }
 }
 
 function toast(message, type) {

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -31,6 +31,10 @@
         <span>Log Feed</span>
         <strong id="lastLog">--</strong>
       </div>
+      <button class="status-chip voice-chip" id="voiceMuteBtn" type="button" aria-pressed="true">
+        <span>Voice</span>
+        <strong id="voiceStatus">Muted</strong>
+      </button>
       <button class="btn ghost" id="compactBtn">Compact</button>
       <button class="btn ghost" id="refreshSnapshotBtn">Refresh</button>
     </div>
@@ -76,6 +80,7 @@
         <span>Alert Center</span>
         <span class="panel-meta" id="blockerSummary">0 open blockers</span>
       </div>
+      <div class="alert-rail" id="alertRail"></div>
       <div class="blocker-board" id="blockerBoard"></div>
 
       <div class="overview-grid">

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -170,6 +170,15 @@ a {
   font-size: 13px;
 }
 
+.voice-chip {
+  border-radius: 999px;
+}
+
+.voice-chip.active {
+  border-color: rgba(157, 247, 125, 0.35);
+  background: rgba(157, 247, 125, 0.12);
+}
+
 .pill-dot {
   width: 10px;
   height: 10px;
@@ -263,6 +272,7 @@ a {
 
 .roster-list,
 .rig-list,
+.alert-rail,
 .blocker-board,
 .queue-list,
 .topology-list {
@@ -272,6 +282,7 @@ a {
 
 .roster-item,
 .rig-item,
+.alert-card,
 .blocker-card,
 .queue-item,
 .hero-card,
@@ -406,6 +417,11 @@ a {
   margin-top: 16px;
 }
 
+.alert-rail {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-bottom: 14px;
+}
+
 .subpanel {
   min-width: 0;
 }
@@ -419,6 +435,7 @@ a {
 }
 
 .blocker-board:empty::before,
+.alert-rail:empty::before,
 .queue-list:empty::before,
 .stream-grid:empty::before,
 .roster-list:empty::before,
@@ -431,6 +448,35 @@ a {
   color: var(--muted);
   border: 1px dashed var(--line);
   border-radius: 14px;
+}
+
+.alert-card {
+  padding: 14px;
+  border-left: 3px solid var(--line-strong);
+  background:
+    linear-gradient(180deg, rgba(77, 214, 255, 0.08), rgba(8, 28, 41, 0.78)),
+    rgba(8, 28, 41, 0.78);
+}
+
+.alert-card.alert-critical {
+  border-left-color: rgba(255, 107, 107, 0.9);
+  background:
+    linear-gradient(135deg, rgba(255, 107, 107, 0.22), transparent 58%),
+    rgba(8, 28, 41, 0.82);
+}
+
+.alert-card.alert-good {
+  border-left-color: rgba(157, 247, 125, 0.9);
+  background:
+    linear-gradient(135deg, rgba(157, 247, 125, 0.16), transparent 58%),
+    rgba(8, 28, 41, 0.82);
+}
+
+.alert-card.alert-warning {
+  border-left-color: rgba(248, 184, 74, 0.9);
+  background:
+    linear-gradient(135deg, rgba(248, 184, 74, 0.18), transparent 58%),
+    rgba(8, 28, 41, 0.82);
 }
 
 .blocker-card {

--- a/web/server.js
+++ b/web/server.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const { WebSocketServer } = require('ws');
 const http = require('http');
+const https = require('https');
 const path = require('path');
 const fs = require('fs');
 const { execFile } = require('child_process');
 
 const {
+  BlockerAlertTracker,
   TmuxStreamManager,
   buildCockpitSnapshot,
   listStateEntries,
@@ -30,9 +32,40 @@ const WS_INTERVAL = 3000;
 const WS_PING_INTERVAL = 15000;
 const WS_PONG_GRACE = 35000;
 const LOG_TAIL_LINES = 120;
+const ELEVENLABS_API_KEY = process.env.SGT_WEB_ELEVENLABS_API_KEY || '';
+const ELEVENLABS_VOICE_ID = process.env.SGT_WEB_ELEVENLABS_VOICE_ID || '';
+const ELEVENLABS_MODEL_ID = process.env.SGT_WEB_ELEVENLABS_MODEL_ID || 'eleven_turbo_v2_5';
+const VOICE_RATE_LIMIT_SECS = Number.parseInt(process.env.SGT_WEB_VOICE_RATE_LIMIT_SECS || '90', 10) || 90;
+const VOICE_EVENT_KINDS = String(process.env.SGT_WEB_VOICE_EVENT_KINDS || 'blocker-resolved')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean);
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'public')));
+
+function elevenLabsConfigured() {
+  return Boolean(ELEVENLABS_API_KEY && ELEVENLABS_VOICE_ID);
+}
+
+const blockerAlertTracker = new BlockerAlertTracker({
+  voice: {
+    enabled: elevenLabsConfigured(),
+    configured: elevenLabsConfigured(),
+    eventKinds: VOICE_EVENT_KINDS,
+    rateLimitMs: VOICE_RATE_LIMIT_SECS * 1000,
+  },
+});
+const announcementAudioCache = new Map();
+
+function voiceState() {
+  return {
+    enabled: elevenLabsConfigured(),
+    configured: elevenLabsConfigured(),
+    eventKinds: VOICE_EVENT_KINDS,
+    rateLimitSeconds: VOICE_RATE_LIMIT_SECS,
+  };
+}
 
 function runSgt(args) {
   return new Promise((resolve, reject) => {
@@ -99,13 +132,55 @@ async function readRigs() {
 
 async function buildSnapshot() {
   const [{ statusRaw, statusJson }, rigs] = await Promise.all([readStatusBundle(), readRigs()]);
+  const blockers = readAcceptanceBlockers(SGT_CONFIG);
+  const alerts = blockerAlertTracker.observe(blockers);
   return buildCockpitSnapshot({
     statusJson,
     statusRaw,
     rigs,
-    blockers: readAcceptanceBlockers(SGT_CONFIG),
+    blockers,
+    alerts,
     recentLogs: readRecentLogLines(SGT_LOG, LOG_TAIL_LINES),
     version: COCKPIT_VERSION,
+    voice: voiceState(),
+  });
+}
+
+async function synthesizeElevenLabs(text) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({
+      text,
+      model_id: ELEVENLABS_MODEL_ID,
+      voice_settings: {
+        stability: 0.45,
+        similarity_boost: 0.72,
+      },
+    });
+    const request = https.request({
+      method: 'POST',
+      hostname: 'api.elevenlabs.io',
+      path: `/v1/text-to-speech/${encodeURIComponent(ELEVENLABS_VOICE_ID)}`,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+        'xi-api-key': ELEVENLABS_API_KEY,
+        Accept: 'audio/mpeg',
+      },
+    }, (response) => {
+      const chunks = [];
+      response.on('data', (chunk) => chunks.push(chunk));
+      response.on('end', () => {
+        const payload = Buffer.concat(chunks);
+        if (response.statusCode && response.statusCode >= 200 && response.statusCode < 300) {
+          resolve(payload);
+          return;
+        }
+        reject(new Error(payload.toString('utf8') || `ElevenLabs request failed with status ${response.statusCode}`));
+      });
+    });
+    request.on('error', reject);
+    request.write(body);
+    request.end();
   });
 }
 
@@ -208,6 +283,35 @@ app.get('/api/blockers', (req, res) => {
   res.json(readAcceptanceBlockers(SGT_CONFIG));
 });
 
+app.get('/api/announcements/:alertId/audio', async (req, res) => {
+  const event = blockerAlertTracker.getEvent(req.params.alertId);
+  if (!event) {
+    res.status(404).json({ error: 'announcement not found' });
+    return;
+  }
+  if (!event.voice || !event.voice.enabled) {
+    res.status(404).json({ error: 'voice announcements are not configured' });
+    return;
+  }
+  if (!event.voice.eligible) {
+    res.status(409).json({ error: `announcement not available: ${event.voice.reason || 'not-ready'}` });
+    return;
+  }
+
+  try {
+    let audio = announcementAudioCache.get(event.id);
+    if (!audio) {
+      audio = await synthesizeElevenLabs(event.voice.text);
+      announcementAudioCache.set(event.id, audio);
+    }
+    res.setHeader('Content-Type', 'audio/mpeg');
+    res.setHeader('Cache-Control', 'private, max-age=86400');
+    res.send(audio);
+  } catch (error) {
+    res.status(502).json({ error: error.message });
+  }
+});
+
 app.get('/api/peek/:target', async (req, res) => {
   try {
     const output = await runSgt(['peek', req.params.target]);
@@ -308,6 +412,7 @@ wss.on('connection', (ws) => {
       normalizedSnapshot: true,
       blockers: true,
       tmuxStreaming: true,
+      voiceAnnouncements: true,
     },
   });
 

--- a/web/test/cockpit.test.js
+++ b/web/test/cockpit.test.js
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const {
+  BlockerAlertTracker,
   TmuxStreamManager,
   buildCockpitSnapshot,
   computeStreamDelta,
@@ -49,19 +50,75 @@ test('buildCockpitSnapshot shapes normalized rig, worker, blocker, and topology 
         evidence: 'Need more work',
       },
     ],
+    alerts: [
+      {
+        id: 'alert:1',
+        blockerId: 'sgt-acceptance-1',
+        kind: 'blocker-opened',
+        severity: 'critical',
+        createdAt: '2026-03-30T06:00:10Z',
+        rig: 'sgt',
+        title: 'Acceptance still red',
+        message: 'sgt blocker opened: Acceptance still red',
+        voice: { enabled: false, eligible: false, reason: 'not-configured' },
+      },
+    ],
     recentLogs: ['[2026-03-30T06:00:00Z] MAYOR_START'],
     version: 'test',
+    voice: {
+      enabled: false,
+      configured: false,
+      eventKinds: ['blocker-resolved'],
+      rateLimitSeconds: 90,
+    },
   });
 
   assert.equal(snapshot.meta.featureFlags.tmuxStreaming, true);
+  assert.equal(snapshot.meta.featureFlags.voiceAnnouncements, false);
   assert.equal(snapshot.rigs.length, 1);
   assert.equal(snapshot.rigs[0].blockers, 1);
   assert.equal(snapshot.rigs[0].activeWorkers, 1);
   assert.equal(snapshot.workers[0].stream.target, 'sgt-34784812');
   assert.equal(snapshot.queue.summary.total, 1);
   assert.equal(snapshot.blockers[0].title, 'Acceptance still red');
+  assert.equal(snapshot.alerts[0].kind, 'blocker-opened');
   assert.ok(snapshot.topology.nodes.some((node) => node.id === 'rig:sgt'));
   assert.ok(snapshot.topology.edges.some((edge) => edge.from === 'rig:sgt' && edge.type === 'runs'));
+});
+
+test('BlockerAlertTracker records blocker opens and resolutions with voice gating', () => {
+  const tracker = new BlockerAlertTracker({
+    now: (() => {
+      const stamps = [
+        '2026-03-30T06:00:00Z',
+        '2026-03-30T06:01:00Z',
+        '2026-03-30T06:02:00Z',
+      ];
+      let index = 0;
+      return () => stamps[index++] || stamps[stamps.length - 1];
+    })(),
+    voice: {
+      enabled: true,
+      eventKinds: ['blocker-resolved'],
+      rateLimitMs: 0,
+    },
+  });
+
+  assert.equal(tracker.observe([{ id: 'b1', rig: 'sgt', title: 'Acceptance still red', status: 'open', requester: 'rigger' }]).length, 0);
+
+  const eventsAfterOpen = tracker.observe([
+    { id: 'b1', rig: 'sgt', title: 'Acceptance still red', status: 'open', requester: 'rigger' },
+    { id: 'b2', rig: 'pmkb', title: 'Smoke test blocked', status: 'open', requester: 'witness' },
+  ]);
+  assert.equal(eventsAfterOpen[0].kind, 'blocker-opened');
+  assert.equal(eventsAfterOpen[0].voice.eligible, false);
+  assert.equal(eventsAfterOpen[0].voice.reason, 'event-disabled');
+
+  const eventsAfterResolve = tracker.observe([{ id: 'b2', rig: 'pmkb', title: 'Smoke test blocked', status: 'open', requester: 'witness' }]);
+  assert.equal(eventsAfterResolve[0].kind, 'blocker-resolved');
+  assert.equal(eventsAfterResolve[0].rig, 'sgt');
+  assert.equal(eventsAfterResolve[0].voice.eligible, true);
+  assert.match(eventsAfterResolve[0].voice.text, /No open blockers remain on this rig|All acceptance blockers are clear/);
 });
 
 test('computeStreamDelta emits append-only chunks when possible and reset on divergence', () => {

--- a/web/test/operator-shell.test.js
+++ b/web/test/operator-shell.test.js
@@ -15,7 +15,9 @@ test("operator shell html includes cockpit sections and assets", () => {
   assert.match(html, /id="streamRoleFilter"/);
   assert.match(html, /id="mayorMonitor"/);
   assert.match(html, /id="monitorWall"/);
+  assert.match(html, /id="alertRail"/);
   assert.match(html, /id="blockerBoard"/);
+  assert.match(html, /id="voiceMuteBtn"/);
   assert.match(html, /id="topologyCanvas"/);
   assert.match(html, /src="\/app\.js"/);
   assert.match(html, /href="\/styles\.css"/);
@@ -31,6 +33,8 @@ test("operator shell script consumes snapshot and tmux stream events", () => {
   assert.match(script, /Tail All: On/);
   assert.match(script, /renderMonitorStream/);
   assert.match(script, /matchesStreamFilters/);
+  assert.match(script, /maybePlayVoiceAnnouncement/);
+  assert.match(script, /renderAlerts/);
   assert.match(script, /renderTopology/);
   assert.match(script, /renderStreamDeck/);
 });


### PR DESCRIPTION
Closes #269

## Summary
- add blocker transition alerts to the normalized web cockpit snapshot and render them in a prominent alert rail
- expose optional ElevenLabs announcement audio behind env-configured gating with browser mute plus backend event/rate limits
- document the new config and cover the snapshot/alert tracker behavior in web tests