### PR TITLE
Fix per-rig mayor scope restoration under President mode

### DIFF
--- a/SGT_CONTEXT.md
+++ b/SGT_CONTEXT.md
@@ -1352,3 +1352,59 @@ Required follow-up:
 ```
 - 2026-04-01T08:25:16+02:00 — 2026-04-01 issue #361: added test_ralph_mode_latest_main_proof.sh as the repo-owned latest-main proof path for Ralph mode; it bundles config/state, President intervention, stranded-rig refill, and cockpit visibility coverage, and README now points operators at that single entrypoint.
 - 2026-04-01T08:54:09+02:00 — 2026-04-01 issue #364 duplicate redispatch fallout: plan tick no longer treats default task status pending/planned as an authoritative reopen of completed work. Explicit repo-local reopen now requires status=reopened/requeue or reopen=true, while unchanged tasks retain the latest merged plan-task issue lineage so duplicate open plan-<task> issues do not reset completed tasks back to pending/dispatched.
+- 2026-04-01T09:07:10+02:00 — 2026-04-01 issue #366: when Ralph is enabled and the condition remains unmet, plan-state completion.acceptance now mirrors the effective pending status instead of leaking stale verified/waived terminal metadata; the original declared terminal status/timestamp is preserved under completion.acceptance.declared_* for operator forensics, and regression coverage lives in test_ralph_mode_config_and_state.sh.
+- 2026-04-01T09:08:14+02:00 — Acceptance blocker sgt-acceptance-1775027294-89db909c reported by witness: Replacement work required after stalled polecat for issue #366
+
+### Acceptance Blocker sgt-acceptance-1775027294-89db909c
+
+- Reported at: 2026-04-01T09:08:14+02:00
+- Reported by: witness
+- Title: Replacement work required after stalled polecat for issue #366
+
+```markdown
+Replacement work required after stalled polecat for issue #366
+
+Stalled polecat recovery did not produce replacement work.
+
+- Rig: sgt
+- Repo: codejeet/sgt
+- Issue: #366
+- Issue URL: https://github.com/codejeet/sgt/issues/366
+- Issue title: unknown
+- Polecat: sgt-89881ba7
+- Failure reason: witness-stalled-issue-title-unavailable
+
+Required follow-up:
+- create replacement work (new PR or re-dispatched polecat) before closing the incident
+- re-investigate why the worker exited without producing a PR
+
+```
+- 2026-04-01T09:09:57+02:00 — Issue #367: the Web cockpit now exposes inline per-rig Ralph controls via POST /api/ralph/:rig (enable/disable, condition text, target concurrency, condition status, count-support toggle), while test_ralph_mode_config_and_state.sh now asserts human status and durable event-log visibility for Ralph state changes.
+- 2026-04-01T11:16:35+02:00 — 2026-04-01 issue #370: per-rig mayor helper calls must preserve the caller's rig scope and existing errexit mode. Status/notify/start-stop-refresh helpers that reset scope to shared or blindly restore set -e can make President-started mayor/<rig> sessions fall off after startup/event handling with clean-exit or nonzero-exit noise instead of staying resident.
+- 2026-04-01T11:18:05+02:00 — Acceptance blocker sgt-acceptance-1775035085-041bcff8 reported by witness: Replacement work required after stalled polecat for issue #370
+
+### Acceptance Blocker sgt-acceptance-1775035085-041bcff8
+
+- Reported at: 2026-04-01T11:18:05+02:00
+- Reported by: witness
+- Title: Replacement work required after stalled polecat for issue #370
+
+```markdown
+Replacement work required after stalled polecat for issue #370
+
+Stalled polecat recovery did not produce replacement work.
+
+- Rig: sgt
+- Repo: codejeet/sgt
+- Issue: #370
+- Issue URL: https://github.com/codejeet/sgt/issues/370
+- Issue title: unknown
+- Polecat: sgt-f1ac7cda
+- Failure reason: witness-stalled-issue-title-unavailable
+
+Required follow-up:
+- create replacement work (new PR or re-dispatched polecat) before closing the incident
+- re-investigate why the worker exited without producing a PR
+
+```
+- 2026-04-01T11:34:21+02:00 — 2026-04-01 issue #371: per-rig mayor liveness under President depends on preserving both caller rig scope and the current errexit mode across helper calls. In practice, _mayor_notify_rigger flipping set -e back on and helper paths like status/wake/start/stop/refresh resetting scope to shared can make mayor/<rig> exit after its first startup/event cycle instead of staying resident.

--- a/sgt
+++ b/sgt
@@ -12575,6 +12575,7 @@ _president_operator_log_event() {
 
 _president_supervise_rig_mayor() {
   local rig="${1:-}" cycle_reason="${2:-periodic}"
+  local prior_scope_rig="${SGT_MAYOR_SCOPE_RIG:-}"
   local mayor_session mayor_hb_age mayor_hb_ts mayor_hb_state mayor_hb_pid mayor_hb_phase mayor_hb_cycle mayor_hb_trigger mayor_hb_stale mayor_hb_health
   local snapshot snapshot_state snapshot_reason open_authorized open_prs active_polecats merge_queue pending_plan_requests plan_rollup plan_status
   local activity changed_at changed_epoch mode meaningful_at meaningful_epoch meaningful_reason wake_at wake_reason
@@ -12667,13 +12668,13 @@ _president_supervise_rig_mayor() {
   fi
 
   if [[ -z "$action" ]]; then
-    _mayor_scope_apply ""
+    _mayor_scope_apply "$prior_scope_rig"
     return 1
   fi
 
   if ! _president_intervention_allowed "$rig" "$reason" "$action"; then
     _president_operator_log_event "$rig" "$action" "$reason" "suppressed-by-cooldown" "$detail" "$cycle_reason"
-    _mayor_scope_apply ""
+    _mayor_scope_apply "$prior_scope_rig"
     return 1
   fi
 
@@ -12688,7 +12689,7 @@ _president_supervise_rig_mayor() {
       cmd_wake_mayor "president:${rig}:${reason}" >/dev/null
       ;;
     *)
-      _mayor_scope_apply ""
+      _mayor_scope_apply "$prior_scope_rig"
       return 1
       ;;
   esac
@@ -12696,7 +12697,7 @@ _president_supervise_rig_mayor() {
   _president_operator_log_event "$rig" "$action" "$reason" "intervened" "$detail" "$cycle_reason"
   log_event "PRESIDENT_INTERVENTION rig=$rig action=$action reason=$reason detail=\"$(_escape_quotes "$detail")\" cycle_trigger=\"$(_escape_quotes "$cycle_reason")\""
   echo "[president] intervened on mayor/$rig — action=$action reason=$reason detail=$detail"
-  _mayor_scope_apply ""
+  _mayor_scope_apply "$prior_scope_rig"
   return 0
 }
 
@@ -12861,6 +12862,7 @@ cmd_wake_president() {
 
 _deacon_supervise_mayor() {
   local scope_rig="${1:-}"
+  local prior_scope_rig="${SGT_MAYOR_SCOPE_RIG:-}"
   _mayor_scope_apply "$scope_rig"
   local mayor_name mayor_session_name
   mayor_name="$(_mayor_scope_agent_name "$scope_rig")"
@@ -12892,7 +12894,10 @@ _deacon_supervise_mayor() {
     restart_line="[deacon] mayor heartbeat stale (${hb_age}s > ${hb_stale_secs}s) — restarting"
   fi
 
-  [[ -n "$restart_reason" ]] || return 1
+  if [[ -z "$restart_reason" ]]; then
+    _mayor_scope_apply "$prior_scope_rig"
+    return 1
+  fi
 
   if [[ "$restart_reason" == heartbeat-* ]]; then
     tmux kill-session -t "$mayor_session_name" 2>/dev/null || true
@@ -12917,6 +12922,7 @@ _deacon_supervise_mayor() {
   echo "$restart_line"
   log_event "DEACON_RESTART_MAYOR reason=$restart_reason rig=${scope_rig:-shared} session=$mayor_session heartbeat_state=${hb_state:-unknown} heartbeat_health=${hb_health:-unknown} heartbeat_age=${hb_age:-unknown}s heartbeat_phase=${hb_phase:-unknown} heartbeat_cycle=${hb_cycle:-unknown} trigger=\"$(_escape_quotes "${hb_trigger:-unknown}")\" last_exit_reason=${exit_reason:-none} last_exit_signal=${exit_signal:-none} last_exit_code=${exit_code:-unknown} last_exit_unexpected=${exit_unexpected:-unknown} last_exit_pid=${exit_pid:-unknown} last_cycle_trigger=\"$(_escape_quotes "${exit_trigger:-unknown}")\" last_cycle_status=${exit_cycle_status:-unknown} last_cycle_at=\"$(_escape_quotes "${exit_cycle_at:-unknown}")\""
   cmd_mayor_start "$scope_rig"
+  _mayor_scope_apply "$prior_scope_rig"
   return 0
 }
 
@@ -15261,6 +15267,7 @@ EOF
 
 _cmd_mayor_start_one() {
   local scope_rig="${1:-}"
+  local prior_scope_rig="${SGT_MAYOR_SCOPE_RIG:-}"
   ensure_init
   _mayor_scope_apply "$scope_rig"
 
@@ -15268,7 +15275,8 @@ _cmd_mayor_start_one() {
   session="$(_mayor_scope_session_name "$scope_rig")"
   if tmux has-session -t "$session" 2>/dev/null; then
     info "$(_mayor_scope_agent_name "$scope_rig") already running"
-    return
+    _mayor_scope_apply "$prior_scope_rig"
+    return 0
   fi
 
   # Create FIFO for event-driven wake
@@ -15311,11 +15319,13 @@ _cmd_mayor_start_one() {
     _mayor_exit_state_write "tmux-new-session-failed" "1" "START" "true" "$$" "" "" "spawn-failed"
     log_event "MAYOR_SPAWN_FAILED reason_code=tmux-new-session-failed attempt=$attempt_token exec_path=\"$(_escape_quotes "$sgt_exec")\" detail=\"$(_escape_quotes "$startup_detail")\""
     warn "$(_mayor_scope_agent_name "$scope_rig") spawn failed before startup validation (attempt=$attempt_token). See $mayor_log"
+    _mayor_scope_apply "$prior_scope_rig"
     return 1
   fi
 
   if _mayor_wait_for_start "$session" "$attempt_token" "$startup_timeout"; then
     info "$(_mayor_scope_agent_name "$scope_rig") started (session: $session, event-driven + fallback every ${SGT_MAYOR_INTERVAL}s)"
+    _mayor_scope_apply "$prior_scope_rig"
     return 0
   fi
 
@@ -15333,6 +15343,7 @@ _cmd_mayor_start_one() {
   log_event "MAYOR_SPAWN_FAILED reason_code=startup-validation-failed attempt=$attempt_token timeout=${startup_timeout}s log_path=\"$(_escape_quotes "$mayor_log")\" detail=\"$(_escape_quotes "$startup_detail")\""
   log_event "MAYOR_START_FAILED reason_code=startup-validation-failed attempt=$attempt_token timeout=${startup_timeout}s log_path=\"$(_escape_quotes "$mayor_log")\" detail=\"$(_escape_quotes "$startup_detail")\""
   warn "$(_mayor_scope_agent_name "$scope_rig") spawn failed validation (attempt=$attempt_token, timeout=${startup_timeout}s). See $mayor_log"
+  _mayor_scope_apply "$prior_scope_rig"
   return 1
 }
 
@@ -15342,8 +15353,10 @@ cmd_mayor_start() {
   if _mayor_architecture_per_rig; then
     _hierarchy_cutover_retire_shared_mayor || true
     if [[ -n "$scope_rig" ]]; then
-      _cmd_mayor_start_one "$scope_rig"
-      return $?
+      local start_rc=0
+      _cmd_mayor_start_one "$scope_rig" || start_rc=$?
+      _mayor_scope_apply "$prior_scope_rig"
+      return "$start_rc"
     fi
     local rig
     for rig in $(_mayor_all_rigs); do
@@ -15353,10 +15366,12 @@ cmd_mayor_start() {
     return 0
   fi
   _cmd_mayor_start_one ""
+  _mayor_scope_apply "$prior_scope_rig"
 }
 
 _cmd_mayor_stop_one() {
   local scope_rig="${1:-}"
+  local prior_scope_rig="${SGT_MAYOR_SCOPE_RIG:-}"
   _mayor_scope_apply "$scope_rig"
   local session
   session="$(_mayor_scope_session_name "$scope_rig")"
@@ -15369,6 +15384,7 @@ _cmd_mayor_stop_one() {
   fi
   # Clean up FIFO
   [[ -p "$SGT_MAYOR_FIFO" ]] && rm -f "$SGT_MAYOR_FIFO"
+  _mayor_scope_apply "$prior_scope_rig"
   return 0
 }
 
@@ -15377,8 +15393,10 @@ cmd_mayor_stop() {
   local prior_scope_rig="${SGT_MAYOR_SCOPE_RIG:-}"
   if _mayor_architecture_per_rig; then
     if [[ -n "$scope_rig" ]]; then
-      _cmd_mayor_stop_one "$scope_rig"
-      return $?
+      local stop_rc=0
+      _cmd_mayor_stop_one "$scope_rig" || stop_rc=$?
+      _mayor_scope_apply "$prior_scope_rig"
+      return "$stop_rc"
     fi
     local rig
     for rig in $(_mayor_all_rigs); do
@@ -15388,10 +15406,12 @@ cmd_mayor_stop() {
     return 0
   fi
   _cmd_mayor_stop_one ""
+  _mayor_scope_apply "$prior_scope_rig"
 }
 
 _cmd_mayor_refresh_one() {
   local scope_rig="${1:-}"
+  local prior_scope_rig="${SGT_MAYOR_SCOPE_RIG:-}"
   local was_running="false" handoff_token handoff_dir handoff_file status_snapshot refresh_reason
   ensure_init
   _mayor_scope_apply "$scope_rig"
@@ -15422,6 +15442,7 @@ _cmd_mayor_refresh_one() {
     refresh_reason="manual-refresh|handoff=$handoff_token"
   fi
   cmd_wake_mayor "$refresh_reason"
+  _mayor_scope_apply "$prior_scope_rig"
   echo "$handoff_file"
 }
 
@@ -15430,8 +15451,10 @@ cmd_mayor_refresh() {
   local prior_scope_rig="${SGT_MAYOR_SCOPE_RIG:-}"
   if _mayor_architecture_per_rig "$scope_rig"; then
     if [[ -n "$scope_rig" ]]; then
-      _cmd_mayor_refresh_one "$scope_rig"
-      return $?
+      local refresh_rc=0
+      _cmd_mayor_refresh_one "$scope_rig" || refresh_rc=$?
+      _mayor_scope_apply "$prior_scope_rig"
+      return "$refresh_rc"
     fi
     local rig
     for rig in $(_mayor_all_rigs); do
@@ -15441,6 +15464,7 @@ cmd_mayor_refresh() {
     return 0
   fi
   _cmd_mayor_refresh_one ""
+  _mayor_scope_apply "$prior_scope_rig"
 }
 
 # Public command: wake the mayor on demand

--- a/test_mayor_helper_state_preservation.sh
+++ b/test_mayor_helper_state_preservation.sh
@@ -26,6 +26,15 @@ eval "$(extract_fn _mayor_scope_dir)"
 eval "$(extract_fn _mayor_scope_apply)"
 eval "$(extract_fn _mayor_target_rigs_for_reason)"
 eval "$(extract_fn _wake_mayor)"
+eval "$(extract_fn _mayor_architecture_per_rig)"
+eval "$(extract_fn _cmd_mayor_start_one)"
+eval "$(extract_fn cmd_mayor_start)"
+eval "$(extract_fn _cmd_mayor_stop_one)"
+eval "$(extract_fn cmd_mayor_stop)"
+eval "$(extract_fn _cmd_mayor_refresh_one)"
+eval "$(extract_fn cmd_mayor_refresh)"
+eval "$(extract_fn cmd_wake_mayor)"
+eval "$(extract_fn _president_supervise_rig_mayor)"
 eval "$(extract_fn cmd_status_json)"
 eval "$(extract_fn _cmd_status_human)"
 eval "$(extract_fn _mayor_notify_rigger)"
@@ -43,8 +52,14 @@ mkdir -p "$SGT_CONFIG" "$SGT_RIGS" "$SGT_POLECATS" "$SGT_AGENTS"
 printf 'demo-repo\n' > "$SGT_RIGS/demo"
 printf 'beta-repo\n' > "$SGT_RIGS/beta"
 export SGT_ROOT SGT_CONFIG SGT_RIGS SGT_POLECATS SGT_AGENTS SGT_DAEMON_PID SGT_LOG TMP_ROOT
+SGT_MAYOR_ARCHITECTURE="per-rig"
+SGT_MAYOR_INTERVAL="60"
+export SGT_MAYOR_ARCHITECTURE SGT_MAYOR_INTERVAL
 
 ensure_init() { :; }
+die() { echo "${1:-die}" >&2; exit 1; }
+info() { :; }
+warn() { :; }
 _json_quote() { printf '"%s"' "${1:-}"; }
 _json_print_array() {
   local first=1 item
@@ -98,6 +113,7 @@ _polecat_runtime_json() { printf '{}'; }
 _agent_heartbeat_stale_secs() { echo 180; }
 _agent_heartbeat_snapshot() { printf '0|2026-04-01T00:00:00Z|ok\n'; }
 _mayor_scope_agent_name() { printf 'mayor/%s\n' "${1:-${SGT_MAYOR_SCOPE_RIG:-}}"; }
+_hierarchy_cutover_retire_shared_mayor() { :; }
 _openclaw_notify_config_read() { printf 'main\nlast\n\n\n'; }
 _rig_notify_agent_read() { return 1; }
 _mayor_notify_result_set() { :; }
@@ -116,7 +132,41 @@ _mayor_record_decision() { :; }
 _one_line() { printf '%s' "${1:-}"; }
 log_event() { :; }
 _escape_quotes() { printf '%s' "${1:-}"; }
-tmux() { return 1; }
+_sgt_exec_path() { printf '%s/fake-sgt\n' "$TMP_ROOT"; }
+_mayor_start_log_file() { printf '%s/mayor-start.log\n' "$TMP_ROOT"; }
+_mayor_start_validation_timeout_secs() { echo 1; }
+_mayor_wait_for_start() { return 0; }
+_mayor_start_failure_state_write() { :; }
+_mayor_exit_state_write() { :; }
+_mayor_refresh_token() { printf 'refresh-token\n'; }
+_mayor_refresh_handoffs_dir() { printf '%s/handoffs\n' "$TMP_ROOT"; }
+_mayor_dispatch_snapshot_file() { :; }
+_mayor_build_briefing() { :; }
+_mayor_refresh_archive_transients() { :; }
+_mayor_refresh_write_handoff() { :; }
+_president_intervention_allowed() { return 0; }
+_president_operator_log_event() { :; }
+_president_intervention_state_write() { :; }
+_mayor_rig_activity_snapshot() { printf 'active|steady|0|0|0|0|0|tasks-in-progress|pending\n'; }
+_mayor_rig_activity_state_read() { printf 'active|steady|2026-04-01T00:00:00Z|0|none|2026-04-01T00:00:00Z|0|steady|2026-04-01T00:00:00Z|manual\n'; }
+rig_repo() { printf 'demo-repo\n'; }
+_ralph_mode_snapshot_fields() { printf '0||||||0|0|0|0|0|0|0||||\n'; }
+_plan_pending_underfill_target() { echo 0; }
+cmd_mayor_start_called=0
+cmd_mayor_refresh_called=0
+cmd_wake_mayor_called=0
+tmux() {
+  if [[ "${1:-}" == "has-session" ]]; then
+    return 1
+  fi
+  return 0
+}
+mkfifo() {
+  if [[ -p "${1:-}" ]]; then
+    return 0
+  fi
+  command mkfifo "$@"
+}
 openclaw() { printf '{}\n'; }
 
 _mayor_scope_apply "demo"
@@ -149,6 +199,55 @@ touch "$SGT_MAYOR_FIFO"
 _wake_mayor "broadcast" >/dev/null
 if [[ "${SGT_MAYOR_SCOPE_RIG:-}" != "demo" ]]; then
   echo "expected _wake_mayor to preserve caller scope after per-rig routing" >&2
+  exit 1
+fi
+
+_mayor_scope_apply "outer"
+cmd_mayor_start "demo" >/dev/null
+if [[ "${SGT_MAYOR_SCOPE_RIG:-}" != "outer" ]]; then
+  echo "expected cmd_mayor_start to preserve caller scope" >&2
+  exit 1
+fi
+
+_mayor_scope_apply "outer"
+cmd_mayor_stop "demo" >/dev/null
+if [[ "${SGT_MAYOR_SCOPE_RIG:-}" != "outer" ]]; then
+  echo "expected cmd_mayor_stop to preserve caller scope" >&2
+  exit 1
+fi
+
+_mayor_scope_apply "outer"
+cmd_mayor_refresh "demo" >/dev/null
+if [[ "${SGT_MAYOR_SCOPE_RIG:-}" != "outer" ]]; then
+  echo "expected cmd_mayor_refresh to preserve caller scope" >&2
+  exit 1
+fi
+
+_mayor_scope_apply "outer"
+_cmd_mayor_start_one "demo" >/dev/null
+if [[ "${SGT_MAYOR_SCOPE_RIG:-}" != "outer" ]]; then
+  echo "expected _cmd_mayor_start_one to preserve caller scope" >&2
+  exit 1
+fi
+
+_mayor_scope_apply "outer"
+_cmd_mayor_stop_one "demo" >/dev/null
+if [[ "${SGT_MAYOR_SCOPE_RIG:-}" != "outer" ]]; then
+  echo "expected _cmd_mayor_stop_one to preserve caller scope" >&2
+  exit 1
+fi
+
+_mayor_scope_apply "outer"
+_cmd_mayor_refresh_one "demo" >/dev/null
+if [[ "${SGT_MAYOR_SCOPE_RIG:-}" != "outer" ]]; then
+  echo "expected _cmd_mayor_refresh_one to preserve caller scope" >&2
+  exit 1
+fi
+
+_mayor_scope_apply "outer"
+_president_supervise_rig_mayor "demo" "startup" >/dev/null
+if [[ "${SGT_MAYOR_SCOPE_RIG:-}" != "outer" ]]; then
+  echo "expected _president_supervise_rig_mayor to preserve caller scope" >&2
   exit 1
 fi
 BASH


### PR DESCRIPTION
Closes #370

## Summary
- preserve caller mayor scope across President/Deacon per-rig supervision and rig-targeted mayor start/stop/refresh helpers
- stop rig-targeted helper paths from forcing scope back to shared after returning
- extend helper-state regression coverage to assert scope preservation across the wrapper and supervision paths that President uses

## Testing
- bash test_control_plane_scope_env.sh
- bash test_mayor_helper_state_preservation.sh
- bash test_president_runtime_supervision.sh
- bash test_mayor_refresh.sh
- bash test_president_refresh.sh