### PR TITLE
Define President operator-notify event model and dedupe rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ Optional per-rig Mayor architecture:
 - `sgt mayor refresh [rig]` captures a timestamped handoff under the scoped mayor directory, archives transient Mayor context there, restarts the Mayor, and prints the handoff markdown path after re-waking it.
 - Entering per-rig mode safely retires any leftover shared `sgt-mayor` session and archives only shared Mayor transient files under `~/.sgt/president/cutovers/<token>/`, leaving durable blocker, plan-state, polecat, and scoped mayor truth in place.
 - President performs bounded supervision only: if a rig-local Mayor is missing, stale, or an actionable rig has no healthy forward motion, President starts, wakes, or refreshes that one Mayor instead of taking over routine repo work directly.
+- President also emits structured `PRESIDENT_OPERATOR_EVENT` records that normalize important cross-rig incidents into stable kinds (`drift`, `stalled-purpose`, `contradiction`, `intervention`, `escalation`, `human-question`) with both a President replay `dedupe_key` and a cross-layer `overlap_key`; low-signal rechecks stay log-only. See [`docs/president-operator-notify-contract.md`](docs/president-operator-notify-contract.md).
 
 President/per-rig Mayor architecture contract:
 - The runtime hierarchy in per-rig mode is `President -> mayor/<rig> -> rig-local workers`.
@@ -582,6 +583,7 @@ Latest-main proof for this hierarchy:
 
 That proof path verifies the documented contract, shared-to-per-rig cutover guardrails, status exposure for `president` plus `mayor/<rig>`, log/peek fallback for President and scoped Mayors, and President-side bounded intervention for a stuck rig-local Mayor.
 It also proves the Web UI keeps `president` and `mayor/<rig>` directly inspectable as separate control-plane nodes.
+It also covers the repo-owned President operator-notify model and dedupe contract.
 
 Mayor and boot both guard against stale deacon heartbeats:
 - Default stale threshold is `300` seconds (`5` minutes), configurable with:

--- a/SGT_CONTEXT.md
+++ b/SGT_CONTEXT.md
@@ -969,3 +969,145 @@ A good finished result should make the following true:
 - If this needs phasing, make the phases explicit and safe.
 ```
 - 2026-03-31T13:01:46+02:00 — 2026-03-31 incident: PMKB final acceptance closeout exposed a coupled SGT bug cluster in live President/per-rig mode. PR #1019 hit HTTP 5xx then GraphQL merge-in-progress; refinery marked it non-transient, then witness/refinery looped on orphan-PR + duplicate-merge-attempt-key for over an hour even though the PR stayed CLEAN/mergeable. After manual merge, GitHub truth became correct but PMKB repo-local acceptance stayed stale: PKL2-11 completed, yet SGT_PLAN.json and .sgt/plan-state/pmkb.json still showed acceptance planned / tasks-exhausted-awaiting-acceptance. Recovery attempts via sgt mayor refresh pmkb and explicit wake did not reconcile; refresh also appeared to act like shared/global refresh in per-rig mode and President kept restarting mayors because pmkb/sgt mayors exited cleanly immediately. See workspace incident note `notes/sgt-incident-pmkb-acceptance-reconciliation-2026-03-31.md` for full timeline and fix guidance.
+- 2026-03-31T13:09:15+02:00 — Plan tick and worker completion-context now prefer the default-branch SGT_PLAN.json snapshot when a rig checkout is on a dirty or non-default branch, so merged acceptance updates reconcile plan-state from authoritative repo truth without clobbering the local worktree.
+- 2026-03-31T22:05:49+02:00 — Plan request sgt-1774987549-42306fbf submitted by OpenClaw agent gastown. Full spec appended below.
+
+### Plan Request sgt-1774987549-42306fbf
+
+- Requested at: 2026-03-31T22:05:49+02:00
+- Requesting OpenClaw agent: gastown
+
+```markdown
+# SGT follow-on plan request: President notifications + WebUI operator usability pass
+
+## Request
+
+Create a follow-on SGT implementation plan on rig `sgt` for the newly deployed **President + per-rig Mayor** system.
+
+This request has five linked goals:
+
+1. **President notifications for important things to check / operator escalations**
+2. **President log visibility in the Web UI**
+3. **Pane/layout improvements in the tmux cockpit UI**
+4. **Notification panel cleanup so it only shows recent/actionable items**
+5. **Text input at the bottom of each pane for fast nudging**
+
+Requester: operator via Gastown
+Date: 2026-03-31
+Rig: `sgt`
+
+## Why this exists
+
+The President/per-rig Mayor runtime is now live, but the operator surfaces still lag behind the new topology and the real operator workflow.
+
+We need the UI and notify layer to match the architecture that now exists in production:
+- President should be able to raise meaningful operator attention for drift / stuck-purpose situations / escalations
+- The Web UI should expose President activity directly instead of burying it in log archaeology
+- The cockpit layout should be easier to read, steer, and operate during live work
+- The notification area should show **what matters now**, not stale long-title clutter
+
+## Work requested
+
+### 1) President notifications for important, actionable events
+
+Wire President into operator-facing notifications for important things worth checking, such as:
+
+- a rig has drifted from its intended purpose
+- a rig is technically active but not actually making forward progress on its real goal
+- a rig's local behavior contradicts the larger program intent / acceptance path
+- President had to intervene because a rig-local Mayor was stale / wedged / misleadingly idle
+- President wants operator attention / escalation
+- President questions that need human input
+
+Guidance:
+- Prefer **important, actionable** notifications rather than noisy chatter
+- Focus on "check this" / "this rig is drifting" / "this needs operator judgment" events
+- Preserve existing preference that voice/attention emphasis should lean toward **resolved blockers / major milestones / meaningful escalations**, not every tiny event
+- If President and Mayor notifications overlap, dedupe or present them coherently rather than spamming both layers independently
+
+### 2) President log / status visibility in the Web UI
+
+Expose President in the Web UI as a first-class operator surface, including things like:
+
+- President cycle status
+- recent President interventions
+- President reasoning/action log or event feed
+- which rig was touched, why, and what President did
+- whether an intervention was wake / refresh / restart / no-op / suppressed-by-cooldown
+
+The operator should not need to grep server logs to understand what President is doing.
+
+### 3) Pane/layout improvements for the tmux cockpit
+
+Requested UI behavior:
+
+- tmux windows should display as **vertical rectangles** in an automatic grid layout
+- focused panes should **move the real pane into the focused spot**, not duplicate the pane in a second location/view
+- pane view should use a **cool blue, slightly transparent-looking font on a black background**
+
+Design constraints / prior operator guidance worth preserving:
+- livestream first / operator-centric cockpit feel
+- less gradient-heavy / less AI-looking CSS
+- mostly square corners or very slight rounding only
+- darker high-contrast theme that still keeps the blue
+
+### 4) Notification panel cleanup
+
+Current problem:
+- notifications overflow with stale old data
+- long titles make the section hard to use
+
+Requested behavior:
+- show only recent and/or actionable items by default
+- prioritize items like:
+  - President questions
+  - current escalations
+  - unresolved meaningful blockers
+  - things the operator should actually act on now
+- reduce useless long-title clutter
+- prefer summaries that are compact, legible, and operationally useful
+
+### 5) Text input at the bottom of each pane for easy nudging
+
+Add a text input / quick command affordance at the bottom of each rectangle pane so the operator can easily nudge the corresponding session/agent.
+
+Goal:
+- make steering from the cockpit much faster
+- reduce friction for nudging a specific pane/session
+- keep the interaction scoped to the pane the operator is looking at
+
+This should work cleanly for the relevant pane/session types exposed by the cockpit.
+
+## Acceptance expectations
+
+Please decompose this into a real repo-local plan rather than a single vague issue.
+
+A good plan should likely cover at least:
+
+1. President notify architecture / event model / dedupe rules
+2. President activity/log exposure in status + Web UI
+3. pane layout / focus behavior changes
+4. notification panel recency/actionability filtering
+5. per-pane input/nudge interaction
+6. docs / proof / latest-main verification
+
+## Concrete acceptance criteria
+
+A good finished result should make the following true:
+
+- President can generate meaningful operator-facing notifications for important drift/escalation situations
+- President activity is visible in the Web UI without log-grep archaeology
+- cockpit panes render as auto-laid-out vertical rectangles
+- focus behavior moves the pane to the focus slot instead of duplicating views
+- pane styling reflects the requested cool-blue-on-black operator look
+- notification panel defaults to recent/actionable information instead of stale overflow
+- President questions / actionable escalations are clearly surfaced
+- each pane has an easy text-input affordance for nudging that pane's session/agent
+- docs/proof demonstrate the new behavior on latest main
+
+## Notes
+
+- This is a follow-on usability / operator-surface layer on top of the newly deployed President system.
+- Keep the implementation grounded in real operator value, not decorative UI churn.
+- If this needs phasing, make the phases explicit and safe.
+```

--- a/docs/president-operator-notify-contract.md
+++ b/docs/president-operator-notify-contract.md
@@ -1,0 +1,111 @@
+# President Operator-Notify Event Contract
+
+Issue: `#320`
+
+This document defines the operator-facing event model for the President runtime and the dedupe rules that keep President and Mayor from paging the operator twice for the same incident.
+
+It does not require President to narrate every cycle. The contract is intentionally biased toward important, actionable events.
+
+## Goal
+
+President notifications exist to answer one question:
+
+"Does the operator need to check, judge, or unblock something at the cross-rig supervision layer?"
+
+If the answer is no, President should log the event for observability without emitting a top-level operator notification.
+
+## Event Shape
+
+Every President operator event uses these fields:
+
+- `rig`: the affected rig
+- `kind`: the normalized event family
+- `severity`: `info`, `warning`, or `critical`
+- `notify`: `1` when this is operator-facing, `0` when it is log-only
+- `dedupe_key`: President-local replay key
+- `overlap_key`: cross-layer incident key for President/Mayor/UI coalescing
+- `action`: what President did or attempted (`start`, `wake`, `refresh`, later `restart` if added)
+- `reason`: the raw runtime reason
+- `outcome`: current result such as `intervened` or `suppressed-by-cooldown`
+- `cycle_trigger`: why the President cycle ran
+- `detail`: operator-readable evidence
+
+The runtime emits this as `PRESIDENT_OPERATOR_EVENT ...`.
+
+## Event Kinds
+
+President normalizes raw reasons into these operator-facing kinds:
+
+- `drift`: a rig is moving, but not toward the intended repo plan or larger purpose
+- `stalled-purpose`: a rig is technically active or actionable, but meaningful forward motion is absent
+- `contradiction`: observed rig behavior conflicts with the accepted repo truth, completion path, or higher-level program intent
+- `intervention`: President had to start, wake, refresh, or later restart a rig-local Mayor because the Mayor itself was unhealthy or missing
+- `escalation`: President is explicitly raising a high-urgency operator attention event
+- `human-question`: President needs operator judgment or missing human input
+
+The kind model is intentionally stable even if the underlying raw `reason` strings grow over time.
+
+## Current Runtime Mapping
+
+Current President supervision reasons map as follows:
+
+- `mayor-session-missing` -> `intervention`, `severity=warning`, `notify=1`
+- `mayor-heartbeat-invalid` or `mayor-heartbeat-stale` -> `intervention`, `severity=warning`, `notify=1`
+- `actionable-no-forward-motion` -> `stalled-purpose`, `severity=warning`, `notify=1`
+- `actionable-rig-recheck` -> `intervention`, `severity=info`, `notify=0`
+
+That last case is important: a quiet recheck wake is part of healthy bounded supervision, not operator-worthy noise by default.
+
+## Notify Rules
+
+President should notify only when at least one of these is true:
+
+- the rig appears to be drifting from intended purpose
+- actionable work exists but the rig lacks healthy forward motion
+- the rig-local behavior contradicts the accepted plan or program intent
+- the President had to intervene because the rig-local Mayor was missing, stale, wedged, or otherwise unhealthy
+- President is escalating a problem that should not stay implicit
+- President needs human judgment or missing human input
+
+President should stay log-only when the event is merely a low-signal recheck, periodic observation, or a duplicate replay of an already surfaced incident.
+
+## Dedupe Rules
+
+There are two dedupe layers.
+
+### 1. President-local replay dedupe
+
+President-local dedupe uses `dedupe_key`.
+
+- Format: `president:<rig>:<kind>:<reason>:<action>`
+- Purpose: suppress repeated President re-alerting for the same rig, normalized event kind, raw reason, and intervention action
+- Current runtime fence: the President intervention cooldown (`SGT_PRESIDENT_INTERVENTION_COOLDOWN_SECS`) already suppresses exact replay of the same `rig + reason + action`
+- When cooldown suppresses a replay, President should emit `PRESIDENT_OPERATOR_EVENT ... outcome=suppressed-by-cooldown` instead of a second operator page
+
+### 2. Cross-layer overlap dedupe
+
+Cross-layer dedupe uses `overlap_key`.
+
+- Purpose: let President, Mayor, the Web UI, and notification surfaces coalesce one underlying incident instead of paging separately from both layers
+- Rule: if President and Mayor are surfacing the same operational incident, only one visible operator notification should survive; the other should remain visible as linked evidence, not a second page
+- Current overlap key families:
+  - `rig-incident:<rig>:actionable-no-forward-motion` for no-progress situations
+  - `mayor-health:<rig>:<reason>` for Mayor-missing or Mayor-heartbeat incidents
+  - `president-incident:<rig>:<kind>:<reason>` for President-specific drift, contradiction, escalation, or human-question situations
+
+The first surfaced notification owns operator attention. Later overlapping events should be shown as corroborating context or merged history, not another independent alert.
+
+## Operator Surface Expectations
+
+Operator surfaces should preserve both truth and quietness:
+
+- show the latest `PRESIDENT_OPERATOR_EVENT` records directly
+- expose `kind`, `reason`, `action`, `outcome`, `notify`, `dedupe_key`, and `overlap_key`
+- make `suppressed-by-cooldown` visible in logs/history so silence is explainable
+- prefer recent, unresolved, and operator-actionable President events over old chatter
+
+## Scope Boundary
+
+This contract does not authorize President to take over routine rig-local Mayor work.
+
+It only defines how President-class incidents are named, logged, and deduped when President observes or performs bounded supervision.

--- a/docs/president-per-rig-mayor-contract.md
+++ b/docs/president-per-rig-mayor-contract.md
@@ -48,6 +48,7 @@ The President must:
 - perform bounded interventions such as wake, refresh, restart, or escalation for one affected Mayor when justified
 - coordinate system-level or cross-rig policy decisions that do not belong inside one rig
 - emit operator-visible evidence for why it intervened, deferred, or declared a rig healthy
+- follow the repo-owned operator event and dedupe contract in [`docs/president-operator-notify-contract.md`](docs/president-operator-notify-contract.md) when surfacing President-class incidents
 
 The President must not:
 
@@ -146,6 +147,7 @@ Current proof for the transition:
 - `./test_peek_mayor_log_fallback.sh` proves `sgt peek president` and `sgt peek mayor/<rig>` both retain scoped log fallback behavior
 - `./test_web_cockpit_control_plane_hierarchy.sh` proves the Web UI topology keeps `president` and `mayor/<rig>` separately inspectable
 - `./test_president_per_rig_mayor_contract.sh` proves the architecture contract remains documented in-repo
+- `./test_president_operator_notify_contract.sh` proves the President operator-notify event model and dedupe rules remain documented in-repo
 - `./test_president_runtime_latest_main_proof.sh` bundles the runtime, surface, and contract checks as the latest-main proof for the active hierarchy
 
 The latest-main proof for the active runtime now proves:

--- a/sgt
+++ b/sgt
@@ -11324,6 +11324,111 @@ _president_intervention_allowed() {
   return 0
 }
 
+_president_operator_event_kind() {
+  local reason="${1:-}" action="${2:-}"
+  case "$reason" in
+    drift*|*drift*)
+      echo "drift"
+      ;;
+    actionable-no-forward-motion|stalled-purpose*|*stalled-purpose*)
+      echo "stalled-purpose"
+      ;;
+    contradiction*|*contradict*)
+      echo "contradiction"
+      ;;
+    escalation*|*escalat*)
+      echo "escalation"
+      ;;
+    human-question*|needs-human-input*|need-human-input*|question-for-human*)
+      echo "human-question"
+      ;;
+    mayor-session-missing|mayor-heartbeat-*|actionable-rig-recheck)
+      echo "intervention"
+      ;;
+    *)
+      if [[ "$action" == "start" || "$action" == "refresh" || "$action" == "wake" ]]; then
+        echo "intervention"
+      else
+        echo "unknown"
+      fi
+      ;;
+  esac
+}
+
+_president_operator_event_severity() {
+  local kind="${1:-}" reason="${2:-}"
+  case "$kind" in
+    escalation)
+      echo "critical"
+      ;;
+    contradiction|drift|stalled-purpose|human-question)
+      echo "warning"
+      ;;
+    intervention)
+      if [[ "$reason" == "actionable-rig-recheck" ]]; then
+        echo "info"
+      else
+        echo "warning"
+      fi
+      ;;
+    *)
+      echo "info"
+      ;;
+  esac
+}
+
+_president_operator_notify_enabled() {
+  local kind="${1:-}" reason="${2:-}"
+  case "$kind" in
+    drift|stalled-purpose|contradiction|escalation|human-question)
+      return 0
+      ;;
+    intervention)
+      [[ "$reason" != "actionable-rig-recheck" ]]
+      return $?
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+_president_operator_dedupe_key() {
+  local rig="${1:-}" kind="${2:-unknown}" reason="${3:-unknown}" action="${4:-unknown}"
+  printf 'president:%s:%s:%s:%s\n' "${rig:-unknown}" "${kind:-unknown}" "${reason:-unknown}" "${action:-unknown}"
+}
+
+_president_operator_overlap_key() {
+  local rig="${1:-}" kind="${2:-unknown}" reason="${3:-unknown}"
+  case "$reason" in
+    actionable-no-forward-motion|actionable-rig-recheck)
+      printf 'rig-incident:%s:actionable-no-forward-motion\n' "${rig:-unknown}"
+      ;;
+    mayor-session-missing|mayor-heartbeat-*)
+      printf 'mayor-health:%s:%s\n' "${rig:-unknown}" "${reason:-unknown}"
+      ;;
+    *)
+      printf 'president-incident:%s:%s:%s\n' "${rig:-unknown}" "${kind:-unknown}" "${reason:-unknown}"
+      ;;
+  esac
+}
+
+_president_operator_log_event() {
+  local rig="${1:-}" action="${2:-}" reason="${3:-}" outcome="${4:-}" detail="${5:-}" cycle_reason="${6:-periodic}"
+  local kind severity notify dedupe_key overlap_key notify_flag
+
+  kind="$(_president_operator_event_kind "$reason" "$action")"
+  severity="$(_president_operator_event_severity "$kind" "$reason")"
+  notify_flag=0
+  if _president_operator_notify_enabled "$kind" "$reason"; then
+    notify_flag=1
+  fi
+  dedupe_key="$(_president_operator_dedupe_key "$rig" "$kind" "$reason" "$action")"
+  overlap_key="$(_president_operator_overlap_key "$rig" "$kind" "$reason")"
+
+  log_event "PRESIDENT_OPERATOR_EVENT rig=$rig kind=$kind severity=$severity notify=$notify_flag dedupe_key=$dedupe_key overlap_key=$overlap_key action=$action reason=$reason outcome=$outcome cycle_trigger=\"$(_escape_quotes "$cycle_reason")\" detail=\"$(_escape_quotes "$detail")\""
+}
+
 _president_supervise_rig_mayor() {
   local rig="${1:-}" cycle_reason="${2:-periodic}"
   local mayor_session mayor_hb_age mayor_hb_ts mayor_hb_state mayor_hb_pid mayor_hb_phase mayor_hb_cycle mayor_hb_trigger mayor_hb_stale mayor_hb_health
@@ -11382,6 +11487,7 @@ _president_supervise_rig_mayor() {
   fi
 
   if ! _president_intervention_allowed "$rig" "$reason" "$action"; then
+    _president_operator_log_event "$rig" "$action" "$reason" "suppressed-by-cooldown" "$detail" "$cycle_reason"
     _mayor_scope_apply ""
     return 1
   fi
@@ -11402,6 +11508,7 @@ _president_supervise_rig_mayor() {
       ;;
   esac
   _president_intervention_state_write "$rig" "$reason" "$action"
+  _president_operator_log_event "$rig" "$action" "$reason" "intervened" "$detail" "$cycle_reason"
   log_event "PRESIDENT_INTERVENTION rig=$rig action=$action reason=$reason detail=\"$(_escape_quotes "$detail")\" cycle_trigger=\"$(_escape_quotes "$cycle_reason")\""
   echo "[president] intervened on mayor/$rig — action=$action reason=$reason detail=$detail"
   _mayor_scope_apply ""

--- a/test_president_operator_notify_contract.sh
+++ b/test_president_operator_notify_contract.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# test_president_operator_notify_contract.sh — Verify the President operator-notify model and dedupe rules stay documented in-repo.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+DOC="$REPO_ROOT/docs/president-operator-notify-contract.md"
+ARCH_DOC="$REPO_ROOT/docs/president-per-rig-mayor-contract.md"
+README="$REPO_ROOT/README.md"
+
+[[ -f "$DOC" ]] || {
+  echo "missing President operator-notify contract doc: $DOC" >&2
+  exit 1
+}
+
+grep -q '^Issue: `#320`$' "$DOC"
+grep -q '^## Event Shape$' "$DOC"
+grep -q 'PRESIDENT_OPERATOR_EVENT' "$DOC"
+grep -q '`dedupe_key`' "$DOC"
+grep -q '`overlap_key`' "$DOC"
+grep -q '^## Event Kinds$' "$DOC"
+grep -q '`drift`' "$DOC"
+grep -q '`stalled-purpose`' "$DOC"
+grep -q '`contradiction`' "$DOC"
+grep -q '`intervention`' "$DOC"
+grep -q '`escalation`' "$DOC"
+grep -q '`human-question`' "$DOC"
+grep -q '^## Current Runtime Mapping$' "$DOC"
+grep -q '`actionable-no-forward-motion` -> `stalled-purpose`' "$DOC"
+grep -q '`actionable-rig-recheck` -> `intervention`, `severity=info`, `notify=0`' "$DOC"
+grep -q '^## Dedupe Rules$' "$DOC"
+grep -q 'President-local dedupe uses `dedupe_key`' "$DOC"
+grep -q 'Cross-layer dedupe uses `overlap_key`' "$DOC"
+grep -q 'only one visible operator notification should survive' "$DOC"
+grep -q 'outcome=suppressed-by-cooldown' "$DOC"
+
+grep -q 'docs/president-operator-notify-contract.md' "$ARCH_DOC"
+grep -q './test_president_operator_notify_contract.sh' "$ARCH_DOC"
+grep -q 'docs/president-operator-notify-contract.md' "$README"
+grep -q 'PRESIDENT_OPERATOR_EVENT' "$README"
+
+echo "ALL TESTS PASSED"

--- a/test_president_runtime_latest_main_proof.sh
+++ b/test_president_runtime_latest_main_proof.sh
@@ -11,5 +11,6 @@ bash "$REPO_ROOT/test_president_runtime_supervision.sh"
 bash "$REPO_ROOT/test_peek_mayor_log_fallback.sh"
 bash "$REPO_ROOT/test_web_cockpit_control_plane_hierarchy.sh"
 bash "$REPO_ROOT/test_president_per_rig_mayor_contract.sh"
+bash "$REPO_ROOT/test_president_operator_notify_contract.sh"
 
 echo "ALL TESTS PASSED"

--- a/test_president_runtime_supervision.sh
+++ b/test_president_runtime_supervision.sh
@@ -32,6 +32,12 @@ eval "$(extract_fn _president_intervention_state_file)"
 eval "$(extract_fn _president_intervention_state_read)"
 eval "$(extract_fn _president_intervention_state_write)"
 eval "$(extract_fn _president_intervention_allowed)"
+eval "$(extract_fn _president_operator_event_kind)"
+eval "$(extract_fn _president_operator_event_severity)"
+eval "$(extract_fn _president_operator_notify_enabled)"
+eval "$(extract_fn _president_operator_dedupe_key)"
+eval "$(extract_fn _president_operator_overlap_key)"
+eval "$(extract_fn _president_operator_log_event)"
 eval "$(extract_fn _deacon_supervise_president)"
 eval "$(extract_fn _president_supervise_rig_mayor)"
 
@@ -155,8 +161,37 @@ if ! grep -q 'PRESIDENT_INTERVENTION rig=demo action=refresh reason=actionable-n
   echo "expected durable president intervention event for stuck rig" >&2
   exit 1
 fi
+if ! grep -q 'PRESIDENT_OPERATOR_EVENT rig=demo kind=stalled-purpose severity=warning notify=1 dedupe_key=president:demo:stalled-purpose:actionable-no-forward-motion:refresh overlap_key=rig-incident:demo:actionable-no-forward-motion action=refresh reason=actionable-no-forward-motion outcome=intervened' "$EVENT_LOG"; then
+  echo "expected structured President operator event for stalled-purpose intervention" >&2
+  exit 1
+fi
 if [[ -s "$WAKE_LOG" ]]; then
   echo "expected refresh intervention instead of plain wake for stale rig" >&2
+  exit 1
+fi
+
+_mayor_rig_activity_state_read() {
+  local now recent wake_recent
+  now="$(date +%s)"
+  recent=$((now - 60))
+  wake_recent=$((now - 30))
+  printf 'active|open_issues=1|2026-03-31T00:00:00Z|1774915200|none|recent|%s|recent-progress|wake-recent|%s|manual\n' "$recent" "$wake_recent"
+}
+
+_president_supervise_rig_mayor demo manual > "$TMP_ROOT/president-wake.out"
+
+grep -qx 'president:demo:actionable-rig-recheck' "$WAKE_LOG" || {
+  echo "expected President to use a quiet wake for recent actionable rig activity" >&2
+  exit 1
+}
+if ! grep -q 'PRESIDENT_OPERATOR_EVENT rig=demo kind=intervention severity=info notify=0 dedupe_key=president:demo:intervention:actionable-rig-recheck:wake overlap_key=rig-incident:demo:actionable-no-forward-motion action=wake reason=actionable-rig-recheck outcome=intervened' "$EVENT_LOG"; then
+  echo "expected quiet President operator event for actionable rig recheck" >&2
+  exit 1
+fi
+
+_president_supervise_rig_mayor demo manual >/dev/null || true
+if ! grep -q 'PRESIDENT_OPERATOR_EVENT rig=demo kind=intervention severity=info notify=0 dedupe_key=president:demo:intervention:actionable-rig-recheck:wake overlap_key=rig-incident:demo:actionable-no-forward-motion action=wake reason=actionable-rig-recheck outcome=suppressed-by-cooldown' "$EVENT_LOG"; then
+  echo "expected President operator event to record cooldown suppression instead of replaying the same wake" >&2
   exit 1
 fi
 BASH


### PR DESCRIPTION
Closes #320

## Summary
- add a repo-owned President operator-notify contract with event kinds, notify rules, and dedupe semantics
- emit structured `PRESIDENT_OPERATOR_EVENT` records from the President runtime for interventions and cooldown-suppressed replays
- extend the President latest-main proof bundle with runtime and contract coverage

## Testing
- bash ./test_president_runtime_supervision.sh
- bash ./test_president_operator_notify_contract.sh
- bash ./test_president_runtime_latest_main_proof.sh