### PR TITLE
Fix Ralph acceptance snapshot drift

### DIFF
--- a/sgt
+++ b/sgt
@@ -6518,6 +6518,10 @@ completion_state = state.get("completion")
 if not isinstance(completion_state, dict):
     completion_state = {}
 
+state_acceptance = completion_state.get("acceptance")
+if not isinstance(state_acceptance, dict):
+    state_acceptance = {}
+
 ralph_state = state.get("ralph")
 if not isinstance(ralph_state, dict):
     ralph_state = {}
@@ -6544,10 +6548,23 @@ acceptance = plan.get("acceptance")
 if not isinstance(acceptance, dict):
     acceptance = {}
 
+state_completion_rollup = str(completion_state.get("rollup") or "").strip().lower()
+ralph_pending_override = (
+    str(completion_state.get("status") or "").strip().lower() == "pending"
+    and (
+        bool(ralph_state.get("completion_blocked_by_condition"))
+        or state_completion_rollup.startswith("ralph-")
+    )
+)
+if ralph_pending_override and state_acceptance:
+    acceptance = dict(state_acceptance)
+
 allowed_completion_status = {"pending", "completed", "verified", "blocked", "waived"}
 plan_completion_status = str(acceptance.get("status") or "").strip().lower()
 state_completion_status = str(completion_state.get("status") or "").strip().lower()
-if plan_completion_status in allowed_completion_status:
+if ralph_pending_override:
+    completion_status = "pending"
+elif plan_completion_status in allowed_completion_status:
     completion_status = plan_completion_status
 elif state_completion_status in allowed_completion_status:
     completion_status = state_completion_status

--- a/test_ralph_mode_config_and_state.sh
+++ b/test_ralph_mode_config_and_state.sh
@@ -236,6 +236,28 @@ assert plan_ralph.get("target_concurrency") == 2, plan_ralph
 assert plan_ralph.get("active_lane_count") == 1, plan_ralph
 PY
 
+LIB_SCRIPT="$HOME/sgt-lib.sh"
+sed '$d' "$HOME/.local/bin/sgt" > "$LIB_SCRIPT"
+source "$LIB_SCRIPT"
+_plan_state_snapshot "demo" "$SGT_ROOT/rigs/demo/SGT_PLAN.json" "$SGT_ROOT/rigs/demo/SGT_PLAN.json" >/dev/null
+
+python3 - "$SGT_ROOT/.sgt/plan-state/demo.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    plan_state = json.load(fh)
+
+completion = plan_state.get("completion") or {}
+assert completion.get("status") == "pending", completion
+assert completion.get("rollup") == "ralph-underfilled", completion
+acceptance = completion.get("acceptance") or {}
+assert acceptance.get("status") == "pending", acceptance
+assert acceptance.get("declared_status") == "verified", acceptance
+assert acceptance.get("declared_verified_at") == "2026-03-31T08:15:00Z", acceptance
+assert "verified_at" not in acceptance, acceptance
+PY
+
 sgt config ralph demo --count-support yes >/dev/null
 sgt status --json > "$SGT_ROOT/status-after.json"
 


### PR DESCRIPTION
Closes #379

## Summary
- preserve the live pending Ralph completion override when plan-state is resnapshotted from SGT_PLAN.json
- keep declared terminal acceptance metadata only as forensics while Ralph remains unmet
- add a regression that exercises _plan_state_snapshot directly so stale verified acceptance cannot drift back in

## Testing
- bash ./test_ralph_mode_config_and_state.sh
- bash ./test_plan_completion_acceptance_lifecycle.sh
- bash ./test_president_runtime_supervision.sh