### PR TITLE
Add per-pane bottom input or nudge affordances

### DIFF
--- a/sgt
+++ b/sgt
@@ -9473,8 +9473,13 @@ cmd_nudge() {
   local session=""
   case "$target" in
     deacon)        session="sgt-deacon" ;;
+    president)     session="sgt-president" ;;
+    mayor)         session="sgt-mayor" ;;
+    mayor/*)       session="sgt-mayor-${target#mayor/}" ;;
     witness/*)     session="sgt-witness-${target#witness/}" ;;
     refinery/*)    session="sgt-refinery-${target#refinery/}" ;;
+    crew/*)        session="sgt-crew-${target#crew/}" ;;
+    dog/*)         session="sgt-${target#dog/}" ;;
     *)             session="sgt-${target}" ;;
   esac
 

--- a/test_nudge_target_resolution.sh
+++ b/test_nudge_target_resolution.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# test_nudge_target_resolution.sh — Verify nudge resolves cockpit-exposed targets to the correct tmux sessions.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+make_mock_bin() {
+  local mock_bin="$1"
+  mkdir -p "$mock_bin"
+
+  cat > "$mock_bin/tmux" <<'TMUX'
+#!/usr/bin/env bash
+set -euo pipefail
+log_file="${TMUX_LOG:?}"
+cmd="${1:-}"
+printf '%s\n' "$*" >> "$log_file"
+  case "$cmd" in
+  has-session)
+    [[ "${2:-}" == "-t" ]] || exit 1
+    case "${3:-}" in
+      sgt-mayor-alpha|sgt-one|sgt-crew-ops) exit 0 ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  send-keys)
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+TMUX
+  chmod +x "$mock_bin/tmux"
+
+  cat > "$mock_bin/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+GH
+  chmod +x "$mock_bin/gh"
+}
+
+run_env() {
+  local home_dir="$1"
+  shift
+  env -i \
+    HOME="$home_dir" \
+    PATH="$home_dir/.local/bin:$TMP_ROOT/mockbin:/usr/local/bin:/usr/bin:/bin" \
+    TERM=dumb \
+    SGT_ROOT="$home_dir/sgt" \
+    TMUX_LOG="$TMP_ROOT/tmux.log" \
+    "$@"
+}
+
+mkdir -p "$TMP_ROOT/mockbin"
+make_mock_bin "$TMP_ROOT/mockbin"
+
+HOME_DIR="$TMP_ROOT/home"
+mkdir -p "$HOME_DIR/.local/bin"
+cp "$SGT_SCRIPT" "$HOME_DIR/.local/bin/sgt"
+chmod +x "$HOME_DIR/.local/bin/sgt"
+: > "$TMP_ROOT/tmux.log"
+
+run_env "$HOME_DIR" bash --noprofile --norc -c '
+set -euo pipefail
+sgt init >/dev/null
+sgt nudge mayor/alpha "mayor ping" >/dev/null
+sgt nudge dog/one "dog ping" >/dev/null
+sgt nudge crew/ops "crew ping" >/dev/null
+'
+
+grep -q '^has-session -t sgt-mayor-alpha$' "$TMP_ROOT/tmux.log" || {
+  echo "expected mayor/alpha nudge to check sgt-mayor-alpha" >&2
+  cat "$TMP_ROOT/tmux.log" >&2
+  exit 1
+}
+
+grep -q '^send-keys -t sgt-mayor-alpha -l mayor ping$' "$TMP_ROOT/tmux.log" || {
+  echo "expected mayor/alpha nudge to send keys to sgt-mayor-alpha" >&2
+  cat "$TMP_ROOT/tmux.log" >&2
+  exit 1
+}
+
+grep -q '^has-session -t sgt-one$' "$TMP_ROOT/tmux.log" || {
+  echo "expected dog/one nudge to check sgt-one" >&2
+  cat "$TMP_ROOT/tmux.log" >&2
+  exit 1
+}
+
+grep -q '^send-keys -t sgt-one -l dog ping$' "$TMP_ROOT/tmux.log" || {
+  echo "expected dog/one nudge to send keys to sgt-one" >&2
+  cat "$TMP_ROOT/tmux.log" >&2
+  exit 1
+}
+
+grep -q '^has-session -t sgt-crew-ops$' "$TMP_ROOT/tmux.log" || {
+  echo "expected crew/ops nudge to check sgt-crew-ops" >&2
+  cat "$TMP_ROOT/tmux.log" >&2
+  exit 1
+}
+
+grep -q '^send-keys -t sgt-crew-ops -l crew ping$' "$TMP_ROOT/tmux.log" || {
+  echo "expected crew/ops nudge to send keys to sgt-crew-ops" >&2
+  cat "$TMP_ROOT/tmux.log" >&2
+  exit 1
+}
+
+echo "ALL TESTS PASSED"

--- a/web/README.md
+++ b/web/README.md
@@ -179,6 +179,7 @@ The goal is higher reliability, a simpler mental model, and easier ops.
 | GET | `/api/peek/:target` | Peek at tmux pane output |
 | GET | `/api/logs?lines=N` | Tail sgt.log |
 | GET | `/api/plan-state/:rig` | Repo plan-state JSON for one rig |
+| POST | `/api/nudge` | Send a pane-scoped nudge `{target, message}` |
 | POST | `/api/sling` | Dispatch a polecat `{rig, task, labels?, convoy?}` |
 | POST | `/api/sling-dog` | Dispatch a dog `{rig, issue}` |
 | WS | `/` | Real-time status/log stream plus snapshot + tmux stream events |
@@ -196,7 +197,7 @@ The stream section defaults to a polecat-focused monitor wall:
 - rig and role filters narrow the active live panes without leaving the page
 - `Match` filters by worker name, rig, issue, or branch text
 - `Tail All` toggles auto-follow across every subscribed pane
-- each pane still supports `Tail`, `Focus`, and `Peek`
+- each pane still supports `Tail`, `Focus`, `Peek`, and a bottom-anchored `Nudge` input scoped to that pane target
 
 Server-to-client additions:
 

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -19,6 +19,8 @@ const appState = {
   alertIdsSeen: new Set(),
   alertsBootstrapped: false,
   activeAnnouncement: null,
+  nudgeDrafts: new Map(),
+  nudgePending: new Set(),
   topology: {
     mode: "pending",
     renderer: null,
@@ -625,28 +627,30 @@ function presidentOutcomeLabel(event) {
 }
 
 function renderStreamDeck() {
+  const nudgeFocus = activeNudgeInputState();
   renderStreamFilters();
   const orderedTargets = Array.from(appState.desiredTargets);
   refs.streamSummary.textContent = `${orderedTargets.length} subscriptions`;
-  refs.overviewHero.innerHTML = renderHeroStream(rootStreamTarget());
-  refs.focusStream.innerHTML = renderHeroStream(appState.focusTarget || rootStreamTarget());
-  refs.mayorMonitor.innerHTML = renderMonitorStream(rootStreamTarget(), { focusable: false });
+  refs.overviewHero.innerHTML = renderHeroStream(rootStreamTarget(), "overview");
+  refs.focusStream.innerHTML = renderHeroStream(appState.focusTarget || rootStreamTarget(), "focus");
+  refs.mayorMonitor.innerHTML = renderMonitorStream(rootStreamTarget(), { focusable: false, paneKey: "leadership" });
 
   const focusTarget = appState.focusTarget || rootStreamTarget();
   const visibleWorkers = monitorWorkers().filter(matchesStreamFilters);
   const wallWorkers = visibleWorkers.filter((worker) => worker.stream && worker.stream.target !== focusTarget);
   refs.monitorWallSummary.textContent = `${wallWorkers.length} panes visible`;
   refs.monitorWall.innerHTML = wallWorkers.length > 0
-    ? wallWorkers.map((worker) => renderMonitorStream(worker.stream.target, { focusable: true })).join("")
+    ? wallWorkers.map((worker) => renderMonitorStream(worker.stream.target, { focusable: true, paneKey: `wall:${worker.stream.target}` })).join("")
     : `<div class="empty-state">No worker streams match the current monitor filters.</div>`;
 
   bindStreamActions(refs.focusStream);
   bindStreamActions(refs.overviewHero);
   bindStreamActions(refs.mayorMonitor);
   bindStreamActions(refs.monitorWall);
+  restoreNudgeInputState(nudgeFocus);
 }
 
-function renderHeroStream(target) {
+function renderHeroStream(target, paneKey) {
   const stream = streamFor(target);
   const details = streamDetail(target);
   return `
@@ -664,6 +668,7 @@ function renderHeroStream(target) {
         </div>
       </div>
       <div class="stream-body" data-stream-target="${escAttr(target)}">${esc(stream.content || "Waiting for tmux stream data...")}</div>
+      ${renderStreamNudge(target, paneKey)}
     </article>
   `;
 }
@@ -688,6 +693,7 @@ function renderMonitorStream(target, options = {}) {
         </div>
       </div>
       <div class="stream-body" data-stream-target="${escAttr(target)}">${esc(stream.content || "Waiting for tmux stream data...")}</div>
+      ${renderStreamNudge(target, options.paneKey || target)}
     </article>
   `;
 }
@@ -710,6 +716,14 @@ function bindStreamActions(root) {
       appState.streams.set(stream.target, stream);
       renderStreamDeck();
     });
+  });
+  root.querySelectorAll("[data-nudge-input]").forEach((input) => {
+    input.addEventListener("input", () => {
+      appState.nudgeDrafts.set(input.dataset.nudgeInput, input.value);
+    });
+  });
+  root.querySelectorAll("[data-nudge-form]").forEach((form) => {
+    form.addEventListener("submit", handlePaneNudgeSubmit);
   });
   root.querySelectorAll("[data-stream-target]").forEach((el) => {
     const stream = appState.streams.get(el.dataset.streamTarget);
@@ -734,6 +748,89 @@ function streamFor(target) {
     lastEventAt: 0,
     session: "",
   };
+}
+
+function renderStreamNudge(target, paneKey) {
+  if (!canNudgeTarget(target)) return "";
+  const draft = nudgeDraft(target);
+  const pending = isNudgePending(target);
+  return `
+    <form class="stream-nudge" data-nudge-form="${escAttr(target)}" data-nudge-pane="${escAttr(paneKey)}">
+      <label class="stream-nudge-label">Nudge this pane</label>
+      <div class="stream-nudge-controls">
+        <input
+          type="text"
+          data-nudge-input="${escAttr(target)}"
+          data-nudge-pane="${escAttr(paneKey)}"
+          value="${escAttr(draft)}"
+          placeholder="Send a scoped nudge to ${escAttr(target)}"
+          aria-label="Nudge ${escAttr(target)}"
+          autocomplete="off"
+          ${pending ? "disabled" : ""}
+        >
+        <button class="btn tiny" type="submit" ${pending || !draft.trim() ? "disabled" : ""}>${pending ? "Sending..." : "Nudge"}</button>
+      </div>
+    </form>
+  `;
+}
+
+function canNudgeTarget(target) {
+  return Boolean(target && hasTarget(target));
+}
+
+function nudgeDraft(target) {
+  return appState.nudgeDrafts.get(target) || "";
+}
+
+function isNudgePending(target) {
+  return appState.nudgePending.has(target);
+}
+
+async function handlePaneNudgeSubmit(event) {
+  event.preventDefault();
+  const target = event.currentTarget.dataset.nudgeForm;
+  const message = nudgeDraft(target).trim();
+  if (!target || !message || isNudgePending(target)) return;
+
+  appState.nudgePending.add(target);
+  renderStreamDeck();
+  try {
+    const response = await fetch("/api/nudge", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ target, message }),
+    });
+    const payload = await response.json();
+    if (!response.ok) throw new Error(payload.error || "Nudge failed");
+    appState.nudgeDrafts.delete(target);
+    toast(`Nudged ${target}.`, "success");
+  } catch (error) {
+    toast(error.message, "error");
+  } finally {
+    appState.nudgePending.delete(target);
+    renderStreamDeck();
+  }
+}
+
+function activeNudgeInputState() {
+  const active = document.activeElement;
+  if (!active || !active.dataset || !active.dataset.nudgeInput || !active.dataset.nudgePane) return null;
+  return {
+    target: active.dataset.nudgeInput,
+    paneKey: active.dataset.nudgePane,
+    start: typeof active.selectionStart === "number" ? active.selectionStart : null,
+    end: typeof active.selectionEnd === "number" ? active.selectionEnd : null,
+  };
+}
+
+function restoreNudgeInputState(state) {
+  if (!state || isNudgePending(state.target)) return;
+  const input = document.querySelector(`[data-nudge-pane="${cssEscape(state.paneKey)}"]`);
+  if (!input) return;
+  input.focus();
+  if (typeof state.start === "number" && typeof state.end === "number") {
+    input.setSelectionRange(state.start, state.end);
+  }
 }
 
 function handleStreamFilterChange() {
@@ -1565,4 +1662,11 @@ function esc(value) {
 
 function escAttr(value) {
   return esc(value).replace(/"/g, "&quot;");
+}
+
+function cssEscape(value) {
+  if (window.CSS && typeof window.CSS.escape === "function") {
+    return window.CSS.escape(value);
+  }
+  return String(value).replace(/[^a-zA-Z0-9_-]/g, "\\$&");
 }

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -665,6 +665,37 @@ a {
   word-break: break-word;
 }
 
+.stream-nudge {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(116, 170, 230, 0.14);
+}
+
+.stream-nudge-label {
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 11px;
+}
+
+.stream-nudge-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.stream-nudge input {
+  width: 100%;
+  padding: 10px 12px;
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  background: rgba(2, 7, 13, 0.98);
+}
+
 .hero-card .stream-body {
   min-height: 420px;
 }
@@ -803,7 +834,8 @@ a {
 .dispatch-form textarea:focus,
 .dispatch-form select:focus,
 .stream-filter select:focus,
-.stream-filter input:focus {
+.stream-filter input:focus,
+.stream-nudge input:focus {
   outline: none;
   border-color: rgba(99, 170, 252, 0.62);
   box-shadow: inset 0 0 0 1px rgba(99, 170, 252, 0.2);

--- a/web/server.js
+++ b/web/server.js
@@ -322,6 +322,19 @@ app.get('/api/peek/:target', async (req, res) => {
   }
 });
 
+app.post('/api/nudge', async (req, res) => {
+  const { target, message } = req.body;
+  if (!target || !message) {
+    res.status(400).json({ error: 'target and message are required' });
+    return;
+  }
+  try {
+    res.json({ output: await runSgt(['nudge', target, message]) });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
 app.post('/api/sling', async (req, res) => {
   const { rig, task, labels, convoy } = req.body;
   if (!rig || !task) {

--- a/web/test/operator-shell.test.js
+++ b/web/test/operator-shell.test.js
@@ -52,6 +52,9 @@ test("operator shell script consumes snapshot and tmux stream events", () => {
   assert.match(script, /streamFilters/);
   assert.match(script, /Tail All: On/);
   assert.match(script, /renderMonitorStream/);
+  assert.match(script, /renderStreamNudge/);
+  assert.match(script, /handlePaneNudgeSubmit/);
+  assert.match(script, /fetch\("\/api\/nudge"/);
   assert.match(script, /matchesStreamFilters/);
   assert.match(script, /maybePlayVoiceAnnouncement/);
   assert.match(script, /renderAlerts/);
@@ -80,6 +83,8 @@ test("operator shell styles reflect the blue-on-black operator theme and vertica
   assert.match(styles, /grid-template-columns:\s*repeat\(auto-fit, minmax\(220px, 1fr\)\)/);
   assert.match(styles, /grid-auto-rows:\s*minmax\(var\(--stream-height\), auto\)/);
   assert.match(styles, /border-top:\s*2px solid rgba\(103, 183, 255, 0\.7\)/);
+  assert.match(styles, /\.stream-nudge\s*\{/);
+  assert.match(styles, /grid-template-columns:\s*minmax\(0, 1fr\) auto/);
   assert.match(styles, /border-radius:\s*2px/);
   assert.doesNotMatch(styles, /Orbitron/);
   assert.doesNotMatch(styles, /backdrop-filter/);


### PR DESCRIPTION
Closes #331

## What changed
- add bottom-anchored nudge inputs to live cockpit panes backed by a new `/api/nudge` endpoint
- preserve pane-local draft text while stream cards rerender and show request feedback
- align `sgt nudge` target resolution with cockpit stream targets for rig mayors, dogs, and crew sessions
- cover the UI contract and target-resolution mapping with regression tests