### PR TITLE
Add first-class Web UI deploy flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The repo includes a minimal Web UI for realtime monitoring and dispatch:
 
 - Docs / quick start: [`web/README.md`](web/README.md)
 - Default URL: `http://localhost:4747`
+- First-class deploy path: `sgt web deploy` from the repo checkout, then `sgt web status` / `sgt web verify` to confirm the live served tree really matches the repo source
 - Latest-main cockpit proof: `./test_web_cockpit_latest_main_proof.sh`
 
 ## Why SGT exists (short)

--- a/sgt
+++ b/sgt
@@ -510,6 +510,7 @@ _mayor_target_rigs_for_reason() {
 }
 
 log_event() {
+  mkdir -p "$(dirname "$SGT_LOG")"
   echo "[$(date -Iseconds)] $*" >> "$SGT_LOG"
 }
 
@@ -12127,6 +12128,360 @@ cmd_daemon_status() {
   fi
 }
 
+# ─── Web UI (deploy/start/restart/verify) ────────────────────────────
+
+_web_session_name() {
+  printf '%s\n' "${SGT_WEB_SESSION_NAME:-sgt-web}"
+}
+
+_web_live_dir() {
+  printf '%s\n' "${SGT_WEB_LIVE_DIR:-/root/sgt/web}"
+}
+
+_web_repo_root() {
+  if [[ -n "${SGT_WEB_REPO_DIR:-}" ]]; then
+    printf '%s\n' "$SGT_WEB_REPO_DIR"
+    return 0
+  fi
+
+  local git_root=""
+  if git_root="$(git rev-parse --show-toplevel 2>/dev/null)" && [[ -n "$git_root" ]]; then
+    printf '%s\n' "$git_root"
+    return 0
+  fi
+
+  local pwd_root=""
+  pwd_root="$(pwd -P 2>/dev/null || pwd)"
+  if [[ -f "$pwd_root/web/package.json" ]]; then
+    printf '%s\n' "$pwd_root"
+    return 0
+  fi
+
+  die "could not determine repo checkout for web source; run from the repo checkout or set SGT_WEB_REPO_DIR"
+}
+
+_web_repo_web_dir() {
+  printf '%s/web\n' "$(_web_repo_root)"
+}
+
+_web_sync_script() {
+  printf '%s/web/scripts/sync-live-copy.sh\n' "$(_web_repo_root)"
+}
+
+_web_log_file() {
+  printf '%s/webui.log\n' "$(_web_live_dir)"
+}
+
+_web_port() {
+  printf '%s\n' "${SGT_WEB_PORT:-4747}"
+}
+
+_web_verify_url() {
+  if [[ -n "${SGT_WEB_VERIFY_URL:-}" ]]; then
+    printf '%s\n' "$SGT_WEB_VERIFY_URL"
+    return 0
+  fi
+  printf 'http://127.0.0.1:%s/api/status\n' "$(_web_port)"
+}
+
+_web_sha256_cmd() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf 'sha256sum\n'
+    return 0
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    printf 'shasum -a 256\n'
+    return 0
+  fi
+  die "sha256sum or shasum is required for web verification"
+}
+
+_web_tree_hash() {
+  local dir="${1:-}"
+  [[ -d "$dir" ]] || return 1
+
+  local hash_cmd
+  hash_cmd="$(_web_sha256_cmd)"
+
+  (
+    cd "$dir"
+    LC_ALL=C find . \
+      -path './node_modules' -prune -o \
+      -name 'webui.log' -prune -o \
+      -type f -print0
+  ) | LC_ALL=C sort -z | while IFS= read -r -d '' rel_path; do
+    local clean_path="${rel_path#./}"
+    local digest
+    digest="$(cd "$dir" && eval "$hash_cmd" "\"$clean_path\"" | awk '{print $1}')"
+    printf '%s  %s\n' "$digest" "$clean_path"
+  done | eval "$hash_cmd" | awk '{print $1}'
+}
+
+_web_tree_state() {
+  local repo_dir live_dir repo_hash live_hash sync_state
+  repo_dir="$(_web_repo_web_dir)"
+  live_dir="$(_web_live_dir)"
+  repo_hash=""
+  live_hash=""
+  sync_state="missing"
+
+  if [[ -d "$repo_dir" ]]; then
+    repo_hash="$(_web_tree_hash "$repo_dir" 2>/dev/null || true)"
+  fi
+  if [[ -d "$live_dir" ]]; then
+    live_hash="$(_web_tree_hash "$live_dir" 2>/dev/null || true)"
+  fi
+
+  if [[ -z "$repo_hash" ]]; then
+    sync_state="repo-missing"
+  elif [[ -z "$live_hash" ]]; then
+    sync_state="live-missing"
+  elif [[ "$repo_hash" == "$live_hash" ]]; then
+    sync_state="in-sync"
+  else
+    sync_state="mismatch"
+  fi
+
+  printf '%s|%s|%s|%s|%s\n' "$repo_dir" "$live_dir" "$repo_hash" "$live_hash" "$sync_state"
+}
+
+_web_http_probe() {
+  local url="${1:-}"
+  if command -v curl >/dev/null 2>&1; then
+    curl --silent --show-error --fail --max-time 3 "$url" >/dev/null
+    return $?
+  fi
+
+  if command -v node >/dev/null 2>&1; then
+    node - "$url" <<'EOF'
+const target = process.argv[2];
+const mod = target.startsWith('https:') ? require('https') : require('http');
+const req = mod.get(target, (res) => {
+  if (res.statusCode >= 200 && res.statusCode < 300) {
+    res.resume();
+    res.on('end', () => process.exit(0));
+    return;
+  }
+  res.resume();
+  res.on('end', () => process.exit(1));
+});
+req.setTimeout(3000, () => {
+  req.destroy(new Error('timeout'));
+});
+req.on('error', () => process.exit(1));
+EOF
+    return $?
+  fi
+
+  die "curl or node is required for web HTTP verification"
+}
+
+_web_wait_for_http() {
+  local url="${1:-}" timeout_secs="${2:-20}" waited=0
+  while (( waited < timeout_secs )); do
+    if _web_http_probe "$url"; then
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  return 1
+}
+
+cmd_web_help() {
+  cat <<EOF
+Usage: sgt web <command> [args]
+
+Commands:
+  status                Show repo source, live served tree, session, and HTTP state
+  start                 Start the live web UI from the deployed tree
+  stop                  Stop the live web UI tmux session
+  restart               Restart the live web UI tmux session
+  deploy [--dry-run]    Sync repo web/ -> live tree, then restart and verify by default
+  verify                Fail unless live tree matches repo checkout and HTTP is healthy
+  help, --help, -h      Show this help
+
+Environment:
+  SGT_WEB_REPO_DIR      Repo checkout to treat as canonical source (default: current git root)
+  SGT_WEB_LIVE_DIR      Live served tree (default: /root/sgt/web)
+  SGT_WEB_SESSION_NAME  tmux session name for the live web server (default: sgt-web)
+  SGT_WEB_PORT          HTTP port for start/verify defaults (default: 4747)
+  SGT_WEB_VERIFY_URL    Override the HTTP health URL (default: http://127.0.0.1:\$SGT_WEB_PORT/api/status)
+EOF
+}
+
+cmd_web_status() {
+  local repo_dir live_dir repo_hash live_hash sync_state session url session_state http_state
+  IFS='|' read -r repo_dir live_dir repo_hash live_hash sync_state <<< "$(_web_tree_state)"
+  session="$(_web_session_name)"
+  url="$(_web_verify_url)"
+  session_state="off"
+  http_state="down"
+
+  if tmux has-session -t "$session" 2>/dev/null; then
+    session_state="on"
+    if _web_http_probe "$url"; then
+      http_state="ok"
+    else
+      http_state="unreachable"
+    fi
+  fi
+
+  info "web source: $repo_dir"
+  info "web live target: $live_dir"
+  info "tree state: $sync_state"
+  info "repo hash: ${repo_hash:-missing}"
+  info "live hash: ${live_hash:-missing}"
+  info "tmux session: $session ($session_state)"
+  info "http verify: $url ($http_state)"
+}
+
+cmd_web_start() {
+  local live_dir session log_file port startup_timeout spawn_cmd
+  live_dir="$(_web_live_dir)"
+  session="$(_web_session_name)"
+  log_file="$(_web_log_file)"
+  port="$(_web_port)"
+  startup_timeout="${SGT_WEB_START_TIMEOUT_SECS:-20}"
+
+  [[ -f "$live_dir/package.json" ]] || die "live web tree missing package.json at $live_dir; run: sgt web deploy"
+
+  if tmux has-session -t "$session" 2>/dev/null; then
+    info "web UI already running (session: $session)"
+    return 0
+  fi
+
+  mkdir -p "$live_dir"
+  printf -v spawn_cmd 'SGT_ROOT=%q SGT_WEB_PORT=%q' "$SGT_ROOT" "$port"
+  if [[ -n "${SGT_BIN:-}" ]]; then
+    printf -v spawn_cmd '%s SGT_BIN=%q' "$spawn_cmd" "$SGT_BIN"
+  fi
+  if [[ -n "${SGT_WEB_ELEVENLABS_API_KEY:-}" ]]; then
+    printf -v spawn_cmd '%s SGT_WEB_ELEVENLABS_API_KEY=%q' "$spawn_cmd" "$SGT_WEB_ELEVENLABS_API_KEY"
+  fi
+  if [[ -n "${SGT_WEB_ELEVENLABS_VOICE_ID:-}" ]]; then
+    printf -v spawn_cmd '%s SGT_WEB_ELEVENLABS_VOICE_ID=%q' "$spawn_cmd" "$SGT_WEB_ELEVENLABS_VOICE_ID"
+  fi
+  if [[ -n "${SGT_WEB_ELEVENLABS_MODEL_ID:-}" ]]; then
+    printf -v spawn_cmd '%s SGT_WEB_ELEVENLABS_MODEL_ID=%q' "$spawn_cmd" "$SGT_WEB_ELEVENLABS_MODEL_ID"
+  fi
+  if [[ -n "${SGT_WEB_VOICE_EVENT_KINDS:-}" ]]; then
+    printf -v spawn_cmd '%s SGT_WEB_VOICE_EVENT_KINDS=%q' "$spawn_cmd" "$SGT_WEB_VOICE_EVENT_KINDS"
+  fi
+  if [[ -n "${SGT_WEB_VOICE_RATE_LIMIT_SECS:-}" ]]; then
+    printf -v spawn_cmd '%s SGT_WEB_VOICE_RATE_LIMIT_SECS=%q' "$spawn_cmd" "$SGT_WEB_VOICE_RATE_LIMIT_SECS"
+  fi
+  printf -v spawn_cmd '%s npm start >> %q 2>&1' "$spawn_cmd" "$log_file"
+
+  if ! tmux new-session -d -s "$session" -c "$live_dir" "$spawn_cmd" 2>/dev/null; then
+    die "failed to start web UI tmux session '$session'"
+  fi
+
+  if ! _web_wait_for_http "$(_web_verify_url)" "$startup_timeout"; then
+    warn "web UI tmux session started, but HTTP health check did not pass within ${startup_timeout}s"
+    warn "see $log_file"
+    return 1
+  fi
+
+  log_event "WEB_START session=$session live_dir=\"$(_escape_quotes "$live_dir")\" port=$port"
+  info "web UI started (session: $session, live: $live_dir, port: $port)"
+}
+
+cmd_web_stop() {
+  local session
+  session="$(_web_session_name)"
+  if tmux has-session -t "$session" 2>/dev/null; then
+    tmux kill-session -t "$session"
+    log_event "WEB_STOP session=$session"
+    info "web UI stopped"
+  else
+    info "web UI not running"
+  fi
+}
+
+cmd_web_restart() {
+  cmd_web_stop >/dev/null 2>&1 || true
+  cmd_web_start
+}
+
+cmd_web_verify() {
+  local repo_dir live_dir repo_hash live_hash sync_state session url problems=0
+  IFS='|' read -r repo_dir live_dir repo_hash live_hash sync_state <<< "$(_web_tree_state)"
+  session="$(_web_session_name)"
+  url="$(_web_verify_url)"
+
+  if [[ "$sync_state" != "in-sync" ]]; then
+    warn "web tree mismatch: repo=$repo_dir live=$live_dir state=$sync_state"
+    problems=1
+  fi
+
+  if ! tmux has-session -t "$session" 2>/dev/null; then
+    warn "web UI tmux session is not running: $session"
+    problems=1
+  fi
+
+  if ! _web_http_probe "$url"; then
+    warn "web UI HTTP verify failed: $url"
+    problems=1
+  fi
+
+  if [[ "$problems" -ne 0 ]]; then
+    return 1
+  fi
+
+  info "web UI verify passed (repo/live hashes match, session running, HTTP healthy)"
+}
+
+cmd_web_deploy() {
+  local dry_run=0 restart_after=1 verify_after=1 arg sync_script
+  while [[ $# -gt 0 ]]; do
+    arg="$1"
+    case "$arg" in
+      --dry-run)
+        dry_run=1
+        shift
+        ;;
+      --no-restart)
+        restart_after=0
+        shift
+        ;;
+      --no-verify)
+        verify_after=0
+        shift
+        ;;
+      -h|--help)
+        cmd_web_help
+        return 0
+        ;;
+      *)
+        die "unknown web deploy option: $arg"
+        ;;
+    esac
+  done
+
+  sync_script="$(_web_sync_script)"
+  [[ -x "$sync_script" ]] || [[ -f "$sync_script" ]] || die "missing deploy helper: $sync_script"
+
+  if [[ "$dry_run" -eq 1 ]]; then
+    SGT_WEB_LIVE_DIR="$(_web_live_dir)" bash "$sync_script" --dry-run
+    info "web deploy dry run complete"
+    return 0
+  fi
+
+  SGT_WEB_LIVE_DIR="$(_web_live_dir)" bash "$sync_script"
+  log_event "WEB_DEPLOY_SYNC repo_dir=\"$(_escape_quotes "$(_web_repo_web_dir)")\" live_dir=\"$(_escape_quotes "$(_web_live_dir)")\""
+
+  if [[ "$restart_after" -eq 1 ]]; then
+    cmd_web_restart
+  fi
+
+  if [[ "$verify_after" -eq 1 ]]; then
+    cmd_web_verify
+  fi
+
+  info "web deploy complete"
+}
+
 # ═══════════════════════════════════════════════════════════════════════
 # MAYOR — AI-powered global coordinator
 # ═══════════════════════════════════════════════════════════════════════
@@ -15034,6 +15389,7 @@ Core Commands:
     --auto-merge                  Auto-merge PR on CI pass
     --backend <claude|codex>      Select AI backend for this polecat (default: SGT_AI_BACKEND)
   status [--json]               Show all agents, polecats, dogs, crew
+  web <subcommand>             Deploy/start/restart/verify the live Web UI
   peek <target>                 View output (polecat, witness/<rig>, refinery/<rig>,
                                 deacon, president, mayor, dog/<name>, crew/<name>)
   nuke <polecat>                Kill polecat and clean up
@@ -15127,6 +15483,11 @@ Environment:
   NO_COLOR              Disable ANSI color output
   OPENAI_API_KEY        Required for 'sgt context index/search' embeddings
   SGT_CONTEXT_EMBED_MODEL  OpenAI embedding model for shared memory (default: text-embedding-3-small)
+  SGT_WEB_REPO_DIR      Repo checkout to treat as canonical Web UI source
+  SGT_WEB_LIVE_DIR      Live served Web UI tree (default: /root/sgt/web)
+  SGT_WEB_SESSION_NAME  tmux session name for live Web UI (default: sgt-web)
+  SGT_WEB_PORT          Web UI port (default: 4747)
+  SGT_WEB_VERIFY_URL    Override Web UI health URL for 'sgt web verify'
 
 Examples:
   sgt init
@@ -15150,6 +15511,9 @@ Examples:
   sgt molecule run feature myapp "User dashboard"  # Multi-step workflow
   sgt escalation init                           # Set up severity levels
   sgt status
+  sgt web status
+  sgt web deploy
+  sgt web verify
   sgt peek mayor                                # Check mayor decisions
   sgt peek dog/dog-a1b2c3d4
   sgt down                                      # Stop agents
@@ -15202,6 +15566,20 @@ main() {
       ;;
     sling)          cmd_sling "$@" ;;
     status|st)      cmd_status "$@" ;;
+    web)
+      local sub="${1:-status}"
+      shift 2>/dev/null || true
+      case "$sub" in
+        status)  cmd_web_status "$@" ;;
+        start)   cmd_web_start "$@" ;;
+        stop)    cmd_web_stop "$@" ;;
+        restart) cmd_web_restart "$@" ;;
+        deploy)  cmd_web_deploy "$@" ;;
+        verify)  cmd_web_verify "$@" ;;
+        help|--help|-h) cmd_web_help ;;
+        *)       die "unknown web command: $sub (try: status, start, stop, restart, deploy, verify)" ;;
+      esac
+      ;;
     peek)           cmd_peek "$@" ;;
     nuke)           cmd_nuke "$@" ;;
     sweep)          cmd_sweep ;;

--- a/test_web_cli_deploy.sh
+++ b/test_web_cli_deploy.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# test_web_cli_deploy.sh — Verify first-class Web UI deploy/status/verify flow.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+HOME_DIR="$TMP_ROOT/home"
+MOCK_BIN="$TMP_ROOT/mockbin"
+LIVE_DIR="$TMP_ROOT/live-web"
+SESSION_DIR="$TMP_ROOT/tmux-sessions"
+WEB_UP_FILE="$TMP_ROOT/web-up"
+mkdir -p "$HOME_DIR/.local/bin" "$MOCK_BIN" "$SESSION_DIR" "$LIVE_DIR"
+cp "$SGT_SCRIPT" "$HOME_DIR/.local/bin/sgt"
+chmod +x "$HOME_DIR/.local/bin/sgt"
+
+cat > "$MOCK_BIN/tmux" <<'TMUX'
+#!/usr/bin/env bash
+set -euo pipefail
+
+SESSIONS_DIR="${SGT_TMUX_SESSIONS_DIR:?missing SGT_TMUX_SESSIONS_DIR}"
+WEB_UP_FILE="${SGT_TEST_WEB_UP_FILE:?missing SGT_TEST_WEB_UP_FILE}"
+
+case "${1:-}" in
+  has-session)
+    [[ "${2:-}" == "-t" ]] || exit 1
+    [[ -f "$SESSIONS_DIR/${3:-}" ]]
+    ;;
+  new-session)
+    session=""
+    shift
+    while [[ $# -gt 0 ]]; do
+      case "${1:-}" in
+        -s)
+          session="${2:-}"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    [[ -n "$session" ]] || exit 1
+    : > "$SESSIONS_DIR/$session"
+    : > "$WEB_UP_FILE"
+    ;;
+  kill-session)
+    [[ "${2:-}" == "-t" ]] || exit 1
+    rm -f "$SESSIONS_DIR/${3:-}"
+    rm -f "$WEB_UP_FILE"
+    ;;
+  *)
+    echo "mock tmux unsupported: $*" >&2
+    exit 1
+    ;;
+esac
+TMUX
+chmod +x "$MOCK_BIN/tmux"
+
+cat > "$MOCK_BIN/npm" <<'NPM'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+NPM
+chmod +x "$MOCK_BIN/npm"
+
+cat > "$MOCK_BIN/curl" <<'CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+WEB_UP_FILE="${SGT_TEST_WEB_UP_FILE:?missing SGT_TEST_WEB_UP_FILE}"
+if [[ -f "$WEB_UP_FILE" ]]; then
+  printf '{}\n'
+  exit 0
+fi
+exit 1
+CURL
+chmod +x "$MOCK_BIN/curl"
+
+run_sgt() {
+  env -i \
+    HOME="$HOME_DIR" \
+    PATH="$MOCK_BIN:$HOME_DIR/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+    TERM=dumb \
+    SGT_ROOT="$HOME_DIR/sgt" \
+    SGT_WEB_REPO_DIR="$REPO_ROOT" \
+    SGT_WEB_LIVE_DIR="$LIVE_DIR" \
+    SGT_TMUX_SESSIONS_DIR="$SESSION_DIR" \
+    SGT_TEST_WEB_UP_FILE="$WEB_UP_FILE" \
+    "$@"
+}
+
+printf 'stale\n' > "$LIVE_DIR/README.md"
+if run_sgt bash --noprofile --norc -c 'set -euo pipefail; sgt web verify'; then
+  echo "expected verify to fail before deploy" >&2
+  exit 1
+fi
+
+status_before="$(run_sgt bash --noprofile --norc -c 'set -euo pipefail; sgt web status')"
+[[ "$status_before" == *"tree state: mismatch"* || "$status_before" == *"tree state: live-missing"* ]] || {
+  echo "expected pre-deploy status to report mismatch or missing live tree" >&2
+  printf '%s\n' "$status_before" >&2
+  exit 1
+}
+
+run_sgt bash --noprofile --norc -c 'set -euo pipefail; sgt web deploy'
+
+run_sgt bash --noprofile --norc -c 'set -euo pipefail; sgt web verify'
+status_after="$(run_sgt bash --noprofile --norc -c 'set -euo pipefail; sgt web status')"
+[[ "$status_after" == *"tree state: in-sync"* ]] || {
+  echo "expected post-deploy status to report in-sync" >&2
+  printf '%s\n' "$status_after" >&2
+  exit 1
+}
+[[ "$status_after" == *"tmux session: sgt-web (on)"* ]] || {
+  echo "expected post-deploy status to report running session" >&2
+  printf '%s\n' "$status_after" >&2
+  exit 1
+}
+[[ "$status_after" == *"http verify: http://127.0.0.1:4747/api/status (ok)"* ]] || {
+  echo "expected post-deploy status to report healthy HTTP" >&2
+  printf '%s\n' "$status_after" >&2
+  exit 1
+}
+
+run_sgt bash --noprofile --norc -c 'set -euo pipefail; sgt web stop'
+if run_sgt bash --noprofile --norc -c 'set -euo pipefail; sgt web verify'; then
+  echo "expected verify to fail once the live session is stopped" >&2
+  exit 1
+fi
+
+echo "PASS: web CLI deploy flow"

--- a/test_web_cockpit_latest_main_proof.sh
+++ b/test_web_cockpit_latest_main_proof.sh
@@ -9,6 +9,6 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 npm --prefix "$REPO_ROOT/web" ci
 npm --prefix "$REPO_ROOT/web" test
-"$REPO_ROOT/web/scripts/sync-live-copy.sh" --dry-run "$TMP_DIR/live"
+SGT_WEB_REPO_DIR="$REPO_ROOT" SGT_WEB_LIVE_DIR="$TMP_DIR/live" "$REPO_ROOT/sgt" web deploy --dry-run
 
 echo "WEB COCKPIT LATEST-MAIN PROOF PASSED"

--- a/web/README.md
+++ b/web/README.md
@@ -19,23 +19,34 @@ npm start
 
 The repo-tracked `web/` directory is the only canonical source for the cockpit.
 The default live served copy on a rig host lives at `/root/sgt/web`, and the default URL is `http://localhost:4747` when you run it locally or `http://<tailscale-host>:4747` on the rig host.
+Code landing in a rig checkout does not update the served UI by itself; the live tree stays stale until you deploy it explicitly.
 
-Sync the repo copy into the live target with:
+Use the first-class SGT deploy flow from the repo checkout:
+
+```bash
+sgt web deploy
+```
+
+That command treats the current checkout's `web/` tree as the source of truth, syncs it into `/root/sgt/web`, restarts the live `sgt-web` tmux session, and verifies both tree parity and HTTP health before reporting success.
+
+Check live truth explicitly:
+
+```bash
+sgt web status
+sgt web verify
+```
+
+Dry-run the deploy first if needed:
+
+```bash
+SGT_WEB_LIVE_DIR=/srv/sgt/web sgt web deploy --dry-run
+```
+
+The lower-level helper still exists underneath that flow:
 
 ```bash
 web/scripts/sync-live-copy.sh
-```
-
-Dry-run the sync first if needed:
-
-```bash
 web/scripts/sync-live-copy.sh --dry-run
-```
-
-Override the live target without editing the script:
-
-```bash
-SGT_WEB_LIVE_DIR=/srv/sgt/web web/scripts/sync-live-copy.sh
 ```
 
 `web/scripts/sync-live-copy.sh` uses `rsync --delete`, preserves runtime-only artifacts such as `node_modules/` and `webui.log`, copies the repo-tracked `package-lock.json`, and runs `npm ci` in the live target so `/root/sgt/web` stays a served deployment copy rather than a second source tree.
@@ -60,6 +71,9 @@ Deploy-helper environment variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SGT_WEB_LIVE_DIR` | `/root/sgt/web` | Alternate live sync target used by `web/scripts/sync-live-copy.sh` |
+| `SGT_WEB_REPO_DIR` | current git root | Override the repo checkout used by `sgt web deploy/status/verify` as the canonical source |
+| `SGT_WEB_SESSION_NAME` | `sgt-web` | tmux session name used by `sgt web start/stop/restart` |
+| `SGT_WEB_VERIFY_URL` | `http://127.0.0.1:$SGT_WEB_PORT/api/status` | Override the HTTP health check used by `sgt web verify` |
 
 Behavior notes:
 
@@ -78,7 +92,7 @@ Run this on a fresh checkout of the latest `master`/mainline commit when you wan
 That proof path bundles:
 
 - `npm --prefix web ci && npm --prefix web test` for a fresh-checkout dependency install plus the cockpit snapshot/topology/blocker alert contracts, operator-shell UI, and docs/deploy-helper assertions
-- `web/scripts/sync-live-copy.sh --dry-run <tempdir>` so the canonical repo `web/` to live-copy sync path is exercised without touching `/root/sgt/web`
+- `sgt web deploy --dry-run` against a temp live dir so the first-class repo `web/` to live-copy deploy path is exercised without touching `/root/sgt/web`
 
 If you want the full President operator-surface proof instead of the web-only proof, run:
 
@@ -138,7 +152,7 @@ Stored under `web/docs/screenshots/`:
 
 - **WebSocket shows Disconnected / stale timestamps**
   - The UI will reconnect automatically with backoff.
-  - If the server is down, restart it: `npm start`.
+  - If the live server is down, restart it: `sgt web restart`.
 
 - **Missing SGT binary / wrong SGT_ROOT**
   - Set `SGT_ROOT` and/or `SGT_BIN` explicitly, e.g.:
@@ -172,6 +186,7 @@ The goal is higher reliability, a simpler mental model, and easier ops.
 - **Real-time**: WebSocket pushes status and log deltas; includes heartbeat + reconnect/backoff.
 - **Topology rendering**: browser-side force simulation with a WebGL node/edge pass when supported; overlay labels and fallback rendering remain canvas-based so the panel still works without GPU support.
 - **Canonical source**: repo `web/` is the source of truth; `/root/sgt/web` is a deployment target.
+- **Live truth check**: `sgt web status` and `sgt web verify` tell you whether the live served tree actually matches the current repo checkout.
 
 ## API Endpoints
 

--- a/web/docs/live-cockpit-architecture.md
+++ b/web/docs/live-cockpit-architecture.md
@@ -173,10 +173,18 @@ Default local deployment target:
 Use the repo-owned helper:
 
 ```bash
+sgt web deploy
+```
+
+That first-class flow treats the current repo checkout as canonical, syncs repo `web/` into the live target, restarts the live `sgt-web` tmux session, and verifies that the served copy matches the repo plus passes HTTP health.
+
+Low-level helper:
+
+```bash
 web/scripts/sync-live-copy.sh
 ```
 
-That script syncs repo `web/` into the live target, preserves runtime-only artifacts such as `node_modules/` and `webui.log`, copies the repo-tracked `package-lock.json`, and runs `npm ci` in the live directory so the served copy reflects the repo source.
+That helper preserves runtime-only artifacts such as `node_modules/` and `webui.log`, copies the repo-tracked `package-lock.json`, and runs `npm ci` in the live directory so the served copy reflects the repo source.
 
 ## Latest-main proof path
 
@@ -189,7 +197,7 @@ Run this on a fresh checkout of the latest `master`/mainline commit when you wan
 This proof path is intentionally narrow:
 
 - `npm --prefix web ci && npm --prefix web test` verifies a fresh-checkout install plus the normalized cockpit snapshot/topology contracts, operator-shell UI structure, and the docs/deploy-helper assertions for the canonical repo copy
-- `web/scripts/sync-live-copy.sh --dry-run <tempdir>` exercises the documented repo `web/` to live-copy deployment helper without mutating `/root/sgt/web`
+- `sgt web deploy --dry-run` against a temp live dir exercises the documented repo `web/` to live-copy deployment flow without mutating `/root/sgt/web`
 
 ## Guardrails For Follow-on Work
 

--- a/web/test/docs-and-sync.test.js
+++ b/web/test/docs-and-sync.test.js
@@ -9,8 +9,14 @@ test('web docs cover deploy path, config, and latest-main proof entrypoint', () 
   const packageLock = fs.readFileSync(path.join(__dirname, '..', 'package-lock.json'), 'utf8');
 
   assert.match(readme, /\/root\/sgt\/web/);
+  assert.match(readme, /sgt web deploy/);
+  assert.match(readme, /sgt web status/);
+  assert.match(readme, /sgt web verify/);
   assert.match(readme, /web\/scripts\/sync-live-copy\.sh/);
   assert.match(readme, /SGT_WEB_LIVE_DIR/);
+  assert.match(readme, /SGT_WEB_REPO_DIR/);
+  assert.match(readme, /SGT_WEB_SESSION_NAME/);
+  assert.match(readme, /SGT_WEB_VERIFY_URL/);
   assert.match(readme, /SGT_WEB_PORT/);
   assert.match(readme, /SGT_WEB_ELEVENLABS_API_KEY/);
   assert.match(readme, /SGT_WEB_VOICE_RATE_LIMIT_SECS/);
@@ -21,6 +27,7 @@ test('web docs cover deploy path, config, and latest-main proof entrypoint', () 
   assert.match(readme, /president-operator-surface-contract\.md/);
   assert.match(readme, /President Activity/);
   assert.match(readme, /human-dashboard-redesign-rules\.md/);
+  assert.match(readme, /Code landing in a rig checkout does not update the served UI by itself/);
   assert.match(packageLock, /"name": "sgt-web"/);
   assert.match(packageLock, /"lockfileVersion": 3/);
 


### PR DESCRIPTION
Closes #339

## Summary
- add `sgt web` commands for deploy/start/stop/restart/status/verify so live Web UI state is explicit
- make deploy sync repo `web/` to the live tree, restart the `sgt-web` tmux session, and verify repo/live parity plus HTTP health
- update docs/proof/tests to use the first-class deploy path and guard against false "UI is updated" assumptions

## Verification
- node --test web/test/docs-and-sync.test.js web/test/cockpit.test.js web/test/operator-shell.test.js
- ./test_web_cli_deploy.sh
- ./test_web_cockpit_latest_main_proof.sh