### PR TITLE
Fix mayor notify transport fail-open path

### DIFF
--- a/sgt
+++ b/sgt
@@ -8215,6 +8215,32 @@ _mayor_notify_rigger() {
   return 1
 }
 
+_mayor_notify_rigger_fail_open() {
+  local message="${1:-}"
+  local suppress_decision_log="${2:-0}"
+  local notify_rig="${3:-${SGT_MAYOR_SCOPE_RIG:-}}"
+  local now_epoch
+  if _mayor_notify_rigger "$message" "$suppress_decision_log" "$notify_rig"; then
+    _mayor_notify_alert_state_clear || true
+    return 0
+  fi
+
+  now_epoch="$(date +%s)"
+  _mayor_notify_alert_state_write \
+    "$now_epoch" \
+    "${_MAYOR_NOTIFY_RESULT_CHANNEL:-rigger}" \
+    "${_MAYOR_NOTIFY_RESULT_TARGET:-rigger}" \
+    "${_MAYOR_NOTIFY_RESULT_MESSAGE_KEY:-unknown}" \
+    "${_MAYOR_NOTIFY_RESULT_ATTEMPT:-0}" \
+    "${_MAYOR_NOTIFY_RESULT_OUTCOME:-failed}" \
+    "${_MAYOR_NOTIFY_RESULT_REASON:-unknown}" \
+    "${_MAYOR_NOTIFY_RESULT_MATCHER:-unknown}" \
+    "true" || true
+  log_event "MAYOR_NOTIFY_FAIL_OPEN channel=${_MAYOR_NOTIFY_RESULT_CHANNEL:-rigger} target=\"$(_escape_quotes "${_MAYOR_NOTIFY_RESULT_TARGET:-rigger}")\" message_key=${_MAYOR_NOTIFY_RESULT_MESSAGE_KEY:-unknown} attempt=${_MAYOR_NOTIFY_RESULT_ATTEMPT:-0} outcome=${_MAYOR_NOTIFY_RESULT_OUTCOME:-failed} reason=${_MAYOR_NOTIFY_RESULT_REASON:-unknown} matcher=${_MAYOR_NOTIFY_RESULT_MATCHER:-unknown} escalated=${_MAYOR_NOTIFY_RESULT_ESCALATED:-0} action=retain-warning-continue"
+  echo "[mayor] notify warning retained without failing command (outcome=${_MAYOR_NOTIFY_RESULT_OUTCOME:-failed} reason=${_MAYOR_NOTIFY_RESULT_REASON:-unknown} matcher=${_MAYOR_NOTIFY_RESULT_MATCHER:-unknown})"
+  return 0
+}
+
 # Wake the mayor via FIFO (non-blocking, fire-and-forget)
 _wake_mayor() {
   local reason="${1:-unknown}"
@@ -14714,7 +14740,7 @@ _mayor_loop() {
 
       # Notify Rigger of significant actions via OpenClaw
       if [[ -n "$notify_rigger" ]]; then
-        _mayor_notify_rigger "$notify_rigger"
+        _mayor_notify_rigger_fail_open "$notify_rigger" "0" "${SGT_MAYOR_SCOPE_RIG:-}"
       fi
     fi
 
@@ -14845,27 +14871,7 @@ MAYORMD
 # Public command: sgt mayor notify "<message>" — lets AI mayor report to Rigger
 cmd_mayor_notify() {
   local message="${1:?usage: sgt mayor notify \"<message>\"}"
-  local rc now_epoch
-  if _mayor_notify_rigger "$message" "0" "${SGT_MAYOR_SCOPE_RIG:-}"; then
-    _mayor_notify_alert_state_clear || true
-    return 0
-  fi
-  rc=$?
-
-  now_epoch="$(date +%s)"
-  _mayor_notify_alert_state_write \
-    "$now_epoch" \
-    "${_MAYOR_NOTIFY_RESULT_CHANNEL:-rigger}" \
-    "${_MAYOR_NOTIFY_RESULT_TARGET:-rigger}" \
-    "${_MAYOR_NOTIFY_RESULT_MESSAGE_KEY:-unknown}" \
-    "${_MAYOR_NOTIFY_RESULT_ATTEMPT:-0}" \
-    "${_MAYOR_NOTIFY_RESULT_OUTCOME:-failed}" \
-    "${_MAYOR_NOTIFY_RESULT_REASON:-unknown}" \
-    "${_MAYOR_NOTIFY_RESULT_MATCHER:-unknown}" \
-    "true" || true
-  log_event "MAYOR_NOTIFY_FAIL_OPEN channel=${_MAYOR_NOTIFY_RESULT_CHANNEL:-rigger} target=\"$(_escape_quotes "${_MAYOR_NOTIFY_RESULT_TARGET:-rigger}")\" message_key=${_MAYOR_NOTIFY_RESULT_MESSAGE_KEY:-unknown} attempt=${_MAYOR_NOTIFY_RESULT_ATTEMPT:-0} outcome=${_MAYOR_NOTIFY_RESULT_OUTCOME:-failed} reason=${_MAYOR_NOTIFY_RESULT_REASON:-unknown} matcher=${_MAYOR_NOTIFY_RESULT_MATCHER:-unknown} escalated=${_MAYOR_NOTIFY_RESULT_ESCALATED:-0} action=retain-warning-continue"
-  echo "[mayor] notify warning retained without failing command (outcome=${_MAYOR_NOTIFY_RESULT_OUTCOME:-failed} reason=${_MAYOR_NOTIFY_RESULT_REASON:-unknown} matcher=${_MAYOR_NOTIFY_RESULT_MATCHER:-unknown})"
-  return 0
+  _mayor_notify_rigger_fail_open "$message" "0" "${SGT_MAYOR_SCOPE_RIG:-}"
 }
 
 cmd_mayor_request_list() {

--- a/test_mayor_notifications.sh
+++ b/test_mayor_notifications.sh
@@ -74,7 +74,7 @@ echo ""
 echo "--- Notify on non-periodic wake ---"
 check "mayor derives wake summary per coalesced event" 'wake_summary=\$\(_mayor_wake_summary "\$event_reason"\)'
 check "mayor checks non-periodic wake" 'wake_reason" != "periodic"'
-check "mayor notifies rigger with wake summary" '_mayor_notify_rigger "\$wake_summary"'
+check "mayor fail-open notifies rigger with wake summary" '_mayor_notify_rigger_fail_open "\$notify_rigger" "0"'
 
 echo ""
 echo "--- Refinery templates ---"

--- a/test_mayor_notify_fail_open_runtime.sh
+++ b/test_mayor_notify_fail_open_runtime.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# test_mayor_notify_fail_open_runtime.sh — Mayor notify helper must fail open inside set -e callers.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SGT_SCRIPT="$REPO_ROOT/sgt"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+bash -s "$SGT_SCRIPT" "$TMP_ROOT" <<'BASH'
+set -euo pipefail
+SGT_SCRIPT="$1"
+TMP_ROOT="$2"
+
+extract_fn() {
+  local name="$1"
+  awk -v n="$name" '
+    $0 ~ "^" n "\\(\\) \\{" {in_fn=1}
+    in_fn {print}
+    in_fn && $0 == "}" {exit}
+  ' "$SGT_SCRIPT"
+}
+
+eval "$(extract_fn _escape_quotes)"
+eval "$(extract_fn _escape_wake_value)"
+eval "$(extract_fn log_event)"
+eval "$(extract_fn _one_line)"
+eval "$(extract_fn _mayor_notify_alert_state_write)"
+eval "$(extract_fn _mayor_notify_alert_state_clear)"
+eval "$(extract_fn _mayor_notify_rigger_fail_open)"
+
+SGT_ROOT="$TMP_ROOT/root"
+SGT_CONFIG="$SGT_ROOT/.sgt"
+SGT_LOG="$SGT_ROOT/sgt.log"
+SGT_MAYOR_NOTIFY_ALERT_STATE="$SGT_CONFIG/mayor-notify-alert.state"
+mkdir -p "$SGT_CONFIG"
+: > "$SGT_LOG"
+
+_mayor_notify_rigger() {
+  _MAYOR_NOTIFY_RESULT_CHANNEL="current"
+  _MAYOR_NOTIFY_RESULT_TARGET="channel=current"
+  _MAYOR_NOTIFY_RESULT_MESSAGE_KEY="notify-deadbeef"
+  _MAYOR_NOTIFY_RESULT_ATTEMPT="1"
+  _MAYOR_NOTIFY_RESULT_OUTCOME="transport-failure"
+  _MAYOR_NOTIFY_RESULT_REASON="transport-hard-failure"
+  _MAYOR_NOTIFY_RESULT_MATCHER="hard-transport-pattern"
+  _MAYOR_NOTIFY_RESULT_ESCALATED="1"
+  return 1
+}
+
+_mayor_notify_rigger_fail_open "wake summary for failed transport" "0" "pmkb"
+printf 'still-running\n' > "$TMP_ROOT/continued.out"
+BASH
+
+grep -qx 'still-running' "$TMP_ROOT/continued.out" || {
+  echo "expected fail-open helper to preserve execution under set -e" >&2
+  exit 1
+}
+
+ALERT_STATE="$TMP_ROOT/root/.sgt/mayor-notify-alert.state"
+[[ -f "$ALERT_STATE" ]] || {
+  echo "expected fail-open helper to persist notify alert state" >&2
+  exit 1
+}
+grep -q 'current|channel=current|notify-deadbeef|1|transport-failure|transport-hard-failure|hard-transport-pattern|true' "$ALERT_STATE" || {
+  echo "expected fail-open alert state to preserve transport failure details" >&2
+  exit 1
+}
+
+grep -q 'MAYOR_NOTIFY_FAIL_OPEN channel=current target="channel=current" message_key=notify-deadbeef attempt=1 outcome=transport-failure reason=transport-hard-failure matcher=hard-transport-pattern escalated=1 action=retain-warning-continue' "$TMP_ROOT/root/sgt.log" || {
+  echo "expected fail-open helper to emit durable MAYOR_NOTIFY_FAIL_OPEN telemetry" >&2
+  exit 1
+}
+
+grep -q '_mayor_notify_rigger_fail_open "\$notify_rigger" "0" "\${SGT_MAYOR_SCOPE_RIG:-}"' "$SGT_SCRIPT" || {
+  echo "expected mayor cycle to use the fail-open notify helper" >&2
+  exit 1
+}
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Closes #354

## Summary
- route mayor-loop wake-summary notifications through the same fail-open helper used by `sgt mayor notify`
- retain durable notify warning state and MAYOR_NOTIFY_FAIL_OPEN telemetry when transport/current-session delivery fails
- add runtime regression coverage that proves notify failures no longer abort set -e callers