### PR TITLE
Fix canonical plan sync across create-plan and plan tick

### DIFF
--- a/sgt
+++ b/sgt
@@ -5948,39 +5948,45 @@ _plan_cache_path() {
 
 _plan_effective_file_path() {
   local rig="${1:-}"
-  local canonical_plan_file rpath default_branch current_branch local_plan_dirty remote_plan cache_path cache_tmp
+  local canonical_plan_file
   canonical_plan_file="$(_plan_file_path "$rig")"
   [[ -f "$canonical_plan_file" ]] || return 1
+  printf '%s\n' "$canonical_plan_file"
+}
 
-  rpath="$(rig_path "$rig")"
-  if [[ ! -d "$rpath" ]] || ! command -v git >/dev/null 2>&1; then
-    printf '%s\n' "$canonical_plan_file"
+_plan_request_reconcile_canonical_plan_file() {
+  local request_id="${1:-}" rig="${2:-}" canonical_plan_file="${3:-}"
+  local scope_dir workspace_plan_file workspace_rig_plan_file request_meta fallback_plan
+  [[ -n "$request_id" && -n "$rig" && -n "$canonical_plan_file" ]] || return 1
+
+  request_meta="$(_plan_request_meta_path "$request_id")"
+  scope_dir="$(_mayor_scope_dir)"
+  workspace_plan_file="$scope_dir/mayor-workspace/SGT_PLAN.json"
+  workspace_rig_plan_file="$scope_dir/mayor-workspace/$rig/SGT_PLAN.json"
+
+  if [[ -f "$canonical_plan_file" ]]; then
+    if [[ -f "$request_meta" ]]; then
+      _plan_request_update_field "$request_id" "PLAN_FILE" "$canonical_plan_file" || true
+    fi
     return 0
   fi
 
-  git -C "$rpath" fetch origin >/dev/null 2>&1 || true
-  default_branch="$(git -C "$rpath" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || true)"
-  [[ -n "$default_branch" ]] || default_branch="main"
-  current_branch="$(git -C "$rpath" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
-  local_plan_dirty="$(git -C "$rpath" status --short -- SGT_PLAN.json 2>/dev/null || true)"
-
-  if [[ "$current_branch" == "$default_branch" && -z "$local_plan_dirty" ]]; then
-    printf '%s\n' "$canonical_plan_file"
-    return 0
+  fallback_plan=""
+  if [[ -f "$workspace_rig_plan_file" ]]; then
+    fallback_plan="$workspace_rig_plan_file"
+  elif [[ -f "$workspace_plan_file" ]]; then
+    fallback_plan="$workspace_plan_file"
   fi
 
-  remote_plan="$(git -C "$rpath" show "origin/$default_branch:SGT_PLAN.json" 2>/dev/null || true)"
-  if [[ -z "$remote_plan" ]]; then
-    printf '%s\n' "$canonical_plan_file"
-    return 0
-  fi
+  [[ -n "$fallback_plan" ]] || return 1
 
-  cache_path="$(_plan_cache_path "$rig")"
-  mkdir -p "$(_plan_cache_dir)"
-  cache_tmp="${cache_path}.tmp.$$"
-  printf '%s\n' "$remote_plan" > "$cache_tmp"
-  mv -f "$cache_tmp" "$cache_path"
-  printf '%s\n' "$cache_path"
+  mkdir -p "$(dirname "$canonical_plan_file")"
+  cp "$fallback_plan" "$canonical_plan_file" || return 1
+  if [[ -f "$request_meta" ]]; then
+    _plan_request_update_field "$request_id" "PLAN_FILE" "$canonical_plan_file" || true
+  fi
+  log_event "PLAN_REQUEST_CANONICALIZED request_id=$request_id rig=$rig source=\"$(_escape_quotes "$fallback_plan")\" destination=\"$(_escape_quotes "$canonical_plan_file")\""
+  printf '%s\n' "$canonical_plan_file"
 }
 
 _plan_request_id() {
@@ -12222,15 +12228,18 @@ HEADER
   done
 
   echo "## Pending Plan Requests" >> "$briefing_tmp"
-  local pending_plan_count=0 request_line request_id request_rig request_status request_requested_at request_requester request_prompt_file
+  local pending_plan_count=0 request_line request_id request_rig request_status request_requested_at request_requester request_prompt_file request_plan_file
   while IFS='|' read -r request_id request_rig request_status request_requested_at request_requester request_prompt_file; do
     [[ -n "$request_id" ]] || continue
     pending_plan_count=$((pending_plan_count + 1))
+    request_plan_file="$(_plan_file_path "$request_rig")"
     echo "### $request_id ($request_rig)" >> "$briefing_tmp"
     echo "- status: $request_status" >> "$briefing_tmp"
     echo "- requested_at: $request_requested_at" >> "$briefing_tmp"
     echo "- requesting_agent: $request_requester" >> "$briefing_tmp"
-    echo "- plan_path: $(_plan_file_path "$request_rig")" >> "$briefing_tmp"
+    echo "- repo_path: $(rig_path "$request_rig")" >> "$briefing_tmp"
+    echo "- plan_path: $request_plan_file" >> "$briefing_tmp"
+    echo "- note: only this repo-local plan path is authoritative; ignore any SGT_PLAN.json under mayor-workspace" >> "$briefing_tmp"
     echo "- prompt_excerpt:" >> "$briefing_tmp"
     head -n 12 "$request_prompt_file" 2>/dev/null | sed 's/^/    /' >> "$briefing_tmp" || true
     echo "" >> "$briefing_tmp"
@@ -13457,6 +13466,7 @@ _mayor_loop() {
       local mayor_workspace="$(_mayor_scope_dir)/mayor-workspace"
       local dispatch_snapshot_file="$(_mayor_scope_dir)/mayor-dispatch-snapshot.tsv"
       mkdir -p "$mayor_workspace"
+      rm -f "$mayor_workspace/SGT_PLAN.json"
       _mayor_dispatch_snapshot_file "$dispatch_snapshot_file"
 
       local briefing_gate briefing briefing_status briefing_generated_at briefing_age briefing_threshold briefing_stale_detected briefing_path briefing_content
@@ -13505,6 +13515,8 @@ $briefing_content
 Decide what to do. Log decisions to $(_mayor_scope_dir)/mayor-decisions.log. Be fast.
 
 For each pending plan request, turn the request into a repo-local \`SGT_PLAN.json\` inside the rig repo when the request is clear enough.
+Use the exact \`repo_path\` / \`plan_path\` listed in the briefing as canonical truth.
+Never create or update \`SGT_PLAN.json\` under \`mayor-workspace\`; workspace-local plan files are ignored.
 For any rig-specific question, ambiguity, or missing decision, search shared rig context first with \`sgt context search <rig> "<query>"\` before guessing or escalating.
 If you still need clarification after checking context, ask the requesting OpenClaw agent via \`sgt mayor request ask ...\`.
 After creating or updating \`SGT_PLAN.json\`, call \`sgt mayor request complete <request-id>\`.
@@ -13645,9 +13657,12 @@ cmd_mayor_request_complete() {
   local meta_path="$(_plan_request_meta_path "$request_id")"
   [[ -f "$meta_path" ]] || die "plan request '$request_id' not found"
   local rig plan_file repo sync_reason sync_blocker_id
-  eval "$(grep -E '^(RIG|REQUESTING_AGENT_ID)=' "$meta_path" 2>/dev/null || true)"
+  eval "$(grep -E '^(RIG|REQUESTING_AGENT_ID|PLAN_FILE)=' "$meta_path" 2>/dev/null || true)"
   rig="${RIG:-}"
   plan_file="$(_plan_file_path "$rig")"
+  if [[ -n "$rig" ]]; then
+    _plan_request_reconcile_canonical_plan_file "$request_id" "$rig" "$plan_file" >/dev/null 2>&1 || true
+  fi
   repo="$(rig_repo "$rig" 2>/dev/null || true)"
   if [[ -n "$rig" && -n "$repo" && -f "$plan_file" ]]; then
     if ! _plan_sync_state_and_labels "$rig" "$plan_file" "$repo"; then

--- a/test_mayor_request_complete_workspace_plan_reconcile.sh
+++ b/test_mayor_request_complete_workspace_plan_reconcile.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Regression: mayor request complete should reconcile a plan accidentally written under mayor-workspace back into the canonical rig repo path.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+mkdir -p "$TMP_HOME/.local/bin" "$TMP_HOME/mock-bin" "$TMP_HOME/state"
+cp "$SGT_SCRIPT" "$TMP_HOME/.local/bin/sgt"
+chmod +x "$TMP_HOME/.local/bin/sgt"
+
+cat > "$TMP_HOME/mock-bin/openclaw" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+chmod +x "$TMP_HOME/mock-bin/openclaw"
+
+cat > "$TMP_HOME/mock-bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+STATE_DIR="${GH_STATE_DIR:?missing GH_STATE_DIR}"
+mkdir -p "$STATE_DIR"
+
+command="${1:-}"
+subcommand="${2:-}"
+shift 2 || true
+
+case "$command:$subcommand" in
+  label:create)
+    printf '%s\n' "${1:-}" >> "$STATE_DIR/label-create.log"
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+chmod +x "$TMP_HOME/mock-bin/gh"
+
+COMMON_ENV=(
+  "HOME=$TMP_HOME"
+  "PATH=$TMP_HOME/mock-bin:$TMP_HOME/.local/bin:/usr/local/bin:/usr/bin:/bin"
+  "TERM=${TERM:-xterm}"
+  "GH_STATE_DIR=$TMP_HOME/state"
+)
+
+env -i "${COMMON_ENV[@]}" bash --noprofile --norc <<'BASH'
+set -euo pipefail
+
+sgt init >/dev/null
+mkdir -p "$HOME/sgt/.sgt/rigs" "$HOME/sgt/rigs/demo" "$HOME/sgt/.sgt/mayor-workspace"
+printf '%s\n' 'https://github.com/acme/demo' > "$HOME/sgt/.sgt/rigs/demo"
+
+sgt create plan demo --agent requester-9 "Expand the plan into multiple phases" >/dev/null
+request_id="$(sgt mayor request list | awk 'NR==1 {print $1}')"
+[[ -n "$request_id" ]] || exit 1
+
+cat > "$HOME/sgt/.sgt/mayor-workspace/SGT_PLAN.json" <<'JSON'
+{
+  "version": 1,
+  "rig": "demo",
+  "policy": { "max_in_flight": 2 },
+  "tasks": [
+    { "id": "PK60", "title": "Workspace-authored phase" },
+    { "id": "PK61", "title": "Follow-up phase", "depends_on": ["PK60"] }
+  ]
+}
+JSON
+
+sgt mayor request complete "$request_id" >/dev/null
+BASH
+
+STATE_FILE="$TMP_HOME/sgt/.sgt/plan-state/demo.json"
+PLAN_FILE="$TMP_HOME/sgt/rigs/demo/SGT_PLAN.json"
+LABEL_LOG="$TMP_HOME/state/label-create.log"
+REQUEST_META="$(find "$TMP_HOME/sgt/.sgt/plan-requests" -mindepth 2 -maxdepth 2 -name request.env | head -1)"
+
+[[ -f "$STATE_FILE" ]] || { echo "expected synced plan state after request completion" >&2; exit 1; }
+[[ -f "$PLAN_FILE" ]] || { echo "expected canonical rig plan file to be created" >&2; exit 1; }
+[[ -f "$REQUEST_META" ]] || { echo "expected request metadata" >&2; exit 1; }
+grep -qx 'plan' "$LABEL_LOG" || { echo "expected base plan label creation" >&2; exit 1; }
+grep -qx 'plan-PK60' "$LABEL_LOG" || { echo "expected plan-PK60 label creation" >&2; exit 1; }
+grep -qx 'plan-PK61' "$LABEL_LOG" || { echo "expected plan-PK61 label creation" >&2; exit 1; }
+grep -Fqx "PLAN_FILE=$PLAN_FILE" "$REQUEST_META" || { echo "expected request metadata to point at canonical plan path" >&2; exit 1; }
+
+python3 - "$STATE_FILE" "$PLAN_FILE" <<'PY'
+import json, sys
+state_file, plan_file = sys.argv[1:3]
+with open(state_file, "r", encoding="utf-8") as fh:
+    state = json.load(fh)
+with open(plan_file, "r", encoding="utf-8") as fh:
+    plan = json.load(fh)
+assert sorted(state["tasks"].keys()) == ["PK60", "PK61"], state["tasks"]
+assert state["tasks"]["PK60"]["status"] == "pending", state["tasks"]["PK60"]
+assert state["tasks"]["PK61"]["status"] == "pending", state["tasks"]["PK61"]
+assert [task["id"] for task in plan["tasks"]] == ["PK60", "PK61"], plan
+PY
+
+echo "ALL TESTS PASSED"

--- a/test_plan_tick_authoritative_default_branch_plan.sh
+++ b/test_plan_tick_authoritative_default_branch_plan.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Regression: plan tick should reconcile against the authoritative default-branch plan when the rig checkout is dirty or off-branch.
+# Regression: plan tick should honor repo-local canonical plan truth even when the rig checkout is dirty or off-branch.
 
 set -euo pipefail
 
@@ -118,10 +118,10 @@ cat > "$TMP_HOME/remote-plan.json" <<'JSON'
 {
   "version": 1,
   "rig": "demo",
-  "completion_condition": "Close out acceptance from the merged default-branch plan.",
+  "completion_condition": "Old default-branch plan that should not override the repo-local checkout.",
   "acceptance": {
     "status": "verified",
-    "details": "The final acceptance PR merged on the default branch.",
+    "details": "This stale remote plan incorrectly looks done.",
     "verified_at": "2026-03-31T10:52:10Z"
   },
   "tasks": [
@@ -141,13 +141,13 @@ cat > "$HOME/sgt/rigs/demo/SGT_PLAN.json" <<'JSON'
 {
   "version": 1,
   "rig": "demo",
-  "completion_condition": "Local stale plan that should not win.",
+  "completion_condition": "Repo-local reopened plan that should stay authoritative.",
   "acceptance": {
-    "status": "planned",
-    "details": "This stale local checkout still thinks acceptance is unresolved."
+    "status": "pending",
+    "details": "Keep dispatching work from the repo-local reopened plan."
   },
   "tasks": [
-    { "id": "ACC1", "title": "Resolve acceptance", "depends_on": [] }
+    { "id": "ACC2", "title": "Reopen continuation lane", "depends_on": [] }
   ]
 }
 JSON
@@ -163,14 +163,12 @@ cat > "$HOME/sgt/.sgt/plan-state/demo.json" <<'JSON'
     }
   },
   "completion": {
-    "status": "pending",
-    "rollup": "tasks-exhausted-awaiting-acceptance",
-    "details": "Stale pending completion carried over from the dirty local plan."
+    "status": "verified",
+    "rollup": "acceptance-verified",
+    "details": "Stale verified completion carried over from an old plan snapshot."
   }
 }
 JSON
-
-printf 'STATE=%q\n' 'CLOSED' > "$HOME/state/issues/1018.env"
 
 sgt plan tick demo > "$HOME/plan-tick.out" 2>&1
 BASH
@@ -181,6 +179,7 @@ CACHE_PLAN="$TMP_HOME/sgt/.sgt/plan-cache/demo.json"
 
 python3 - "$STATE_FILE" "$LOCAL_PLAN" "$CACHE_PLAN" <<'PY'
 import json
+import os
 import sys
 
 state_file, local_plan_file, cache_plan_file = sys.argv[1:4]
@@ -189,22 +188,21 @@ with open(state_file, "r", encoding="utf-8") as fh:
     state = json.load(fh)
 with open(local_plan_file, "r", encoding="utf-8") as fh:
     local_plan = json.load(fh)
-with open(cache_plan_file, "r", encoding="utf-8") as fh:
-    cache_plan = json.load(fh)
 
 completion = state["completion"]
-assert completion["status"] == "verified", completion
-assert completion["rollup"] == "acceptance-verified", completion
-assert completion["details"] == "The final acceptance PR merged on the default branch.", completion
-assert completion["acceptance"]["status"] == "verified", completion
+assert completion["status"] == "pending", completion
+assert completion["rollup"] == "tasks-in-progress", completion
+assert completion["details"] == "Keep dispatching work from the repo-local reopened plan.", completion
+assert completion["acceptance"]["status"] == "pending", completion
 assert state["plan_file"].endswith("/sgt/rigs/demo/SGT_PLAN.json"), state["plan_file"]
-
-assert local_plan["acceptance"]["status"] == "planned", local_plan
-assert cache_plan["acceptance"]["status"] == "verified", cache_plan
+assert sorted(state["tasks"].keys()) == ["ACC2"], state["tasks"]
+assert state["tasks"]["ACC2"]["status"] == "pending", state["tasks"]["ACC2"]
+assert local_plan["acceptance"]["status"] == "pending", local_plan
+assert not os.path.exists(cache_plan_file), cache_plan_file
 PY
 
-grep -q 'completion=acceptance-verified status=verified' "$TMP_HOME/plan-tick.out" || {
-  echo "expected plan tick summary to report verified acceptance from the authoritative default-branch plan" >&2
+grep -q 'completion=tasks-in-progress status=pending' "$TMP_HOME/plan-tick.out" || {
+  echo "expected plan tick summary to report pending completion from the repo-local reopened plan" >&2
   cat "$TMP_HOME/plan-tick.out" >&2
   exit 1
 }


### PR DESCRIPTION
Closes #337

## Summary
- keep control-plane plan reads on the canonical rig repo path instead of a default-branch cache
- recover plans accidentally written into mayor-workspace by copying them into the rig repo before request completion sync
- add regressions for repo-local plan truth and mayor-workspace reconciliation