### PR TITLE
Expose Ralph controls and live state in cockpit surfaces

### DIFF
--- a/SGT_CONTEXT.md
+++ b/SGT_CONTEXT.md
@@ -1350,3 +1350,5 @@ Required follow-up:
 - re-investigate why the worker exited without producing a PR
 
 ```
+- 2026-04-01T08:25:16+02:00 — 2026-04-01 issue #361: added test_ralph_mode_latest_main_proof.sh as the repo-owned latest-main proof path for Ralph mode; it bundles config/state, President intervention, stranded-rig refill, and cockpit visibility coverage, and README now points operators at that single entrypoint.
+- 2026-04-01T08:54:09+02:00 — 2026-04-01 issue #364 duplicate redispatch fallout: plan tick no longer treats default task status pending/planned as an authoritative reopen of completed work. Explicit repo-local reopen now requires status=reopened/requeue or reopen=true, while unchanged tasks retain the latest merged plan-task issue lineage so duplicate open plan-<task> issues do not reset completed tasks back to pending/dispatched.

--- a/test_ralph_mode_config_and_state.sh
+++ b/test_ralph_mode_config_and_state.sh
@@ -159,11 +159,27 @@ JSON
 
 sgt config ralph demo --enable --condition "1K PNL for 5m btc pipeline" --target 2 >/dev/null
 sgt plan tick demo >/dev/null 2>&1
+sgt status > "$SGT_ROOT/status-before.txt"
 sgt status --json > "$SGT_ROOT/status-before.json"
 
 BLOCKER_FILE="$SGT_ROOT/.sgt/plan-blockers/demo--__continuation__.env"
 [[ -f "$BLOCKER_FILE" ]] || {
   echo "expected Ralph continuation blocker to be recorded while live lanes stay below target" >&2
+  exit 1
+}
+
+grep -q 'ralph: state=underfilled target=2 active_lanes=1 admissible=1 backlog=0 support_excluded=1 duplicate_excluded=1 underfilled=1 condition_status=unmet' "$SGT_ROOT/status-before.txt" || {
+  echo "expected human status to show Ralph live state" >&2
+  exit 1
+}
+
+grep -q 'ralph condition: 1K PNL for 5m btc pipeline' "$SGT_ROOT/status-before.txt" || {
+  echo "expected human status to show Ralph condition text" >&2
+  exit 1
+}
+
+grep -q 'RIG_RALPH_MODE_SET rig=demo enabled=true condition_status=unmet target=2 count_support_lanes=false' "$SGT_ROOT/sgt.log" || {
+  echo "expected Ralph config changes to be written to the durable event log" >&2
   exit 1
 }
 
@@ -215,6 +231,11 @@ PY
 
 sgt config ralph demo --count-support yes >/dev/null
 sgt status --json > "$SGT_ROOT/status-after.json"
+
+grep -q 'RIG_RALPH_MODE_SET rig=demo enabled=true condition_status=unmet target=2 count_support_lanes=true' "$SGT_ROOT/sgt.log" || {
+  echo "expected Ralph support-lane changes to be written to the durable event log" >&2
+  exit 1
+}
 
 python3 - "$SGT_ROOT/status-after.json" <<'PY'
 import json

--- a/web/README.md
+++ b/web/README.md
@@ -108,6 +108,7 @@ That broader proof also checks `sgt status --json` President event history plus 
 - **Live tmux monitoring** — Mayor gets a dedicated live monitor, while all active polecats can stay open simultaneously in a filtered multi-pane wall with per-pane tail/focus/peek controls
 - **Acceptance blocker center** — Open blockers stay prominent with rig ownership, evidence snippets, and timestamps
 - **Recent alert rail** — Defaults to recent and actionable President incidents plus unresolved blocker openings/follow-ups, while trimming stale resolved noise and long-title clutter
+- **Ralph controls per rig** — Each rig card exposes live Ralph state plus inline controls for enable/disable, condition text, target concurrency, condition status, and support-lane counting
 - **Optional ElevenLabs voice** — Env-gated blocker voice announcements with browser mute control plus backend dedupe and rate limiting
 - **Realtime WS** — Normalized `snapshot` pushes plus tmux stream events and live `sgt.log` updates; reconnect/backoff and stale states remain visible
 - **Topology radar** — Force-laid live graph driven from normalized `topology` nodes/edges, using WebGL when available plus a canvas fallback with click/hover focus plus direct focus/peek actions for `president` and `mayor/<rig>` nodes
@@ -204,6 +205,7 @@ The goal is higher reliability, a simpler mental model, and easier ops.
 | GET | `/api/logs?lines=N` | Tail sgt.log |
 | GET | `/api/plan-state/:rig` | Repo plan-state JSON for one rig |
 | POST | `/api/nudge` | Send a pane-scoped nudge `{target, message}` |
+| POST | `/api/ralph/:rig` | Update Ralph mode config `{enabled?, condition?, conditionStatus?, targetConcurrency?, countSupportLanes?}` |
 | POST | `/api/sling` | Dispatch a polecat `{rig, task, labels?, convoy?}` |
 | POST | `/api/sling-dog` | Dispatch a dog `{rig, issue}` |
 | WS | `/` | Real-time status/log stream plus snapshot + tmux stream events |

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -535,11 +535,75 @@ function renderRigs() {
         <span>${rig.blockers || 0} blockers</span>
         <span>${rig.mergeQueue || 0} queue</span>
       </div>
-      ${rig.ralph && rig.ralph.enabled ? `<div class="subtle">Ralph ${esc(rig.ralph.state || "enabled")} · target ${esc(String(rig.ralph.target_concurrency || 1))} · active ${esc(String(rig.ralph.active_lane_count || 0))}/${esc(String(rig.ralph.target_concurrency || 1))} · admissible ${esc(String(rig.ralph.admissible_lane_count || 0))}</div>` : ""}
-      ${rig.ralph && rig.ralph.enabled && rig.ralph.condition ? `<div class="subtle">${esc(snippet(rig.ralph.condition, 160))}</div>` : ""}
+      ${renderRigRalph(rig)}
       <div class="subtle">${esc(rig.reason || "No rig-local mayor detail available.")}</div>
     </article>
   `).join("");
+
+  refs.rigMatrix.querySelectorAll("[data-ralph-form]").forEach((form) => {
+    form.addEventListener("submit", handleRalphSubmit);
+  });
+  refs.rigMatrix.querySelectorAll("[data-ralph-disable]").forEach((button) => {
+    button.addEventListener("click", handleRalphDisable);
+  });
+}
+
+function renderRigRalph(rig) {
+  const ralph = rig.ralph || {};
+  const enabled = Boolean(ralph.enabled);
+  const target = Number.parseInt(ralph.target_concurrency, 10) > 0 ? Number.parseInt(ralph.target_concurrency, 10) : 1;
+  const conditionStatus = ralph.condition_status || "unmet";
+  const lastAction = ralph.last_president_action || {};
+  const lastActionSummary = lastAction.action || lastAction.reason || lastAction.outcome
+    ? `President ${lastAction.action || "observed"} ${lastAction.reason || "ralph"} (${lastAction.outcome || "unknown"})`
+    : "";
+
+  return `
+    <div class="ralph-panel">
+      <div class="subtle">
+        Ralph ${esc(ralph.state || (enabled ? "enabled" : "disabled"))}
+        · target ${esc(String(target))}
+        · active ${esc(String(ralph.active_lane_count || 0))}/${esc(String(target))}
+        · admissible ${esc(String(ralph.admissible_lane_count || 0))}
+        · backlog ${esc(String(ralph.backlog_lane_count || 0))}
+        · underfilled ${esc(String(ralph.underfilled ? 1 : 0))}
+        · condition ${esc(conditionStatus)}
+      </div>
+      ${ralph.condition ? `<div class="subtle">${esc(snippet(ralph.condition, 160))}</div>` : ""}
+      ${ralph.reason ? `<div class="subtle">${esc(ralph.reason)}</div>` : ""}
+      ${lastActionSummary ? `<div class="subtle">${esc(lastActionSummary)}</div>` : ""}
+      <form class="ralph-form" data-ralph-form="${escAttr(rig.name)}">
+        <div class="ralph-grid">
+          <label class="ralph-check">
+            <input type="checkbox" name="enabled" ${enabled ? "checked" : ""}>
+            <span>Ralph enabled</span>
+          </label>
+          <label>
+            Condition
+            <input type="text" name="condition" value="${escAttr(ralph.condition || "")}" placeholder="Operator-owned Ralph condition">
+          </label>
+          <label>
+            Target Concurrency
+            <input type="number" name="targetConcurrency" min="1" step="1" value="${escAttr(String(target))}">
+          </label>
+          <label>
+            Condition Status
+            <select name="conditionStatus">
+              ${["unmet", "met", "waived"].map((value) => `<option value="${escAttr(value)}" ${conditionStatus === value ? "selected" : ""}>${esc(value)}</option>`).join("")}
+            </select>
+          </label>
+          <label class="ralph-check">
+            <input type="checkbox" name="countSupportLanes" ${ralph.count_support_lanes ? "checked" : ""}>
+            <span>Count support-only lanes</span>
+          </label>
+        </div>
+        <div class="ralph-actions">
+          <button class="btn tiny" type="submit">Save Ralph</button>
+          <button class="btn tiny ghost" type="button" data-ralph-disable="${escAttr(rig.name)}">Disable</button>
+        </div>
+      </form>
+    </div>
+  `;
 }
 
 function renderBlockers() {
@@ -890,6 +954,18 @@ async function loadRigs() {
   } catch {}
 }
 
+async function loadCockpitSnapshot() {
+  const response = await fetch("/api/cockpit");
+  const snapshot = await response.json();
+  if (!response.ok) {
+    throw new Error(snapshot.error || "Snapshot refresh failed");
+  }
+  appState.cockpit = snapshot;
+  appState.lastSnapshotAt = Date.now();
+  syncStreamTargets();
+  renderAll();
+}
+
 function populateRigSelects() {
   const options = appState.rigs.map((rig) => `<option value="${escAttr(rig.name)}">${esc(rig.name)}</option>`).join("");
   const placeholder = `<option value="">Select a rig...</option>`;
@@ -949,6 +1025,75 @@ async function handleDogSubmit(event) {
     refs.dogBtn.disabled = false;
     refs.dogBtn.textContent = "Dispatch Dog";
     populateRigSelects();
+  }
+}
+
+function setRalphFormPending(form, pending, submitLabel = "Save Ralph") {
+  form.querySelectorAll("input, select, button").forEach((control) => {
+    control.disabled = pending;
+  });
+  const submit = form.querySelector('button[type="submit"]');
+  if (submit) {
+    submit.textContent = pending ? "Saving..." : submitLabel;
+  }
+}
+
+async function handleRalphSubmit(event) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const rig = form.dataset.ralphForm;
+  if (!rig) return;
+
+  const formData = new FormData(form);
+  const targetRaw = String(formData.get("targetConcurrency") || "").trim();
+  const targetConcurrency = Number.parseInt(targetRaw, 10);
+  const payload = {
+    enabled: formData.get("enabled") === "on",
+    condition: String(formData.get("condition") || "").trim(),
+    conditionStatus: String(formData.get("conditionStatus") || "unmet").trim(),
+    targetConcurrency: Number.isFinite(targetConcurrency) && targetConcurrency > 0 ? targetConcurrency : 1,
+    countSupportLanes: formData.get("countSupportLanes") === "on",
+  };
+
+  setRalphFormPending(form, true);
+  try {
+    const response = await fetch(`/api/ralph/${encodeURIComponent(rig)}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || "Ralph update failed");
+    toast(`Ralph updated for ${rig}.`, "success");
+    await loadCockpitSnapshot();
+    await loadRigs();
+  } catch (error) {
+    toast(error.message, "error");
+    setRalphFormPending(form, false);
+  }
+}
+
+async function handleRalphDisable(event) {
+  const button = event.currentTarget;
+  const rig = button.dataset.ralphDisable;
+  const form = button.closest("[data-ralph-form]");
+  if (!rig || !form) return;
+  setRalphFormPending(form, true, "Save Ralph");
+
+  try {
+    const response = await fetch(`/api/ralph/${encodeURIComponent(rig)}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: false }),
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || "Ralph disable failed");
+    toast(`Ralph disabled for ${rig}.`, "success");
+    await loadCockpitSnapshot();
+    await loadRigs();
+  } catch (error) {
+    toast(error.message, "error");
+    setRalphFormPending(form, false);
   }
 }
 

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -370,6 +370,55 @@ a {
   font-size: 12px;
 }
 
+.ralph-panel {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(103, 183, 255, 0.14);
+}
+
+.ralph-form {
+  display: grid;
+  gap: 10px;
+  margin-top: 2px;
+}
+
+.ralph-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+.ralph-form label {
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 11px;
+}
+
+.ralph-check {
+  align-content: start;
+}
+
+.ralph-check span {
+  color: var(--text);
+  letter-spacing: 0.04em;
+}
+
+.ralph-check input {
+  width: auto;
+  margin: 2px 0 0;
+}
+
+.ralph-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .pill,
 .state-pill,
 .severity-pill {
@@ -816,7 +865,9 @@ a {
 
 .dispatch-form input,
 .dispatch-form textarea,
-.dispatch-form select {
+.dispatch-form select,
+.ralph-form input,
+.ralph-form select {
   width: 100%;
   padding: 12px;
   color: var(--text);

--- a/web/server.js
+++ b/web/server.js
@@ -368,6 +368,39 @@ app.post('/api/sling-dog', async (req, res) => {
   }
 });
 
+app.post('/api/ralph/:rig', async (req, res) => {
+  const rig = String(req.params.rig || '').trim();
+  if (!rig) {
+    res.status(400).json({ error: 'rig is required' });
+    return;
+  }
+
+  const body = req.body && typeof req.body === 'object' ? req.body : {};
+  const args = ['config', 'ralph', rig];
+  const enabled = body.enabled;
+  const condition = typeof body.condition === 'string' ? body.condition.trim() : '';
+  const conditionStatus = typeof body.conditionStatus === 'string' ? body.conditionStatus.trim().toLowerCase() : '';
+  const targetRaw = body.targetConcurrency;
+  const countSupport = body.countSupportLanes;
+
+  if (enabled === true) args.push('--enable');
+  if (enabled === false) args.push('--disable');
+  if (condition) args.push('--condition', condition);
+  if (conditionStatus) args.push('--condition-status', conditionStatus);
+  if (targetRaw !== undefined && targetRaw !== null && String(targetRaw).trim() !== '') {
+    args.push('--target', String(targetRaw).trim());
+  }
+  if (countSupport === true) args.push('--count-support', 'yes');
+  if (countSupport === false) args.push('--count-support', 'no');
+
+  try {
+    const output = await runSgt(args);
+    res.json({ output });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
 app.get('/api/logs', (req, res) => {
   const lines = Number.parseInt(req.query.lines, 10) || 100;
   res.json({ lines: readRecentLogLines(SGT_LOG, lines) });

--- a/web/test/cockpit.test.js
+++ b/web/test/cockpit.test.js
@@ -51,6 +51,11 @@ test('buildCockpitSnapshot shapes normalized rig, worker, blocker, and topology 
             target_concurrency: 5,
             active_lane_count: 1,
             admissible_lane_count: 3,
+            last_president_action: {
+              action: 'wake',
+              reason: 'ralph-underfilled',
+              outcome: 'intervened',
+            },
           },
         },
       ],
@@ -123,6 +128,7 @@ test('buildCockpitSnapshot shapes normalized rig, worker, blocker, and topology 
   assert.equal(snapshot.rigs[0].activeWorkers, 1);
   assert.equal(snapshot.rigs[0].ralph.enabled, true);
   assert.equal(snapshot.rigs[0].ralph.target_concurrency, 5);
+  assert.equal(snapshot.rigs[0].ralph.last_president_action.reason, 'ralph-underfilled');
   assert.equal(snapshot.workers[0].stream.target, 'sgt-34784812');
   assert.equal(snapshot.workers[0].runtime.classification, 'busy-long-running');
   assert.equal(snapshot.workers[0].runtime.busy_comm, 'python3');

--- a/web/test/docs-and-sync.test.js
+++ b/web/test/docs-and-sync.test.js
@@ -26,6 +26,8 @@ test('web docs cover deploy path, config, and latest-main proof entrypoint', () 
   assert.match(readme, /npm --prefix web ci && npm --prefix web test/);
   assert.match(readme, /president-operator-surface-contract\.md/);
   assert.match(readme, /President Activity/);
+  assert.match(readme, /Ralph controls per rig/);
+  assert.match(readme, /POST \| `\/api\/ralph\/:rig` \| Update Ralph mode config/);
   assert.match(readme, /human-dashboard-redesign-rules\.md/);
   assert.match(readme, /Code landing in a rig checkout does not update the served UI by itself/);
   assert.match(packageLock, /"name": "sgt-web"/);

--- a/web/test/operator-shell.test.js
+++ b/web/test/operator-shell.test.js
@@ -55,6 +55,11 @@ test("operator shell script consumes snapshot and tmux stream events", () => {
   assert.match(script, /renderStreamNudge/);
   assert.match(script, /handlePaneNudgeSubmit/);
   assert.match(script, /fetch\("\/api\/nudge"/);
+  assert.match(script, /data-ralph-form/);
+  assert.match(script, /handleRalphSubmit/);
+  assert.match(script, /handleRalphDisable/);
+  assert.match(script, /fetch\(`\/api\/ralph\/\$\{encodeURIComponent\(rig\)\}`/);
+  assert.match(script, /Save Ralph/);
   assert.match(script, /matchesStreamFilters/);
   assert.match(script, /maybePlayVoiceAnnouncement/);
   assert.match(script, /renderAlerts/);
@@ -85,6 +90,9 @@ test("operator shell styles reflect the blue-on-black operator theme and vertica
   assert.match(styles, /border-top:\s*2px solid rgba\(103, 183, 255, 0\.7\)/);
   assert.match(styles, /\.stream-nudge\s*\{/);
   assert.match(styles, /grid-template-columns:\s*minmax\(0, 1fr\) auto/);
+  assert.match(styles, /\.ralph-panel\s*\{/);
+  assert.match(styles, /\.ralph-form\s*\{/);
+  assert.match(styles, /\.ralph-grid\s*\{/);
   assert.match(styles, /border-radius:\s*2px/);
   assert.doesNotMatch(styles, /Orbitron/);
   assert.doesNotMatch(styles, /backdrop-filter/);


### PR DESCRIPTION
Closes #367

## Summary
- add a Web API and inline cockpit controls for per-rig Ralph config changes
- show richer Ralph live state and recent President action on rig cards
- extend Ralph regression coverage to human status and durable event-log visibility

## Testing
- bash test_ralph_mode_config_and_state.sh
- npm --prefix web test