### PR TITLE
Document cockpit deploy path and proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The repo includes a minimal Web UI for realtime monitoring and dispatch:
 
 - Docs / quick start: [`web/README.md`](web/README.md)
 - Default URL: `http://localhost:4747`
+- Latest-main cockpit proof: `./test_web_cockpit_latest_main_proof.sh`
 
 ## Why SGT exists (short)
 

--- a/test_web_cockpit_latest_main_proof.sh
+++ b/test_web_cockpit_latest_main_proof.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# test_web_cockpit_latest_main_proof.sh — Prove the repo-tracked web cockpit docs, tests, and deploy helper on a latest-main checkout.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+npm --prefix "$REPO_ROOT/web" test
+"$REPO_ROOT/web/scripts/sync-live-copy.sh" --dry-run "$TMP_DIR/live"
+
+echo "WEB COCKPIT LATEST-MAIN PROOF PASSED"

--- a/web/README.md
+++ b/web/README.md
@@ -13,7 +13,12 @@ npm start
 # open http://localhost:4747
 ```
 
-To sync the repo-tracked `web/` copy into the live served target on the rig host:
+## Deploy path
+
+The repo-tracked `web/` directory is the only canonical source for the cockpit.
+The default live served copy on a rig host lives at `/root/sgt/web`, and the default URL is `http://localhost:4747` when you run it locally or `http://<tailscale-host>:4747` on the rig host.
+
+Sync the repo copy into the live target with:
 
 ```bash
 web/scripts/sync-live-copy.sh
@@ -25,9 +30,17 @@ Dry-run the sync first if needed:
 web/scripts/sync-live-copy.sh --dry-run
 ```
 
+Override the live target without editing the script:
+
+```bash
+SGT_WEB_LIVE_DIR=/srv/sgt/web web/scripts/sync-live-copy.sh
+```
+
+`web/scripts/sync-live-copy.sh` uses `rsync --delete`, preserves runtime-only artifacts such as `node_modules/` and `webui.log`, and runs `npm install` in the live target so `/root/sgt/web` stays a served deployment copy rather than a second source tree.
+
 ## Configuration
 
-Environment variables:
+Server runtime environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -39,6 +52,31 @@ Environment variables:
 | `SGT_WEB_ELEVENLABS_MODEL_ID` | `eleven_turbo_v2_5` | Optional ElevenLabs model override |
 | `SGT_WEB_VOICE_EVENT_KINDS` | `blocker-resolved` | Comma-separated blocker alert kinds eligible for voice |
 | `SGT_WEB_VOICE_RATE_LIMIT_SECS` | `90` | Minimum seconds between eligible voice announcements |
+
+Deploy-helper environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SGT_WEB_LIVE_DIR` | `/root/sgt/web` | Alternate live sync target used by `web/scripts/sync-live-copy.sh` |
+
+Behavior notes:
+
+- Voice stays optional. Without `SGT_WEB_ELEVENLABS_API_KEY` and `SGT_WEB_ELEVENLABS_VOICE_ID`, the cockpit stays fully usable and the UI reports voice as unavailable.
+- The browser mute toggle is local state only. Backend event gating and rate limiting still come from `SGT_WEB_VOICE_EVENT_KINDS` and `SGT_WEB_VOICE_RATE_LIMIT_SECS`.
+- The topology panel prefers WebGL for the live graph and falls back to the canvas/overlay path when WebGL init or GPU support is unavailable.
+
+## Latest-main proof
+
+Run this on a fresh checkout of the latest `master`/mainline commit when you want repo-owned proof that the repo-tracked cockpit still covers the documented shell, data model, and deploy path:
+
+```bash
+./test_web_cockpit_latest_main_proof.sh
+```
+
+That proof path bundles:
+
+- `npm --prefix web test` for the cockpit snapshot/topology/blocker alert contracts plus the operator-shell UI and docs/deploy-helper assertions
+- `web/scripts/sync-live-copy.sh --dry-run <tempdir>` so the canonical repo `web/` to live-copy sync path is exercised without touching `/root/sgt/web`
 
 ## Features
 

--- a/web/docs/live-cockpit-architecture.md
+++ b/web/docs/live-cockpit-architecture.md
@@ -174,6 +174,19 @@ web/scripts/sync-live-copy.sh
 
 That script syncs repo `web/` into the live target, preserves runtime-only artifacts such as `node_modules/` and `webui.log`, and runs `npm install` in the live directory so the served copy reflects the repo source.
 
+## Latest-main proof path
+
+Run this on a fresh checkout of the latest `master`/mainline commit when you want repo-owned proof that the repo-tracked cockpit still matches the locked deploy/config/proof contract:
+
+```bash
+./test_web_cockpit_latest_main_proof.sh
+```
+
+This proof path is intentionally narrow:
+
+- `npm --prefix web test` verifies the normalized cockpit snapshot/topology contracts, operator-shell UI structure, and the docs/deploy-helper assertions for the canonical repo copy
+- `web/scripts/sync-live-copy.sh --dry-run <tempdir>` exercises the documented repo `web/` to live-copy deployment helper without mutating `/root/sgt/web`
+
 ## Guardrails For Follow-on Work
 
 - Do not split the app into multiple deployables for this plan.

--- a/web/test/docs-and-sync.test.js
+++ b/web/test/docs-and-sync.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+test('web docs cover deploy path, config, and latest-main proof entrypoint', () => {
+  const readme = fs.readFileSync(path.join(__dirname, '..', 'README.md'), 'utf8');
+
+  assert.match(readme, /\/root\/sgt\/web/);
+  assert.match(readme, /web\/scripts\/sync-live-copy\.sh/);
+  assert.match(readme, /SGT_WEB_LIVE_DIR/);
+  assert.match(readme, /SGT_WEB_PORT/);
+  assert.match(readme, /SGT_WEB_ELEVENLABS_API_KEY/);
+  assert.match(readme, /SGT_WEB_VOICE_RATE_LIMIT_SECS/);
+  assert.match(readme, /WebGL/);
+  assert.match(readme, /test_web_cockpit_latest_main_proof\.sh/);
+});
+
+test('sync-live-copy helper defaults to the canonical live target and preserves runtime artifacts', () => {
+  const script = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'sync-live-copy.sh'), 'utf8');
+
+  assert.match(script, /SGT_WEB_LIVE_DIR/);
+  assert.match(script, /\/root\/sgt\/web/);
+  assert.match(script, /--exclude=node_modules\//);
+  assert.match(script, /--exclude=webui\.log/);
+  assert.match(script, /npm install --prefix "\$TARGET_DIR"/);
+});


### PR DESCRIPTION
Closes #276

## Summary
- document the canonical repo web/ -> /root/sgt/web deploy path and config/runtime defaults
- add a repo-owned latest-main cockpit proof script for the web app
- cover the new docs/deploy-helper contract in the web test suite