### PR TITLE
Build the live topology visualization layer

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -41,7 +41,7 @@ Environment variables:
 - **Live tmux monitoring** — Mayor gets a dedicated live monitor, while all active polecats can stay open simultaneously in a filtered multi-pane wall with per-pane tail/focus/peek controls
 - **Acceptance blocker center** — Open blockers stay prominent with rig ownership, evidence snippets, and timestamps
 - **Realtime WS** — Normalized `snapshot` pushes plus tmux stream events and live `sgt.log` updates; reconnect/backoff and stale states remain visible
-- **Topology radar** — Canvas relationship view driven from normalized `topology` nodes/edges, with a clean fallback when WebGL is absent
+- **Topology radar** — Live WebGL relationship graph for Mayor, rigs, workers, issues, PRs, blockers, and queue links, with clean canvas fallback when WebGL is absent
 - **Keyboard shortcuts** — `1..5` jump between shell sections, `c` toggles compact mode, `Esc` closes peek modal
 - **Dispatch** — Sling polecats and dogs without leaving the shell
 

--- a/web/docs/live-cockpit-architecture.md
+++ b/web/docs/live-cockpit-architecture.md
@@ -4,6 +4,8 @@ Issue: `#262`
 
 This document records the current `web/` audit and locks the implementation shape for the live cockpit build-out. Follow-on work should extend this architecture rather than replace it with a separate app tree or a different stack without an explicit new decision.
 
+Status note: the topology/WebGL follow-on called out below landed in issue `#272`; this document remains the architecture lock for the surrounding app shape and degradation rules.
+
 ## Audit Summary
 
 Current repo-tracked implementation:

--- a/web/lib/cockpit.js
+++ b/web/lib/cockpit.js
@@ -236,32 +236,132 @@ function normalizeWorker(worker, role) {
 function buildTopology(snapshot) {
   const nodes = [];
   const edges = [];
+  const seenNodes = new Map();
+  const seenEdges = new Set();
 
-  nodes.push({ id: 'mayor', type: 'agent', label: 'Mayor' });
+  function upsertNode(node) {
+    if (!node || !node.id) return node;
+    const existing = seenNodes.get(node.id) || {};
+    const merged = { ...existing, ...node };
+    seenNodes.set(node.id, merged);
+    return merged;
+  }
+
+  function addEdge(edge) {
+    if (!edge || !edge.from || !edge.to || !edge.type) return;
+    const key = `${edge.from}|${edge.to}|${edge.type}`;
+    if (seenEdges.has(key)) return;
+    seenEdges.add(key);
+    edges.push(edge);
+  }
+
+  upsertNode({ id: 'mayor', type: 'agent', label: 'Mayor', state: 'active' });
   for (const rig of snapshot.rigs) {
-    nodes.push({ id: `rig:${rig.name}`, type: 'rig', label: rig.name, state: rig.state });
-    edges.push({ from: 'mayor', to: `rig:${rig.name}`, type: 'oversees' });
+    upsertNode({
+      id: `rig:${rig.name}`,
+      type: 'rig',
+      label: rig.name,
+      state: rig.state,
+      detail: rig.reason || '',
+    });
+    addEdge({ from: 'mayor', to: `rig:${rig.name}`, type: 'oversees' });
   }
 
   for (const worker of snapshot.workers) {
     const workerNode = `worker:${worker.id}`;
-    nodes.push({ id: workerNode, type: worker.role, label: worker.name, state: worker.status });
-    if (worker.rig) edges.push({ from: `rig:${worker.rig}`, to: workerNode, type: 'runs' });
-    if (worker.issue) edges.push({ from: workerNode, to: `issue:${worker.rig || 'unknown'}:${worker.issue}`, type: 'tracks' });
-    if (worker.pr && worker.pr.number) edges.push({ from: workerNode, to: `pr:${worker.rig || 'unknown'}:${worker.pr.number}`, type: 'owns' });
+    upsertNode({
+      id: workerNode,
+      type: worker.role,
+      label: worker.name,
+      state: worker.status,
+      rig: worker.rig || '',
+      detail: worker.branch || '',
+    });
+    if (worker.rig) addEdge({ from: `rig:${worker.rig}`, to: workerNode, type: 'runs' });
+    if (worker.issue) {
+      const issueNode = `issue:${worker.rig || 'unknown'}:${worker.issue}`;
+      upsertNode({
+        id: issueNode,
+        type: 'issue',
+        label: `#${worker.issue}`,
+        state: worker.status === 'alive' ? 'active' : 'open',
+        rig: worker.rig || '',
+        detail: worker.branch || '',
+      });
+      addEdge({ from: workerNode, to: issueNode, type: 'tracks' });
+    }
+    if (worker.pr && worker.pr.number) {
+      const prNode = `pr:${worker.rig || 'unknown'}:${worker.pr.number}`;
+      upsertNode({
+        id: prNode,
+        type: 'pr',
+        label: `PR #${worker.pr.number}`,
+        state: worker.pr.state || 'open',
+        rig: worker.rig || '',
+        detail: worker.pr.title || '',
+      });
+      addEdge({ from: workerNode, to: prNode, type: 'owns' });
+      if (worker.issue) {
+        addEdge({
+          from: prNode,
+          to: `issue:${worker.rig || 'unknown'}:${worker.issue}`,
+          type: 'addresses',
+        });
+      }
+    }
   }
 
   for (const blocker of snapshot.blockers) {
     const blockerNode = `blocker:${blocker.id}`;
-    nodes.push({ id: blockerNode, type: 'blocker', label: blocker.title, state: blocker.status });
-    if (blocker.rig) edges.push({ from: `rig:${blocker.rig}`, to: blockerNode, type: 'blocked-by' });
+    upsertNode({
+      id: blockerNode,
+      type: 'blocker',
+      label: blocker.title,
+      state: blocker.status,
+      rig: blocker.rig || '',
+      detail: blocker.requester || '',
+    });
+    if (blocker.rig) addEdge({ from: `rig:${blocker.rig}`, to: blockerNode, type: 'blocked-by' });
   }
 
   for (const item of snapshot.queue.items) {
     const queueNode = `queue:${item.name}`;
-    nodes.push({ id: queueNode, type: 'queue', label: item.name, detail: item.detail || '' });
+    const detail = `${item.name || ''} ${item.detail || ''}`;
+    const prMatch = detail.match(/PR#(\d+)/i);
+    const rigMatch = detail.match(/\b([a-z0-9_-]+)\b$/i);
+    upsertNode({
+      id: queueNode,
+      type: 'queue',
+      label: item.name,
+      state: 'queued',
+      rig: rigMatch ? rigMatch[1] : '',
+      detail: item.detail || '',
+    });
+    if (prMatch) {
+      const prNode = `pr:${rigMatch ? rigMatch[1] : 'unknown'}:${prMatch[1]}`;
+      upsertNode({
+        id: prNode,
+        type: 'pr',
+        label: `PR #${prMatch[1]}`,
+        state: 'queued',
+        rig: rigMatch ? rigMatch[1] : '',
+        detail: item.detail || '',
+      });
+      addEdge({ from: queueNode, to: prNode, type: 'queues' });
+    }
+    if (rigMatch) {
+      upsertNode({ id: `rig:${rigMatch[1]}`, type: 'rig', label: rigMatch[1], state: 'active' });
+      addEdge({ from: `rig:${rigMatch[1]}`, to: queueNode, type: 'feeds' });
+    }
   }
 
+  nodes.push(...Array.from(seenNodes.values()));
+  nodes.sort((left, right) => left.id.localeCompare(right.id));
+  edges.sort((left, right) => {
+    const a = `${left.type}:${left.from}:${left.to}`;
+    const b = `${right.type}:${right.from}:${right.to}`;
+    return a.localeCompare(b);
+  });
   return { nodes, edges };
 }
 
@@ -592,6 +692,7 @@ class TmuxStreamManager {
 module.exports = {
   TmuxStreamManager,
   buildCockpitSnapshot,
+  buildTopology,
   computeStreamDelta,
   listStateEntries,
   parseStatus,

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -14,6 +14,16 @@ const appState = {
   desiredTargets: new Set(),
   streams: new Map(),
   sections: ["overview", "streams", "topology", "dispatch", "logs"],
+  topology: {
+    renderer: "canvas",
+    modeLabel: "Canvas fallback",
+    layout: new Map(),
+    hoveredId: "",
+    selectedId: "",
+    gl: null,
+    program: null,
+    buffers: null,
+  },
 };
 
 const refs = {
@@ -46,6 +56,7 @@ const refs = {
   serverTimeLabel: document.getElementById("serverTimeLabel"),
   topologyMode: document.getElementById("topologyMode"),
   topologyCanvas: document.getElementById("topologyCanvas"),
+  topologySummary: document.getElementById("topologySummary"),
   topologyList: document.getElementById("topologyList"),
   logSummary: document.getElementById("logSummary"),
   logViewer: document.getElementById("logViewer"),
@@ -68,7 +79,7 @@ initialize();
 function initialize() {
   setCompact(localStorage.getItem(COMPACT_KEY) === "1");
   bindEvents();
-  detectTopologyMode();
+  setupTopologyCanvas();
   loadRigs();
   loadLogs();
   connectWs();
@@ -123,6 +134,9 @@ function bindEvents() {
   });
 
   window.addEventListener("resize", renderTopology);
+  refs.topologyCanvas.addEventListener("mousemove", handleTopologyPointerMove);
+  refs.topologyCanvas.addEventListener("mouseleave", () => updateTopologyHover(""));
+  refs.topologyCanvas.addEventListener("click", handleTopologyClick);
 }
 
 function emptyCockpit() {
@@ -726,83 +740,503 @@ function closePeek() {
 
 function renderTopology() {
   const topology = appState.cockpit.topology || { nodes: [], edges: [] };
-  refs.topologyList.innerHTML = (topology.edges || []).slice(0, 16).map((edge) => `
-    <div class="topology-item">${esc(edge.from)} -> ${esc(edge.to)} (${esc(edge.type)})</div>
-  `).join("");
-
   const canvas = refs.topologyCanvas;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return;
-
   const width = canvas.clientWidth || canvas.width;
   const height = canvas.clientHeight || canvas.height;
-  canvas.width = width * devicePixelRatio;
-  canvas.height = height * devicePixelRatio;
-  ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
-  ctx.clearRect(0, 0, width, height);
+  const renderState = buildTopologyRenderState(topology, width, height);
 
-  const nodes = topology.nodes || [];
-  const edges = topology.edges || [];
-  if (nodes.length === 0) {
-    ctx.fillStyle = "#7fa9bc";
-    ctx.font = "14px IBM Plex Sans";
-    ctx.fillText("Topology data will appear when the cockpit snapshot contains nodes.", 20, 34);
+  refs.topologyList.innerHTML = renderTopologyFeed(renderState);
+  refs.topologySummary.innerHTML = renderTopologySummary(renderState);
+
+  if (renderState.nodes.length === 0) {
+    renderTopologyCanvasFallback(renderState, width, height);
     return;
   }
 
-  const positions = new Map();
-  const centerX = width / 2;
-  const centerY = height / 2;
-  const radius = Math.max(120, Math.min(width, height) / 2.8);
+  const renderedWithWebGl = renderTopologyWebGl(renderState, width, height);
+  if (!renderedWithWebGl) {
+    renderTopologyCanvasFallback(renderState, width, height);
+  }
+}
 
-  nodes.forEach((node, index) => {
-    const angle = (Math.PI * 2 * index) / Math.max(nodes.length, 1) - Math.PI / 2;
-    positions.set(node.id, {
-      x: centerX + Math.cos(angle) * radius,
-      y: centerY + Math.sin(angle) * radius,
-      color: topologyColor(node.type, node.state),
-    });
-  });
-
-  ctx.lineWidth = 1.2;
-  edges.forEach((edge) => {
-    const from = positions.get(edge.from);
-    const to = positions.get(edge.to);
-    if (!from || !to) return;
-    ctx.strokeStyle = "rgba(77, 214, 255, 0.28)";
-    ctx.beginPath();
-    ctx.moveTo(from.x, from.y);
-    ctx.lineTo(to.x, to.y);
-    ctx.stroke();
-  });
-
-  nodes.forEach((node) => {
-    const pos = positions.get(node.id);
-    if (!pos) return;
-    ctx.fillStyle = pos.color;
-    ctx.shadowBlur = 18;
-    ctx.shadowColor = pos.color;
-    ctx.beginPath();
-    ctx.arc(pos.x, pos.y, 8, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.shadowBlur = 0;
-    ctx.fillStyle = "#d9f4ff";
-    ctx.font = "12px IBM Plex Sans";
-    ctx.fillText(node.label || node.id, pos.x + 12, pos.y + 4);
-  });
+function setupTopologyCanvas() {
+  detectTopologyMode();
 }
 
 function detectTopologyMode() {
   const hasWebGl = Boolean(window.WebGLRenderingContext && document.createElement("canvas").getContext("webgl"));
-  refs.topologyMode.textContent = hasWebGl ? "WebGL-ready browser, canvas radar active" : "Canvas fallback";
+  appState.topology.renderer = hasWebGl ? "webgl" : "canvas";
+  appState.topology.modeLabel = hasWebGl ? "WebGL live topology" : "Canvas fallback";
+  refs.topologyMode.textContent = appState.topology.modeLabel;
 }
 
 function topologyColor(type, state) {
   if (type === "blocker" || state === "blocked") return "#ff6b6b";
   if (type === "rig") return "#8bf0ff";
   if (type === "queue") return "#f8b84a";
+  if (type === "issue") return "#c58fff";
+  if (type === "pr") return "#7da8ff";
   if (state === "alive" || state === "active") return "#9df77d";
   return "#7da8ff";
+}
+
+function buildTopologyRenderState(topology, width, height) {
+  const nodes = Array.isArray(topology.nodes) ? topology.nodes : [];
+  const edges = Array.isArray(topology.edges) ? topology.edges : [];
+  const layout = appState.topology.layout;
+  const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+  const rigIds = nodes.filter((node) => node.type === "rig").map((node) => node.id);
+
+  for (const id of Array.from(layout.keys())) {
+    if (!nodeMap.has(id)) layout.delete(id);
+  }
+
+  const bounds = {
+    minX: 30,
+    maxX: Math.max(30, width - 30),
+    minY: 30,
+    maxY: Math.max(30, height - 30),
+  };
+
+  nodes.forEach((node) => {
+    const anchor = topologyAnchor(node, width, height, rigIds);
+    const existing = layout.get(node.id);
+    const position = existing || {
+      x: anchor.x + ((hashString(node.id) % 23) - 11) * 2.2,
+      y: anchor.y + ((hashString(`${node.id}:y`) % 23) - 11) * 1.9,
+      vx: 0,
+      vy: 0,
+    };
+    layout.set(node.id, {
+      id: node.id,
+      ...position,
+      anchorX: anchor.x,
+      anchorY: anchor.y,
+      radius: topologyRadius(node),
+      color: topologyColor(node.type, node.state),
+      label: node.label || node.id,
+      detail: node.detail || "",
+      rig: node.rig || "",
+      type: node.type || "node",
+      state: node.state || "",
+    });
+  });
+
+  for (let iteration = 0; iteration < 30; iteration += 1) {
+    for (let i = 0; i < nodes.length; i += 1) {
+      const left = layout.get(nodes[i].id);
+      if (!left) continue;
+      for (let j = i + 1; j < nodes.length; j += 1) {
+        const right = layout.get(nodes[j].id);
+        if (!right) continue;
+        const dx = left.x - right.x;
+        const dy = left.y - right.y;
+        const distanceSq = Math.max(dx * dx + dy * dy, 1);
+        const distance = Math.sqrt(distanceSq);
+        const force = 1600 / distanceSq;
+        const pushX = (dx / distance) * force;
+        const pushY = (dy / distance) * force;
+        left.vx += pushX;
+        left.vy += pushY;
+        right.vx -= pushX;
+        right.vy -= pushY;
+      }
+    }
+
+    edges.forEach((edge) => {
+      const from = layout.get(edge.from);
+      const to = layout.get(edge.to);
+      if (!from || !to) return;
+      const dx = to.x - from.x;
+      const dy = to.y - from.y;
+      const distance = Math.max(Math.hypot(dx, dy), 1);
+      const desired = preferredTopologyEdgeLength(from, to, width, height);
+      const pull = (distance - desired) * 0.0034;
+      const shiftX = (dx / distance) * pull;
+      const shiftY = (dy / distance) * pull;
+      from.vx += shiftX;
+      from.vy += shiftY;
+      to.vx -= shiftX;
+      to.vy -= shiftY;
+    });
+
+    nodes.forEach((node) => {
+      const current = layout.get(node.id);
+      if (!current) return;
+      current.vx += (current.anchorX - current.x) * 0.018;
+      current.vy += (current.anchorY - current.y) * 0.018;
+      current.vx *= 0.82;
+      current.vy *= 0.82;
+      current.x = clamp(current.x + current.vx, bounds.minX, bounds.maxX);
+      current.y = clamp(current.y + current.vy, bounds.minY, bounds.maxY);
+    });
+  }
+
+  const renderNodes = nodes.map((node) => ({ id: node.id, ...layout.get(node.id) }));
+  const renderNodeMap = new Map(renderNodes.map((node) => [node.id, node]));
+  const renderEdges = edges
+    .map((edge) => ({ ...edge, fromNode: renderNodeMap.get(edge.from), toNode: renderNodeMap.get(edge.to) }))
+    .filter((edge) => edge.fromNode && edge.toNode);
+
+  const activeId = appState.topology.selectedId || appState.topology.hoveredId || renderNodes[0]?.id || "";
+  const activeNode = activeId ? renderNodeMap.get(activeId) : null;
+
+  return {
+    width,
+    height,
+    nodes: renderNodes,
+    edges: renderEdges,
+    nodeMap: renderNodeMap,
+    activeNode,
+    activeId: activeNode ? activeNode.id : "",
+  };
+}
+
+function renderTopologyFeed(renderState) {
+  if (renderState.edges.length === 0) {
+    return `<div class="empty-state">Relationship edges will appear here once the cockpit snapshot includes linked rigs, workers, blockers, or queue items.</div>`;
+  }
+
+  const activeId = renderState.activeId;
+  const prioritized = [...renderState.edges].sort((left, right) => {
+    const leftScore = left.from === activeId || left.to === activeId ? 1 : 0;
+    const rightScore = right.from === activeId || right.to === activeId ? 1 : 0;
+    return rightScore - leftScore;
+  });
+
+  return prioritized.slice(0, 18).map((edge) => `
+    <div class="topology-item">${esc(shortTopologyLabel(renderState.nodeMap.get(edge.from)))} -> ${esc(shortTopologyLabel(renderState.nodeMap.get(edge.to)))} (${esc(edge.type)})</div>
+  `).join("");
+}
+
+function renderTopologySummary(renderState) {
+  if (renderState.nodes.length === 0) {
+    return `<strong>No topology yet</strong>Waiting for snapshot nodes and edges from the cockpit backend.`;
+  }
+
+  const node = renderState.activeNode;
+  if (!node) {
+    return `<strong>Live graph ready</strong>${esc(renderState.nodes.length)} nodes, ${esc(renderState.edges.length)} edges. Select a node in the graph to inspect its connected lanes.`;
+  }
+
+  const connected = renderState.edges.filter((edge) => edge.from === node.id || edge.to === node.id);
+  const detailParts = [node.type];
+  if (node.rig) detailParts.push(node.rig);
+  if (node.state) detailParts.push(node.state);
+  return `
+    <strong>${esc(node.label)}</strong>
+    ${esc(detailParts.join(" • "))}<br>
+    ${esc(node.detail || "No extra detail recorded.")}<br>
+    ${esc(connected.length)} linked relationship${connected.length === 1 ? "" : "s"} in the current cockpit snapshot.
+  `;
+}
+
+function renderTopologyCanvasFallback(renderState, width, height) {
+  const canvas = refs.topologyCanvas;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = Math.max(1, Math.round(width * dpr));
+  canvas.height = Math.max(1, Math.round(height * dpr));
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, width, height);
+  refs.topologyMode.textContent = appState.topology.renderer === "webgl" ? "Canvas fallback (WebGL init failed)" : appState.topology.modeLabel;
+
+  drawTopologyBackdrop(ctx, width, height);
+
+  if (renderState.nodes.length === 0) {
+    ctx.fillStyle = "#7fa9bc";
+    ctx.font = "14px IBM Plex Sans";
+    ctx.fillText("Topology data will appear when the cockpit snapshot contains nodes.", 20, 34);
+    return;
+  }
+
+  renderState.edges.forEach((edge) => {
+    const emphasis = edge.from === renderState.activeId || edge.to === renderState.activeId;
+    ctx.strokeStyle = emphasis ? "rgba(248, 184, 74, 0.72)" : "rgba(77, 214, 255, 0.24)";
+    ctx.lineWidth = emphasis ? 2 : 1.2;
+    ctx.beginPath();
+    ctx.moveTo(edge.fromNode.x, edge.fromNode.y);
+    ctx.lineTo(edge.toNode.x, edge.toNode.y);
+    ctx.stroke();
+  });
+
+  renderState.nodes.forEach((node) => {
+    const selected = node.id === renderState.activeId;
+    const hovered = node.id === appState.topology.hoveredId;
+    ctx.fillStyle = node.color;
+    ctx.shadowBlur = selected || hovered ? 20 : 12;
+    ctx.shadowColor = node.color;
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, node.radius + (selected ? 2 : 0), 0, Math.PI * 2);
+    ctx.fill();
+    ctx.shadowBlur = 0;
+    ctx.fillStyle = "#d9f4ff";
+    ctx.font = selected ? "600 12px IBM Plex Sans" : "12px IBM Plex Sans";
+    ctx.fillText(node.label, node.x + node.radius + 8, node.y + 4);
+  });
+}
+
+function renderTopologyWebGl(renderState, width, height) {
+  if (appState.topology.renderer !== "webgl") return false;
+  const gl = ensureTopologyGl();
+  if (!gl) return false;
+
+  refs.topologyMode.textContent = appState.topology.modeLabel;
+  const canvas = refs.topologyCanvas;
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = Math.max(1, Math.round(width * dpr));
+  canvas.height = Math.max(1, Math.round(height * dpr));
+  gl.viewport(0, 0, canvas.width, canvas.height);
+  gl.clearColor(0.015, 0.05, 0.08, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+
+  const edgeVertices = [];
+  const edgeColors = [];
+  renderState.edges.forEach((edge) => {
+    const emphasis = edge.from === renderState.activeId || edge.to === renderState.activeId;
+    const rgba = emphasis ? [0.973, 0.722, 0.29, 0.95] : [0.302, 0.839, 1, 0.24];
+    pushGlVertex(edgeVertices, edge.fromNode.x, edge.fromNode.y, width, height);
+    pushGlVertex(edgeVertices, edge.toNode.x, edge.toNode.y, width, height);
+    edgeColors.push(...rgba, ...rgba);
+  });
+
+  const nodeVertices = [];
+  const nodeColors = [];
+  const nodeSizes = [];
+  renderState.nodes.forEach((node) => {
+    pushGlVertex(nodeVertices, node.x, node.y, width, height);
+    nodeColors.push(...hexToRgb(topologyColor(node.type, node.state)), 1);
+    const emphasis = node.id === renderState.activeId ? 5 : node.id === appState.topology.hoveredId ? 3 : 0;
+    nodeSizes.push((node.radius + emphasis) * (window.devicePixelRatio || 1));
+  });
+
+  const { program, buffers } = appState.topology;
+  gl.useProgram(program.handle);
+
+  if (edgeVertices.length > 0) {
+    bindGlAttribute(gl, buffers.edgePosition, program.attributes.aPosition, new Float32Array(edgeVertices), 2);
+    bindGlAttribute(gl, buffers.edgeColor, program.attributes.aColor, new Float32Array(edgeColors), 4);
+    gl.disableVertexAttribArray(program.attributes.aPointSize);
+    gl.vertexAttrib1f(program.attributes.aPointSize, 1);
+    gl.uniform1f(program.uniforms.uRenderPoints, 0);
+    gl.drawArrays(gl.LINES, 0, edgeVertices.length / 2);
+  }
+
+  bindGlAttribute(gl, buffers.nodePosition, program.attributes.aPosition, new Float32Array(nodeVertices), 2);
+  bindGlAttribute(gl, buffers.nodeColor, program.attributes.aColor, new Float32Array(nodeColors), 4);
+  bindGlAttribute(gl, buffers.nodeSize, program.attributes.aPointSize, new Float32Array(nodeSizes), 1);
+  gl.uniform1f(program.uniforms.uRenderPoints, 1);
+  gl.drawArrays(gl.POINTS, 0, nodeVertices.length / 2);
+  return true;
+}
+
+function ensureTopologyGl() {
+  if (appState.topology.gl) return appState.topology.gl;
+  const canvas = refs.topologyCanvas;
+  const gl = canvas.getContext("webgl", { antialias: true, alpha: false, preserveDrawingBuffer: false });
+  if (!gl) {
+    appState.topology.renderer = "canvas";
+    appState.topology.modeLabel = "Canvas fallback";
+    return null;
+  }
+
+  const vertexSource = `
+    attribute vec2 aPosition;
+    attribute vec4 aColor;
+    attribute float aPointSize;
+    varying vec4 vColor;
+    uniform float uRenderPoints;
+    void main() {
+      gl_Position = vec4(aPosition, 0.0, 1.0);
+      gl_PointSize = max(aPointSize, 1.0);
+      vColor = aColor;
+    }
+  `;
+  const fragmentSource = `
+    precision mediump float;
+    varying vec4 vColor;
+    uniform float uRenderPoints;
+    void main() {
+      if (uRenderPoints > 0.5) {
+        vec2 p = gl_PointCoord * 2.0 - 1.0;
+        if (dot(p, p) > 1.0) discard;
+      }
+      gl_FragColor = vColor;
+    }
+  `;
+
+  const program = createGlProgram(gl, vertexSource, fragmentSource);
+  if (!program) {
+    appState.topology.renderer = "canvas";
+    appState.topology.modeLabel = "Canvas fallback";
+    return null;
+  }
+
+  appState.topology.gl = gl;
+  appState.topology.program = {
+    handle: program,
+    attributes: {
+      aPosition: gl.getAttribLocation(program, "aPosition"),
+      aColor: gl.getAttribLocation(program, "aColor"),
+      aPointSize: gl.getAttribLocation(program, "aPointSize"),
+    },
+    uniforms: {
+      uRenderPoints: gl.getUniformLocation(program, "uRenderPoints"),
+    },
+  };
+  appState.topology.buffers = {
+    edgePosition: gl.createBuffer(),
+    edgeColor: gl.createBuffer(),
+    nodePosition: gl.createBuffer(),
+    nodeColor: gl.createBuffer(),
+    nodeSize: gl.createBuffer(),
+  };
+  gl.useProgram(program);
+  gl.enable(gl.BLEND);
+  gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+  return gl;
+}
+
+function handleTopologyPointerMove(event) {
+  const hit = topologyHitTest(event);
+  updateTopologyHover(hit ? hit.id : "");
+}
+
+function handleTopologyClick(event) {
+  const hit = topologyHitTest(event);
+  appState.topology.selectedId = hit ? hit.id : "";
+  renderTopology();
+}
+
+function topologyHitTest(event) {
+  const canvas = refs.topologyCanvas;
+  const rect = canvas.getBoundingClientRect();
+  const x = event.clientX - rect.left;
+  const y = event.clientY - rect.top;
+  let nearest = null;
+  let nearestDistance = 28;
+
+  for (const node of appState.topology.layout.values()) {
+    const distance = Math.hypot(node.x - x, node.y - y);
+    if (distance < nearestDistance) {
+      nearest = node;
+      nearestDistance = distance;
+    }
+  }
+
+  return nearest;
+}
+
+function updateTopologyHover(id) {
+  if (appState.topology.hoveredId === id) return;
+  appState.topology.hoveredId = id;
+  renderTopology();
+}
+
+function topologyAnchor(node, width, height, rigIds) {
+  const rigIndex = node.rig ? rigIds.indexOf(`rig:${node.rig}`) : -1;
+  const rigCount = Math.max(rigIds.length, 1);
+  const rigX = rigIndex >= 0 ? width * (0.18 + (0.64 * (rigIndex + 0.5)) / rigCount) : width * 0.5;
+  const rigY = height * 0.42;
+
+  if (node.id === "mayor") return { x: width * 0.5, y: height * 0.14 };
+  if (node.type === "rig") return { x: rigX, y: rigY };
+  if (node.type === "polecat" || node.type === "dog") return { x: rigX, y: Math.min(height - 60, rigY + 95) };
+  if (node.type === "issue") return { x: rigX - 54, y: Math.min(height - 40, rigY + 182) };
+  if (node.type === "pr") return { x: rigX + 56, y: Math.min(height - 40, rigY + 180) };
+  if (node.type === "blocker") return { x: rigX, y: Math.max(52, rigY - 112) };
+  if (node.type === "queue") return { x: rigX + 96, y: Math.max(60, rigY - 28) };
+  return { x: width * 0.5, y: height * 0.5 };
+}
+
+function preferredTopologyEdgeLength(from, to, width, height) {
+  if (from.type === "rig" || to.type === "rig") return Math.min(width, height) * 0.18;
+  if (from.type === "blocker" || to.type === "blocker") return Math.min(width, height) * 0.2;
+  return Math.min(width, height) * 0.14;
+}
+
+function topologyRadius(node) {
+  if (node.type === "mayor" || node.id === "mayor") return 14;
+  if (node.type === "rig") return 11;
+  if (node.type === "blocker") return 9;
+  if (node.type === "queue") return 8;
+  return 7;
+}
+
+function drawTopologyBackdrop(ctx, width, height) {
+  ctx.clearRect(0, 0, width, height);
+  const gradient = ctx.createRadialGradient(width * 0.5, height * 0.48, 30, width * 0.5, height * 0.48, Math.max(width, height) * 0.44);
+  gradient.addColorStop(0, "rgba(77, 214, 255, 0.12)");
+  gradient.addColorStop(1, "rgba(3, 14, 22, 0.98)");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  ctx.strokeStyle = "rgba(77, 214, 255, 0.08)";
+  ctx.lineWidth = 1;
+  for (let ring = 1; ring <= 4; ring += 1) {
+    ctx.beginPath();
+    ctx.arc(width / 2, height / 2, (Math.min(width, height) * ring) / 7, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+}
+
+function shortTopologyLabel(node) {
+  return node ? node.label || node.id : "unknown";
+}
+
+function pushGlVertex(target, x, y, width, height) {
+  target.push((x / width) * 2 - 1, 1 - (y / height) * 2);
+}
+
+function bindGlAttribute(gl, buffer, attribute, data, size) {
+  gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+  gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
+  gl.enableVertexAttribArray(attribute);
+  gl.vertexAttribPointer(attribute, size, gl.FLOAT, false, 0, 0);
+}
+
+function createGlProgram(gl, vertexSource, fragmentSource) {
+  const vertexShader = compileGlShader(gl, gl.VERTEX_SHADER, vertexSource);
+  const fragmentShader = compileGlShader(gl, gl.FRAGMENT_SHADER, fragmentSource);
+  if (!vertexShader || !fragmentShader) return null;
+  const program = gl.createProgram();
+  gl.attachShader(program, vertexShader);
+  gl.attachShader(program, fragmentShader);
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) return null;
+  return program;
+}
+
+function compileGlShader(gl, type, source) {
+  const shader = gl.createShader(type);
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) return null;
+  return shader;
+}
+
+function hexToRgb(hex) {
+  const value = hex.replace("#", "");
+  const normalized = value.length === 3 ? value.split("").map((item) => `${item}${item}`).join("") : value;
+  const intValue = Number.parseInt(normalized, 16);
+  return [
+    ((intValue >> 16) & 255) / 255,
+    ((intValue >> 8) & 255) / 255,
+    (intValue & 255) / 255,
+  ];
+}
+
+function hashString(value) {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = ((hash << 5) - hash + value.charCodeAt(index)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
 }
 
 function workerPriority(worker) {

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -146,6 +146,8 @@
       <div class="topology-wrap">
         <canvas id="topologyCanvas" width="960" height="520"></canvas>
         <div class="topology-sidebar">
+          <div class="subpanel-title">Node Focus</div>
+          <div class="topology-summary" id="topologySummary">Select a node in the graph to inspect its connected lanes.</div>
           <div class="subpanel-title">Relationship Feed</div>
           <div class="topology-list" id="topologyList"></div>
         </div>

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -598,13 +598,40 @@ a {
 }
 
 #topologyCanvas {
+  display: block;
   width: 100%;
   min-height: 520px;
   border: 1px solid var(--line);
   border-radius: 18px;
+  cursor: crosshair;
   background:
     radial-gradient(circle at center, rgba(77, 214, 255, 0.08), transparent 45%),
     rgba(3, 14, 22, 0.96);
+}
+
+.topology-sidebar {
+  display: grid;
+  gap: 12px;
+}
+
+.topology-summary {
+  min-height: 78px;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(7, 24, 35, 0.78);
+  color: #c7e7f4;
+  line-height: 1.5;
+}
+
+.topology-summary strong {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--cyan-strong);
+  font-family: var(--display);
+  font-size: 13px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
 }
 
 .topology-item {

--- a/web/test/cockpit.test.js
+++ b/web/test/cockpit.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const {
   TmuxStreamManager,
   buildCockpitSnapshot,
+  buildTopology,
   computeStreamDelta,
 } = require('../lib/cockpit');
 
@@ -62,6 +63,39 @@ test('buildCockpitSnapshot shapes normalized rig, worker, blocker, and topology 
   assert.equal(snapshot.blockers[0].title, 'Acceptance still red');
   assert.ok(snapshot.topology.nodes.some((node) => node.id === 'rig:sgt'));
   assert.ok(snapshot.topology.edges.some((edge) => edge.from === 'rig:sgt' && edge.type === 'runs'));
+  assert.ok(snapshot.topology.nodes.some((node) => node.id === 'issue:sgt:264'));
+  assert.ok(snapshot.topology.nodes.some((node) => node.id === 'queue:sgt-pr264'));
+  assert.ok(snapshot.topology.nodes.some((node) => node.id === 'pr:sgt:264'));
+  assert.ok(snapshot.topology.edges.some((edge) => edge.from === 'worker:polecat:sgt-34784812' && edge.to === 'issue:sgt:264' && edge.type === 'tracks'));
+  assert.ok(snapshot.topology.edges.some((edge) => edge.from === 'queue:sgt-pr264' && edge.to === 'pr:sgt:264' && edge.type === 'queues'));
+});
+
+test('buildTopology materializes issue, pr, blocker, and queue nodes before linking edges', () => {
+  const topology = buildTopology({
+    rigs: [{ name: 'sgt', state: 'active', reason: 'open work' }],
+    workers: [
+      {
+        id: 'polecat:sgt-worker',
+        name: 'sgt-worker',
+        role: 'polecat',
+        status: 'alive',
+        rig: 'sgt',
+        issue: '272',
+        branch: 'sgt/sgt-worker',
+        pr: { number: '901', state: 'OPEN', title: 'Build topology' },
+      },
+    ],
+    blockers: [{ id: 'sgt-acceptance-1', rig: 'sgt', status: 'open', title: 'Acceptance blocked', requester: 'rigger' }],
+    queue: { items: [{ name: 'sgt-pr901', detail: 'PR#901 sgt' }] },
+  });
+
+  const nodeIds = new Set(topology.nodes.map((node) => node.id));
+  assert.ok(nodeIds.has('issue:sgt:272'));
+  assert.ok(nodeIds.has('pr:sgt:901'));
+  assert.ok(nodeIds.has('blocker:sgt-acceptance-1'));
+  assert.ok(nodeIds.has('queue:sgt-pr901'));
+  assert.ok(topology.edges.some((edge) => edge.from === 'pr:sgt:901' && edge.to === 'issue:sgt:272' && edge.type === 'addresses'));
+  assert.ok(topology.edges.some((edge) => edge.from === 'rig:sgt' && edge.to === 'queue:sgt-pr901' && edge.type === 'feeds'));
 });
 
 test('computeStreamDelta emits append-only chunks when possible and reset on divergence', () => {

--- a/web/test/operator-shell.test.js
+++ b/web/test/operator-shell.test.js
@@ -17,6 +17,7 @@ test("operator shell html includes cockpit sections and assets", () => {
   assert.match(html, /id="monitorWall"/);
   assert.match(html, /id="blockerBoard"/);
   assert.match(html, /id="topologyCanvas"/);
+  assert.match(html, /id="topologySummary"/);
   assert.match(html, /src="\/app\.js"/);
   assert.match(html, /href="\/styles\.css"/);
 });
@@ -33,4 +34,7 @@ test("operator shell script consumes snapshot and tmux stream events", () => {
   assert.match(script, /matchesStreamFilters/);
   assert.match(script, /renderTopology/);
   assert.match(script, /renderStreamDeck/);
+  assert.match(script, /WebGL live topology/);
+  assert.match(script, /renderTopologyWebGl/);
+  assert.match(script, /renderTopologyCanvasFallback/);
 });


### PR DESCRIPTION
## Summary
- upgrade the cockpit topology snapshot so rigs, workers, issues, PRs, blockers, and queue links all materialize as explicit graph entities
- replace the static radar placeholder with an interactive force-laid topology view that uses WebGL when available and falls back cleanly to canvas
- document the live topology capability and extend web tests around the richer graph model and operator shell wiring

## Testing
- cd web && npm test
- cd web && node --check public/app.js

Closes #272