### PR TITLE
Fix plan continuation reconciliation and scoped mayor refresh

### DIFF
--- a/sgt
+++ b/sgt
@@ -149,18 +149,28 @@ _status_badge() {
 }
 
 _mayor_architecture() {
+  local rig_hint="${1:-}"
   case "${SGT_MAYOR_ARCHITECTURE:-shared}" in
     per-rig|per_rig)
       printf 'per-rig\n'
-      ;;
-    *)
-      printf 'shared\n'
+      return 0
       ;;
   esac
+  if command -v tmux >/dev/null 2>&1; then
+    if tmux has-session -t "$(_president_session_name)" 2>/dev/null; then
+      printf 'per-rig\n'
+      return 0
+    fi
+    if [[ -n "$rig_hint" ]] && tmux has-session -t "$(_mayor_scope_session_name "$rig_hint")" 2>/dev/null; then
+      printf 'per-rig\n'
+      return 0
+    fi
+  fi
+  printf 'shared\n'
 }
 
 _mayor_architecture_per_rig() {
-  [[ "$(_mayor_architecture)" == "per-rig" ]]
+  [[ "$(_mayor_architecture "${1:-}")" == "per-rig" ]]
 }
 
 _president_enabled() {
@@ -6531,6 +6541,18 @@ else:
 def one_line(value):
     return str(value or "").replace("\t", " ").replace("\n", " ").strip()
 
+def declared_task_status(value):
+    normalized = str(value or "").strip().lower().replace("-", "_")
+    if normalized in {"completed", "done", "closed", "verified"}:
+        return "completed"
+    if normalized in {"in_progress", "active", "working"}:
+        return "in_progress"
+    if normalized in {"dispatched", "queued", "issued"}:
+        return "dispatched"
+    if normalized in {"pending", "planned", "open", "todo", "ready"}:
+        return "pending"
+    return ""
+
 normalized = {}
 for task in tasks:
     if not isinstance(task, dict):
@@ -6541,6 +6563,15 @@ for task in tasks:
     current = tasks_state.get(task_id)
     if not isinstance(current, dict):
         current = {}
+    declared_status = declared_task_status(task.get("status"))
+    current_status = str(current.get("status") or "").strip()
+    if declared_status:
+        if declared_status == "completed":
+            current["status"] = "completed"
+        elif current_status != declared_status:
+            # Repo-local plan truth can explicitly reopen or requeue a task;
+            # when that happens, drop stale issue/completion bookkeeping.
+            current = {"status": declared_status}
     current.setdefault("status", "pending")
     normalized[task_id] = current
 
@@ -6553,7 +6584,7 @@ doc = {
     "tasks": normalized,
 }
 
-completion_details = one_line(acceptance.get("details") or completion_state.get("details"))
+completion_details = one_line(acceptance.get("details") or acceptance.get("note") or completion_state.get("details"))
 blocked_reason = one_line(acceptance.get("blocked_reason") or completion_state.get("blocked_reason"))
 if completion_status != "blocked":
     blocked_reason = ""
@@ -15161,7 +15192,7 @@ _cmd_mayor_refresh_one() {
 
 cmd_mayor_refresh() {
   local scope_rig="${1:-}"
-  if _mayor_architecture_per_rig; then
+  if _mayor_architecture_per_rig "$scope_rig"; then
     if [[ -n "$scope_rig" ]]; then
       _cmd_mayor_refresh_one "$scope_rig"
       return $?

--- a/test_mayor_refresh.sh
+++ b/test_mayor_refresh.sh
@@ -341,4 +341,58 @@ case "$rig_handoff" in
     ;;
 esac
 
+grep -q 'MAYOR_REFRESH scope=alpha' "$RIG_HOME/sgt/sgt.log" || {
+  echo "expected per-rig refresh log scope to stay on alpha" >&2
+  exit 1
+}
+if grep -q 'MAYOR_REFRESH scope=shared' "$RIG_HOME/sgt/sgt.log"; then
+  echo "did not expect shared refresh scope in per-rig refresh log" >&2
+  exit 1
+fi
+
+echo "=== president-mode refresh without caller env ==="
+PRESIDENT_HOME="$TMP_ROOT/president-mode-home"
+PRESIDENT_SESSIONS="$TMP_ROOT/president-mode-sessions"
+mkdir -p "$PRESIDENT_HOME/.local/bin"
+cp "$SGT_SCRIPT" "$PRESIDENT_HOME/.local/bin/sgt"
+chmod +x "$PRESIDENT_HOME/.local/bin/sgt"
+printf 'sgt-president\nsgt-mayor-alpha\nsgt-mayor-beta\n' > "$PRESIDENT_SESSIONS"
+
+run_env "$PRESIDENT_HOME" "$PRESIDENT_SESSIONS" bash --noprofile --norc -c '
+set -euo pipefail
+sgt init >/dev/null
+mkdir -p "$SGT_ROOT/.sgt/rigs" "$SGT_ROOT/rigs/alpha" "$SGT_ROOT/rigs/beta"
+printf "https://github.com/acme/alpha\n" > "$SGT_ROOT/.sgt/rigs/alpha"
+printf "https://github.com/acme/beta\n" > "$SGT_ROOT/.sgt/rigs/beta"
+mkdir -p "$SGT_ROOT/.sgt/president" "$SGT_ROOT/.sgt/mayors/alpha/mayor-workspace" "$SGT_ROOT/.sgt/mayors/beta/mayor-workspace"
+printf "alpha briefing\n" > "$SGT_ROOT/.sgt/mayors/alpha/mayor-briefing.md"
+printf "beta briefing\n" > "$SGT_ROOT/.sgt/mayors/beta/mayor-briefing.md"
+printf "alpha notes\n" > "$SGT_ROOT/.sgt/mayors/alpha/mayor-workspace/CLAUDE.md"
+printf "beta notes\n" > "$SGT_ROOT/.sgt/mayors/beta/mayor-workspace/CLAUDE.md"
+printf "alpha decision\n" > "$SGT_ROOT/.sgt/mayors/alpha/mayor-decisions.log"
+printf "beta decision\n" > "$SGT_ROOT/.sgt/mayors/beta/mayor-decisions.log"
+'
+
+PRESIDENT_OUT="$TMP_ROOT/president-mode-refresh.out"
+run_env "$PRESIDENT_HOME" "$PRESIDENT_SESSIONS" bash --noprofile --norc -c 'set -euo pipefail; timeout 15 sgt mayor refresh alpha' > "$PRESIDENT_OUT"
+president_handoff="$(tail -n 1 "$PRESIDENT_OUT")"
+assert_file "$president_handoff"
+case "$president_handoff" in
+  *"/mayors/alpha/handoffs/"*) ;;
+  *)
+    echo "expected president-mode refresh to infer alpha per-rig scope" >&2
+    exit 1
+    ;;
+esac
+assert_file "$PRESIDENT_HOME/sgt/.sgt/mayors/beta/mayor-briefing.md"
+assert_file "$PRESIDENT_HOME/sgt/.sgt/mayors/beta/mayor-workspace/CLAUDE.md"
+grep -q 'MAYOR_REFRESH scope=alpha' "$PRESIDENT_HOME/sgt/sgt.log" || {
+  echo "expected president-mode refresh log scope to stay on alpha" >&2
+  exit 1
+}
+if grep -q 'MAYOR_REFRESH scope=shared' "$PRESIDENT_HOME/sgt/sgt.log"; then
+  echo "did not expect shared refresh scope under live president mode" >&2
+  exit 1
+fi
+
 echo "ALL TESTS PASSED"

--- a/test_plan_tick_repo_local_reopen_reconcile.sh
+++ b/test_plan_tick_repo_local_reopen_reconcile.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Regression: repo-local task status can explicitly reopen a stale completed plan-state task for redispatch.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+mkdir -p "$TMP_HOME/.local/bin" "$TMP_HOME/mock-bin" "$TMP_HOME/state/issues"
+cp "$SGT_SCRIPT" "$TMP_HOME/.local/bin/sgt"
+chmod +x "$TMP_HOME/.local/bin/sgt"
+
+cat > "$TMP_HOME/mock-bin/openclaw" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+chmod +x "$TMP_HOME/mock-bin/openclaw"
+
+cat > "$TMP_HOME/mock-bin/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  has-session)
+    exit 1
+    ;;
+  new-session|kill-session)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+chmod +x "$TMP_HOME/mock-bin/tmux"
+
+cat > "$TMP_HOME/mock-bin/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-C" ]]; then
+  shift 2
+fi
+case "${1:-}" in
+  fetch)
+    exit 0
+    ;;
+  symbolic-ref)
+    echo "refs/remotes/origin/main"
+    exit 0
+    ;;
+  worktree)
+    shift
+    case "${1:-}" in
+      add)
+        shift
+        if [[ "${1:-}" == "-b" ]]; then
+          worktree="${3:-}"
+        else
+          worktree="${1:-}"
+        fi
+        mkdir -p "$worktree"
+        exit 0
+        ;;
+      remove)
+        exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$TMP_HOME/mock-bin/git"
+
+cat > "$TMP_HOME/mock-bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+STATE_DIR="${GH_STATE_DIR:?missing GH_STATE_DIR}"
+ISSUES_DIR="$STATE_DIR/issues"
+mkdir -p "$ISSUES_DIR"
+
+command="${1:-}"
+subcommand="${2:-}"
+shift 2 || true
+
+next_issue() {
+  local counter_file="$STATE_DIR/issue-counter"
+  local current=0
+  if [[ -f "$counter_file" ]]; then
+    current="$(cat "$counter_file")"
+  fi
+  current=$((current + 1))
+  printf '%s' "$current" > "$counter_file"
+  echo "$current"
+}
+
+case "$command:$subcommand" in
+  label:create|pr:list|issue:edit|api:*)
+    exit 0
+    ;;
+  issue:list)
+    echo '[]'
+    exit 0
+    ;;
+  issue:view)
+    issue_number="${1:-}"
+    issue_number="${issue_number#\#}"
+    issue_file="$ISSUES_DIR/$issue_number.env"
+    [[ -f "$issue_file" ]] || exit 1
+    state_value="$(sed -n 's/^STATE=//p' "$issue_file" | head -1)"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --json|--jq)
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    printf '%s\n' "${state_value:-}"
+    ;;
+  issue:create)
+    repo=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --repo) repo="$2"; shift 2 ;;
+        --title|--body|--label) shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    issue_number="$(next_issue)"
+    printf 'STATE=%q\n' "OPEN" > "$ISSUES_DIR/$issue_number.env"
+    echo "${repo}/issues/${issue_number}"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+chmod +x "$TMP_HOME/mock-bin/gh"
+
+COMMON_ENV=(
+  "HOME=$TMP_HOME"
+  "PATH=$TMP_HOME/mock-bin:$TMP_HOME/.local/bin:/usr/local/bin:/usr/bin:/bin"
+  "TERM=${TERM:-xterm}"
+  "GH_STATE_DIR=$TMP_HOME/state"
+)
+
+env -i "${COMMON_ENV[@]}" bash --noprofile --norc <<'BASH'
+set -euo pipefail
+
+sgt init >/dev/null
+mkdir -p "$HOME/sgt/.sgt/rigs" "$HOME/sgt/rigs/demo" "$HOME/sgt/.sgt/plan-state"
+printf '%s\n' 'https://github.com/acme/demo' > "$HOME/sgt/.sgt/rigs/demo"
+
+cat > "$HOME/sgt/rigs/demo/SGT_PLAN.json" <<'JSON'
+{
+  "version": 1,
+  "rig": "demo",
+  "policy": { "max_in_flight": 1 },
+  "tasks": [
+    { "id": "ACC2", "title": "Repo-local continuation reopened", "status": "planned" }
+  ]
+}
+JSON
+
+cat > "$HOME/sgt/.sgt/plan-state/demo.json" <<'JSON'
+{
+  "tasks": {
+    "ACC2": {
+      "status": "completed",
+      "issue_number": "42",
+      "issue_url": "https://github.com/acme/demo/issues/42",
+      "completed_at": "2026-04-01T04:52:23Z"
+    }
+  },
+  "completion": {
+    "status": "pending",
+    "rollup": "tasks-exhausted-awaiting-acceptance",
+    "details": "stale carried-over completion"
+  }
+}
+JSON
+
+printf 'STATE=%q\n' 'CLOSED' > "$HOME/state/issues/42.env"
+
+sgt plan tick demo > "$HOME/plan-tick.out" 2>&1
+BASH
+
+STATE_FILE="$TMP_HOME/sgt/.sgt/plan-state/demo.json"
+
+python3 - "$STATE_FILE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    state = json.load(fh)
+
+task = state["tasks"]["ACC2"]
+assert task["status"] in ("dispatched", "in_progress"), task
+assert str(task.get("issue_number")) == "1", task
+assert "completed_at" not in task, task
+PY
+
+grep -q 'dispatched_now=1' "$TMP_HOME/plan-tick.out" || {
+  echo "expected reopened repo-local task to dispatch replacement work" >&2
+  cat "$TMP_HOME/plan-tick.out" >&2
+  exit 1
+}
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Closes #348

## Summary
- honor explicit repo-local reopened plan task status when reconciling plan-state so stale completed continuation lanes can be refilled
- infer live President/per-rig mayor topology for scoped refresh even when the caller shell lacks SGT_MAYOR_ARCHITECTURE=per-rig
- add regressions for repo-local reopened continuation tasks and president-mode scoped refresh