### PR TITLE
Add Ralph duplicate-redispatch regression for #363

### DIFF
--- a/SGT_CONTEXT.md
+++ b/SGT_CONTEXT.md
@@ -1352,3 +1352,59 @@ Required follow-up:
 ```
 - 2026-04-01T08:25:16+02:00 — 2026-04-01 issue #361: added test_ralph_mode_latest_main_proof.sh as the repo-owned latest-main proof path for Ralph mode; it bundles config/state, President intervention, stranded-rig refill, and cockpit visibility coverage, and README now points operators at that single entrypoint.
 - 2026-04-01T08:54:09+02:00 — 2026-04-01 issue #364 duplicate redispatch fallout: plan tick no longer treats default task status pending/planned as an authoritative reopen of completed work. Explicit repo-local reopen now requires status=reopened/requeue or reopen=true, while unchanged tasks retain the latest merged plan-task issue lineage so duplicate open plan-<task> issues do not reset completed tasks back to pending/dispatched.
+- 2026-04-01T09:07:10+02:00 — 2026-04-01 issue #366: when Ralph is enabled and the condition remains unmet, plan-state completion.acceptance now mirrors the effective pending status instead of leaking stale verified/waived terminal metadata; the original declared terminal status/timestamp is preserved under completion.acceptance.declared_* for operator forensics, and regression coverage lives in test_ralph_mode_config_and_state.sh.
+- 2026-04-01T09:08:14+02:00 — Acceptance blocker sgt-acceptance-1775027294-89db909c reported by witness: Replacement work required after stalled polecat for issue #366
+
+### Acceptance Blocker sgt-acceptance-1775027294-89db909c
+
+- Reported at: 2026-04-01T09:08:14+02:00
+- Reported by: witness
+- Title: Replacement work required after stalled polecat for issue #366
+
+```markdown
+Replacement work required after stalled polecat for issue #366
+
+Stalled polecat recovery did not produce replacement work.
+
+- Rig: sgt
+- Repo: codejeet/sgt
+- Issue: #366
+- Issue URL: https://github.com/codejeet/sgt/issues/366
+- Issue title: unknown
+- Polecat: sgt-89881ba7
+- Failure reason: witness-stalled-issue-title-unavailable
+
+Required follow-up:
+- create replacement work (new PR or re-dispatched polecat) before closing the incident
+- re-investigate why the worker exited without producing a PR
+
+```
+- 2026-04-01T09:09:57+02:00 — Issue #367: the Web cockpit now exposes inline per-rig Ralph controls via POST /api/ralph/:rig (enable/disable, condition text, target concurrency, condition status, count-support toggle), while test_ralph_mode_config_and_state.sh now asserts human status and durable event-log visibility for Ralph state changes.
+- 2026-04-01T11:16:35+02:00 — 2026-04-01 issue #370: per-rig mayor helper calls must preserve the caller's rig scope and existing errexit mode. Status/notify/start-stop-refresh helpers that reset scope to shared or blindly restore set -e can make President-started mayor/<rig> sessions fall off after startup/event handling with clean-exit or nonzero-exit noise instead of staying resident.
+- 2026-04-01T11:18:05+02:00 — Acceptance blocker sgt-acceptance-1775035085-041bcff8 reported by witness: Replacement work required after stalled polecat for issue #370
+
+### Acceptance Blocker sgt-acceptance-1775035085-041bcff8
+
+- Reported at: 2026-04-01T11:18:05+02:00
+- Reported by: witness
+- Title: Replacement work required after stalled polecat for issue #370
+
+```markdown
+Replacement work required after stalled polecat for issue #370
+
+Stalled polecat recovery did not produce replacement work.
+
+- Rig: sgt
+- Repo: codejeet/sgt
+- Issue: #370
+- Issue URL: https://github.com/codejeet/sgt/issues/370
+- Issue title: unknown
+- Polecat: sgt-f1ac7cda
+- Failure reason: witness-stalled-issue-title-unavailable
+
+Required follow-up:
+- create replacement work (new PR or re-dispatched polecat) before closing the incident
+- re-investigate why the worker exited without producing a PR
+
+```
+- 2026-04-01T11:34:21+02:00 — 2026-04-01 issue #371: per-rig mayor liveness under President depends on preserving both caller rig scope and the current errexit mode across helper calls. In practice, _mayor_notify_rigger flipping set -e back on and helper paths like status/wake/start/stop/refresh resetting scope to shared can make mayor/<rig> exit after its first startup/event cycle instead of staying resident.

--- a/test_plan_tick_duplicate_completed_task_guard.sh
+++ b/test_plan_tick_duplicate_completed_task_guard.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Regression: default plan "pending" status must not reopen a task already completed by merged lineage.
+# Regression: default plan "pending" status must not reopen Ralph tasks already completed by merged lineage.
 
 set -euo pipefail
 
@@ -123,6 +123,30 @@ case "$command:$subcommand" in
   }
 ]
 JSON
+    elif [[ "$label" == "plan-SGT56" && "$state_filter" == "all" ]]; then
+      cat <<'JSON'
+[
+  {
+    "number": 349,
+    "url": "https://github.com/acme/demo/issues/349",
+    "state": "CLOSED",
+    "closedAt": "2026-04-01T05:17:41Z",
+    "createdAt": "2026-04-01T05:03:00Z"
+  }
+]
+JSON
+    elif [[ "$label" == "plan-SGT57" && "$state_filter" == "all" ]]; then
+      cat <<'JSON'
+[
+  {
+    "number": 350,
+    "url": "https://github.com/acme/demo/issues/350",
+    "state": "CLOSED",
+    "closedAt": "2026-04-01T05:25:41Z",
+    "createdAt": "2026-04-01T05:09:00Z"
+  }
+]
+JSON
     elif [[ "$label" == "plan-SGT55" && "$state_filter" == "open" ]]; then
       cat <<'JSON'
 [
@@ -153,6 +177,8 @@ JSON
     done
     case "$issue_number:$json_fields" in
       335:state) echo "CLOSED" ;;
+      349:state) echo "CLOSED" ;;
+      350:state) echo "CLOSED" ;;
       361:state) echo "CLOSED" ;;
       364:state) echo "OPEN" ;;
       *) echo "" ;;
@@ -165,6 +191,16 @@ JSON
     "number": 341,
     "body": "Closes #335",
     "mergedAt": "2026-04-01T04:59:02Z"
+  },
+  {
+    "number": 351,
+    "body": "Closes #349",
+    "mergedAt": "2026-04-01T05:17:40Z"
+  },
+  {
+    "number": 352,
+    "body": "Closes #350",
+    "mergedAt": "2026-04-01T05:25:40Z"
   },
   {
     "number": 362,
@@ -204,7 +240,9 @@ cat > "$HOME/sgt/rigs/demo/SGT_PLAN.json" <<'JSON'
   "rig": "demo",
   "policy": { "max_in_flight": 1 },
   "tasks": [
-    { "id": "SGT55", "title": "Define Ralph mode config, state model, and concurrency accounting rules", "status": "pending" }
+    { "id": "SGT55", "title": "Define Ralph mode config, state model, and concurrency accounting rules", "status": "pending" },
+    { "id": "SGT56", "title": "Teach President to refill Ralph rigs toward target concurrency", "status": "pending" },
+    { "id": "SGT57", "title": "Force Ralph rigs back to pending while the condition remains unmet", "status": "pending" }
   ]
 }
 JSON
@@ -216,6 +254,18 @@ cat > "$HOME/sgt/.sgt/plan-state/demo.json" <<'JSON'
       "issue_url": "https://github.com/acme/demo/issues/364",
       "status": "dispatched",
       "updated_at": "2026-04-01T06:41:56Z"
+    },
+    "SGT56": {
+      "issue_number": "349",
+      "issue_url": "https://github.com/acme/demo/issues/349",
+      "status": "pending",
+      "updated_at": "2026-04-01T05:18:00Z"
+    },
+    "SGT57": {
+      "issue_number": "350",
+      "issue_url": "https://github.com/acme/demo/issues/350",
+      "status": "pending",
+      "updated_at": "2026-04-01T05:26:00Z"
     }
   }
 }
@@ -233,15 +283,33 @@ import sys
 with open(sys.argv[1], "r", encoding="utf-8") as fh:
     data = json.load(fh)
 
-task = data["tasks"]["SGT55"]
-assert task["status"] == "completed", task
-assert str(task.get("issue_number")) == "361", task
-assert "completed_at" in task, task
-assert task.get("reopen_requested") is False, task
+expected = {
+    "SGT55": "361",
+    "SGT56": "349",
+    "SGT57": "350",
+}
+for task_id, issue_number in expected.items():
+    task = data["tasks"][task_id]
+    assert task["status"] == "completed", (task_id, task)
+    assert str(task.get("issue_number")) == issue_number, (task_id, task)
+    assert "completed_at" in task, (task_id, task)
+    assert task.get("reopen_requested") is False, (task_id, task)
 PY
 
 grep -q 'PLAN_TASK_RETAIN_MERGED_LINEAGE rig=demo task=SGT55 issue=#361 pr=#362 merged_at=2026-04-01T06:26:21Z source=manual' "$TMP_HOME/sgt/sgt.log" || {
   echo "expected merged-lineage retention log entry" >&2
+  cat "$TMP_HOME/sgt/sgt.log" >&2
+  exit 1
+}
+
+grep -q 'PLAN_TASK_RETAIN_MERGED_LINEAGE rig=demo task=SGT56 issue=#349 pr=#351 merged_at=2026-04-01T05:17:40Z source=manual' "$TMP_HOME/sgt/sgt.log" || {
+  echo "expected SGT56 merged-lineage retention log entry" >&2
+  cat "$TMP_HOME/sgt/sgt.log" >&2
+  exit 1
+}
+
+grep -q 'PLAN_TASK_RETAIN_MERGED_LINEAGE rig=demo task=SGT57 issue=#350 pr=#352 merged_at=2026-04-01T05:25:40Z source=manual' "$TMP_HOME/sgt/sgt.log" || {
+  echo "expected SGT57 merged-lineage retention log entry" >&2
   cat "$TMP_HOME/sgt/sgt.log" >&2
   exit 1
 }


### PR DESCRIPTION
Closes #363

## Summary
- expand the duplicate completed-task regression to cover the live Ralph SGT55/SGT56/SGT57 shape
- assert default repo-local pending task statuses retain merged lineage instead of reopening completed work
- keep explicit reopen behavior covered separately via the existing repo-local reopen regression

## Testing
- bash test_plan_tick_duplicate_completed_task_guard.sh
- bash test_plan_tick_repo_local_reopen_reconcile.sh