### PR TITLE
Preserve wake notify and refresh compatibility across scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,9 +560,10 @@ Default lease is `SGT_MAYOR_INTERVAL + 120` seconds.
 Optional per-rig Mayor architecture:
 - Set `SGT_MAYOR_ARCHITECTURE=per-rig` to run the hierarchical control plane: one `president` tmux session supervising one Mayor tmux session per rig instead of one shared `sgt-mayor`.
 - In that mode, President state/logs live under `~/.sgt/president/`, rig-local Mayor sessions/state/logs live under `~/.sgt/mayors/<rig>/`, deacon supervises `sgt-president`, and `sgt status` / `sgt status --json` expose `president` plus entries like `mayor/pmkb` or `mayor/sgt`.
-- `sgt mayor start|stop` without a rig acts on all rig Mayors in per-rig mode; `sgt wake-mayor` routes rig-targeted wake reasons to the matching Mayor and otherwise broadcasts to all rig Mayors.
-- `sgt president start|stop|refresh` controls the cross-rig supervisor, and `sgt peek president` / the Web UI can inspect it separately from any `mayor/<rig>`.
+- `sgt mayor start|stop` without a rig acts on all rig Mayors in per-rig mode; `sgt wake-mayor` routes rig-targeted wake reasons to the matching Mayor, including President-originated reasons like `president:<rig>:...`, and otherwise broadcasts to all rig Mayors.
+- `sgt president start|stop|refresh` controls the cross-rig supervisor, and `sgt peek president` / the Web UI can inspect it separately from any `mayor/<rig>`. `sgt president refresh` now mirrors Mayor refresh ergonomics by archiving scoped President transient state into a handoff and printing the handoff markdown path.
 - `sgt mayor refresh [rig]` captures a timestamped handoff under the scoped mayor directory, archives transient Mayor context there, restarts the Mayor, and prints the handoff markdown path after re-waking it.
+- Scoped Mayor notify flows inherit the active rig scope for notify-agent routing and durable notify receipt state, so per-rig Mayor alerts stay under `~/.sgt/mayors/<rig>/`.
 - President performs bounded supervision only: if a rig-local Mayor is missing, stale, or an actionable rig has no healthy forward motion, President starts, wakes, or refreshes that one Mayor instead of taking over routine repo work directly.
 
 President/per-rig Mayor architecture contract:

--- a/SGT_CONTEXT.md
+++ b/SGT_CONTEXT.md
@@ -759,3 +759,65 @@ Please produce and execute a repo-local SGT plan for this feature:
 
 If needed, start with design/migration scaffolding first, but the plan should clearly converge on a working hierarchical control plane rather than stopping at docs-only architecture notes.
 ```
+- 2026-03-31T07:59:44+02:00 — 2026-03-31 issue #300 defines the President -> mayor/<rig> architecture contract in docs/president-per-rig-mayor-contract.md, clarifies README that SGT_MAYOR_ARCHITECTURE=per-rig is transition scaffolding rather than final state, and adds test_president_per_rig_mayor_contract_latest_main_proof.sh to pin the contract plus existing per-rig Mayor runtime slice.
+- 2026-03-31T08:07:45+02:00 — 2026-03-31 issue #302: Mayor runtime scope now treats refresh/handoff as a full scoped transient bundle (including heartbeat/observability/auto-refresh/watchdog/receipt directories under ~/.sgt[/mayors/<rig>]/), and mayor target -> tmux session/log resolution is centralized around shared vs mayor/<rig> naming.
+- 2026-03-31T08:10:42+02:00 — Acceptance blocker sgt-acceptance-1774937442-8524a714 reported by witness: Polecat blocked by backend usage limit for issue #304
+
+### Acceptance Blocker sgt-acceptance-1774937442-8524a714
+
+- Reported at: 2026-03-31T08:10:42+02:00
+- Reported by: witness
+- Title: Polecat blocked by backend usage limit for issue #304
+
+```markdown
+Polecat blocked by backend usage limit for issue #304
+
+A polecat hit a known backend/quota limit before opening a PR.
+
+- Rig: sgt
+- Repo: codejeet/sgt
+- Issue: #304
+- Issue URL: https://github.com/codejeet/sgt/issues/304
+- Issue title: Teach deacon and control commands to manage Mayor scope correctly
+- Polecat: sgt-0ed53c0b
+- Backend: codex
+- Reason code: codex_usage_limit
+- Matched first output: You've hit your usage limit
+
+Required follow-up:
+- leave this issue blocked until backend quota resets or an operator explicitly changes backend policy
+- do not auto-resling while the issue is marked backend-limited
+
+```
+- 2026-03-31T08:10:48+02:00 — Acceptance blocker sgt-acceptance-1774937448-02090b79 reported by witness: Polecat blocked by backend usage limit for issue #305
+
+### Acceptance Blocker sgt-acceptance-1774937448-02090b79
+
+- Reported at: 2026-03-31T08:10:48+02:00
+- Reported by: witness
+- Title: Polecat blocked by backend usage limit for issue #305
+
+```markdown
+Polecat blocked by backend usage limit for issue #305
+
+A polecat hit a known backend/quota limit before opening a PR.
+
+- Rig: sgt
+- Repo: codejeet/sgt
+- Issue: #305
+- Issue URL: https://github.com/codejeet/sgt/issues/305
+- Issue title: Add the President runtime and supervisory intervention model
+- Polecat: sgt-4d1a7d2e
+- Backend: codex
+- Reason code: codex_usage_limit
+- Matched first output: You've hit your usage limit
+
+Required follow-up:
+- leave this issue blocked until backend quota resets or an operator explicitly changes backend policy
+- do not auto-resling while the issue is marked backend-limited
+
+```
+- 2026-03-31T08:27:53+02:00 — Acceptance blocker sgt-acceptance-1774937442-8524a714 resolved. Note: Operator confirmed recovery after transient codex usage issue; direct codex probe now returns OK. Clear stale backend-limit block and allow recovery of issue #304.
+- 2026-03-31T08:27:55+02:00 — Acceptance blocker sgt-acceptance-1774937448-02090b79 resolved. Note: Operator confirmed recovery after transient codex usage issue; direct codex probe now returns OK. Clear stale backend-limit block and allow recovery of issue #305.
+- 2026-03-31T08:37:51+02:00 — 2026-03-31 issue #304: deacon, daemon, and scoped mayor tmux spawns must propagate SGT_MAYOR_ARCHITECTURE so per-rig mode survives background restarts and deacon supervises mayor/<rig> sessions instead of silently falling back to shared-Mayor assumptions.
+- 2026-03-31T08:42:09+02:00 — 2026-03-31 issue #305: per-rig mode now runs a first-class President supervisor in ~/.sgt/president with sgt-president; deacon supervises President, President performs bounded per-rig mayor start/wake/refresh interventions for missing, stale, or no-forward-motion rigs, and the latest-main proof path is ./test_president_runtime_latest_main_proof.sh.

--- a/sgt
+++ b/sgt
@@ -997,10 +997,20 @@ _mayor_refresh_handoffs_dir() {
   echo "$(_mayor_scope_dir)/handoffs"
 }
 
+_president_refresh_handoffs_dir() {
+  echo "$(_president_runtime_dir)/handoffs"
+}
+
 _mayor_refresh_token() {
   local now
   now="$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || date '+%Y%m%dT%H%M%S')"
   printf 'mayor-refresh-%s-%s\n' "$now" "$$"
+}
+
+_president_refresh_token() {
+  local now
+  now="$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || date '+%Y%m%dT%H%M%S')"
+  printf 'president-refresh-%s-%s\n' "$now" "$$"
 }
 
 _mayor_refresh_transient_entries() {
@@ -1031,6 +1041,15 @@ mayor-workspace
 EOF
 }
 
+_president_refresh_transient_entries() {
+  cat <<'EOF'
+president-exit.state
+president-heartbeat.json
+president-interventions.tsv
+president-start.log
+EOF
+}
+
 _mayor_refresh_archive_transients() {
   local handoff_dir="${1:-}"
   local scope_dir src name
@@ -1051,6 +1070,28 @@ _mayor_refresh_archive_transients() {
       fi
     fi
   done < <(_mayor_refresh_transient_entries)
+}
+
+_president_refresh_archive_transients() {
+  local handoff_dir="${1:-}"
+  local scope_dir src name
+  [[ -n "$handoff_dir" ]] || return 1
+
+  scope_dir="$(_president_runtime_dir)"
+  mkdir -p "$handoff_dir"
+
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    src="$scope_dir/$name"
+    if [[ -e "$src" ]]; then
+      mv "$src" "$handoff_dir/$name"
+      if [[ -d "$handoff_dir/$name" ]]; then
+        printf '%s/\n' "$name"
+      else
+        printf '%s\n' "$name"
+      fi
+    fi
+  done < <(_president_refresh_transient_entries)
 }
 
 _mayor_refresh_write_handoff() {
@@ -1132,6 +1173,70 @@ $(tail -20 "$decisions_log" 2>/dev/null)
 \`\`\`
 EOF
   fi
+}
+
+_president_refresh_write_handoff() {
+  local handoff_file="${1:-}" handoff_token="${2:-}" was_running="${3:-false}" status_snapshot="${4:-}"
+  local runtime_dir architecture generated_at event_log_path
+  local hb_age hb_ts hb_state hb_pid hb_phase hb_cycle hb_trigger
+  local exit_ts exit_reason exit_code exit_signal exit_unexpected
+
+  [[ -n "$handoff_file" ]] || return 1
+  runtime_dir="$(_president_runtime_dir)"
+  architecture="$(_mayor_architecture)"
+  generated_at="$(date -Iseconds)"
+  event_log_path="$SGT_LOG"
+
+  IFS='|' read -r hb_age hb_ts hb_state hb_pid hb_phase hb_cycle hb_trigger <<< "$(_president_heartbeat_snapshot)"
+  IFS='|' read -r exit_ts exit_reason exit_code exit_signal exit_unexpected <<< "$(_president_exit_state_read)"
+
+  cat > "$handoff_file" <<EOF
+# President Refresh Handoff
+
+- generated_at: $generated_at
+- handoff_token: $handoff_token
+- architecture: $architecture
+- runtime_dir: $runtime_dir
+- president_was_running: $was_running
+- event_log: $event_log_path
+
+## President Health Snapshot
+
+- heartbeat_age_seconds: ${hb_age:-unknown}
+- heartbeat_timestamp: ${hb_ts:-unknown}
+- heartbeat_state: ${hb_state:-unknown}
+- heartbeat_pid: ${hb_pid:-unknown}
+- heartbeat_phase: ${hb_phase:-unknown}
+- heartbeat_cycle: ${hb_cycle:-unknown}
+- heartbeat_trigger: ${hb_trigger:-unknown}
+
+## Last Exit Snapshot
+
+- exit_timestamp_epoch: ${exit_ts:-unknown}
+- exit_reason_code: ${exit_reason:-unknown}
+- exit_code: ${exit_code:-unknown}
+- exit_signal: ${exit_signal:-unknown}
+- exit_unexpected: ${exit_unexpected:-unknown}
+
+## Archived Transients
+EOF
+
+  if find "$(dirname "$handoff_file")" -mindepth 1 -maxdepth 2 ! -name 'handoff.md' | read -r _; then
+    (
+      cd "$(dirname "$handoff_file")"
+      find . -mindepth 1 -maxdepth 2 ! -name 'handoff.md' | sed 's#^\./#- #'
+    ) >> "$handoff_file"
+  else
+    echo "- none" >> "$handoff_file"
+  fi
+
+  cat >> "$handoff_file" <<EOF
+
+## Status Snapshot
+\`\`\`
+${status_snapshot:-status unavailable}
+\`\`\`
+EOF
 }
 
 _mayor_auto_refresh_resume() {
@@ -1694,6 +1799,8 @@ _mayor_wake_reason_rig() {
   elif [[ "$reason" =~ ^stalled-unreplaced:([^:]+): ]]; then
     printf '%s\n' "${BASH_REMATCH[1]}"
   elif [[ "$reason" =~ ^backend-limit:([^:]+): ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+  elif [[ "$reason" =~ ^president:([^:]+): ]]; then
     printf '%s\n' "${BASH_REMATCH[1]}"
   else
     printf '%s\n' ""
@@ -6901,6 +7008,9 @@ _mayor_notify_rigger() {
   local send_rc=0 delivered=0 context="mayor-notify-receipt-rigger"
 
   [[ -n "$message" ]] || return 1
+  if [[ -z "$notify_rig" && -n "${SGT_MAYOR_SCOPE_RIG:-}" ]]; then
+    notify_rig="$SGT_MAYOR_SCOPE_RIG"
+  fi
   _mayor_notify_result_set "" "" "" "" "" "" "" "0"
   if [[ "$message" == mayor\ warning:\ decision-log\ write\ failed* ]]; then
     suppress_decision_log=1
@@ -11246,9 +11356,30 @@ cmd_president_stop() {
 }
 
 cmd_president_refresh() {
+  local was_running="false" handoff_token handoff_dir handoff_file status_snapshot
+  ensure_init
+  _president_enabled || {
+    info "president is disabled in shared-mayor mode"
+    return 0
+  }
+
+  handoff_token="$(_president_refresh_token)"
+  handoff_dir="$(_president_refresh_handoffs_dir)/$handoff_token"
+  handoff_file="$handoff_dir/handoff.md"
+  mkdir -p "$handoff_dir"
+  status_snapshot="$(cmd_status 2>&1 || true)"
+
+  if tmux has-session -t "$(_president_session_name)" 2>/dev/null; then
+    was_running="true"
+  fi
+
   cmd_president_stop >/dev/null 2>&1 || true
-  cmd_president_start
-  _wake_president "manual-refresh" >/dev/null 2>&1 || true
+  _president_refresh_archive_transients "$handoff_dir" >/dev/null || true
+  _president_refresh_write_handoff "$handoff_file" "$handoff_token" "$was_running" "$status_snapshot"
+  log_event "PRESIDENT_REFRESH running_before=$was_running handoff=\"$(_escape_quotes "$handoff_file")\""
+  cmd_president_start >/dev/null
+  _wake_president "manual-refresh|handoff=$handoff_token" >/dev/null 2>&1 || true
+  echo "$handoff_file"
 }
 
 cmd_wake_president() {

--- a/test_mayor_notify_scope_compat.sh
+++ b/test_mayor_notify_scope_compat.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# test_mayor_notify_scope_compat.sh — Scoped mayor notify should inherit rig routing/state without explicit notify_rig.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+HOME_DIR="$TMP_ROOT/home"
+MOCK_BIN="$TMP_ROOT/mockbin"
+OPENCLAW_LOG="$TMP_ROOT/openclaw.log"
+mkdir -p "$HOME_DIR/.local/bin" "$MOCK_BIN"
+cp "$SGT_SCRIPT" "$HOME_DIR/.local/bin/sgt"
+chmod +x "$HOME_DIR/.local/bin/sgt"
+
+cat > "$MOCK_BIN/openclaw" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${OPENCLAW_LOG:?missing OPENCLAW_LOG}"
+printf '{"delivered":true,"deliveryStatus":"delivered"}\n'
+EOF
+chmod +x "$MOCK_BIN/openclaw"
+
+cat > "$MOCK_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+chmod +x "$MOCK_BIN/gh"
+
+env -i \
+  HOME="$HOME_DIR" \
+  PATH="$MOCK_BIN:$HOME_DIR/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+  TERM=dumb \
+  OPENCLAW_LOG="$OPENCLAW_LOG" \
+  SGT_ROOT="$HOME_DIR/sgt" \
+  SGT_MAYOR_ARCHITECTURE=per-rig \
+  SGT_MAYOR_SCOPE_RIG=alpha \
+  bash --noprofile --norc -c '
+    set -euo pipefail
+    sgt init >/dev/null
+    mkdir -p "$SGT_ROOT/.sgt/mayors/alpha" "$SGT_ROOT/.sgt/rig-config" "$SGT_ROOT/rigs/alpha"
+    printf "https://github.com/acme/alpha\n" > "$SGT_ROOT/.sgt/rigs/alpha"
+    cat > "$SGT_ROOT/.sgt/notify.json" <<JSON
+{"agent":"default-agent","channel":"last"}
+JSON
+    cat > "$SGT_ROOT/.sgt/rig-config/alpha.json" <<JSON
+{"notify_agent":"alpha-agent"}
+JSON
+    sgt mayor notify "scoped notify compatibility" >/dev/null
+  '
+
+grep -q -- '--agent alpha-agent' "$OPENCLAW_LOG" || {
+  echo "expected scoped notify to use alpha rig notify agent" >&2
+  cat "$OPENCLAW_LOG" >&2
+  exit 1
+}
+
+find "$HOME_DIR/sgt/.sgt/mayors/alpha/mayor-notify-receipts" -type f | grep -q . || {
+  echo "expected scoped notify receipt under alpha mayor scope" >&2
+  exit 1
+}
+
+if [[ -d "$HOME_DIR/sgt/.sgt/mayor-notify-receipts" ]] && find "$HOME_DIR/sgt/.sgt/mayor-notify-receipts" -type f | grep -q .; then
+  echo "expected scoped notify to avoid shared mayor receipt path" >&2
+  exit 1
+fi
+
+echo "ALL TESTS PASSED"

--- a/test_mayor_per_rig_architecture.sh
+++ b/test_mayor_per_rig_architecture.sh
@@ -131,4 +131,27 @@ if [[ -s "$BETA_OUT" ]]; then
   exit 1
 fi
 
+: > "$ALPHA_OUT"
+: > "$BETA_OUT"
+timeout 3 cat "$ALPHA_FIFO" > "$ALPHA_OUT" &
+alpha_reader=$!
+timeout 1 cat "$BETA_FIFO" > "$BETA_OUT" &
+beta_reader=$!
+
+"${ENV_PREFIX[@]}" bash --noprofile --norc -c 'set -euo pipefail; sgt wake-mayor "president:alpha:actionable-rig-recheck" >/dev/null'
+
+wait "$alpha_reader"
+wait "$beta_reader" || true
+
+grep -qx 'president:alpha:actionable-rig-recheck' "$ALPHA_OUT" || {
+  echo "expected alpha mayor fifo to receive president-targeted wake" >&2
+  exit 1
+}
+
+if [[ -s "$BETA_OUT" ]]; then
+  echo "expected beta mayor fifo to stay idle for president-targeted alpha wake" >&2
+  cat "$BETA_OUT" >&2
+  exit 1
+fi
+
 echo "ALL TESTS PASSED"

--- a/test_president_refresh.sh
+++ b/test_president_refresh.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# test_president_refresh.sh — President refresh should archive scoped transient state into a handoff and restart cleanly.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+HOME_DIR="$TMP_ROOT/home"
+MOCK_BIN="$TMP_ROOT/mockbin"
+SESSIONS_FILE="$TMP_ROOT/tmux-sessions"
+mkdir -p "$HOME_DIR/.local/bin" "$MOCK_BIN"
+cp "$SGT_SCRIPT" "$HOME_DIR/.local/bin/sgt"
+chmod +x "$HOME_DIR/.local/bin/sgt"
+printf 'sgt-president\n' > "$SESSIONS_FILE"
+
+cat > "$MOCK_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+sessions_file="${SGT_TEST_TMUX_SESSIONS_FILE:?missing SGT_TEST_TMUX_SESSIONS_FILE}"
+cmd="${1:-}"
+case "$cmd" in
+  has-session)
+    [[ "${2:-}" == "-t" ]] || exit 1
+    grep -qx "${3:-}" "$sessions_file" 2>/dev/null
+    ;;
+  kill-session)
+    [[ "${2:-}" == "-t" ]] || exit 1
+    tmp="${sessions_file}.tmp.$$"
+    grep -vx "${3:-}" "$sessions_file" > "$tmp" 2>/dev/null || true
+    mv "$tmp" "$sessions_file"
+    ;;
+  new-session)
+    session=""
+    while [[ $# -gt 0 ]]; do
+      case "${1:-}" in
+        -s)
+          session="${2:-}"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    [[ -n "$session" ]] || exit 1
+    printf '%s\n' "$session" >> "$sessions_file"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$MOCK_BIN/tmux"
+
+cat > "$MOCK_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+chmod +x "$MOCK_BIN/gh"
+
+env -i \
+  HOME="$HOME_DIR" \
+  PATH="$MOCK_BIN:$HOME_DIR/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+  TERM=dumb \
+  SGT_ROOT="$HOME_DIR/sgt" \
+  SGT_MAYOR_ARCHITECTURE=per-rig \
+  SGT_TEST_TMUX_SESSIONS_FILE="$SESSIONS_FILE" \
+  bash --noprofile --norc -c '
+    set -euo pipefail
+    sgt init >/dev/null
+    mkdir -p "$SGT_ROOT/.sgt/president"
+    printf "1|2026-03-31T00:00:00Z|123|cycle-complete|4|periodic\n" > "$SGT_ROOT/.sgt/president/president-heartbeat.json"
+    printf "1|clean-exit|0|EXIT|false\n" > "$SGT_ROOT/.sgt/president/president-exit.state"
+    printf "demo\t1\tactionable-no-forward-motion\trefresh\n" > "$SGT_ROOT/.sgt/president/president-interventions.tsv"
+    printf "president start log\n" > "$SGT_ROOT/.sgt/president/president-start.log"
+    sgt president refresh > "$SGT_ROOT/.sgt/president-refresh.out"
+  '
+
+HANDOFF_FILE="$(tail -n 1 "$HOME_DIR/sgt/.sgt/president-refresh.out")"
+[[ -f "$HANDOFF_FILE" ]] || {
+  echo "expected president refresh to print a handoff file path" >&2
+  exit 1
+}
+
+case "$HANDOFF_FILE" in
+  *"/.sgt/president/handoffs/"*) ;;
+  *)
+    echo "expected president handoff path under president scope" >&2
+    exit 1
+    ;;
+esac
+
+grep -q '^# President Refresh Handoff$' "$HANDOFF_FILE" || {
+  echo "expected president handoff title" >&2
+  exit 1
+}
+
+grep -q 'president_was_running: true' "$HANDOFF_FILE" || {
+  echo "expected handoff to record running president" >&2
+  exit 1
+}
+
+[[ -f "$(dirname "$HANDOFF_FILE")/president-heartbeat.json" ]] || {
+  echo "expected archived president heartbeat state" >&2
+  exit 1
+}
+
+[[ ! -f "$HOME_DIR/sgt/.sgt/president/president-heartbeat.json" ]] || {
+  echo "expected president heartbeat state to be moved into handoff" >&2
+  exit 1
+}
+
+grep -qx 'sgt-president' "$SESSIONS_FILE" || {
+  echo "expected president session to be restarted" >&2
+  exit 1
+}
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Closes #309\n\n## Summary\n- keep President-originated wake reasons rig-targeted instead of broadcasting across all mayors\n- make scoped mayor notify inherit rig-local routing and receipt storage\n- give president refresh the same handoff/archive ergonomics as mayor refresh\n\n## Testing\n- bash test_mayor_per_rig_architecture.sh\n- bash test_mayor_notify_scope_compat.sh\n- bash test_president_refresh.sh\n- bash test_president_runtime_supervision.sh\n- bash test_mayor_refresh.sh